### PR TITLE
fix(appliance): size the api and worker limits from the node's RAM in the supervisor; helm-stuck-recover hands its chart list through a file

### DIFF
--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -976,8 +976,15 @@ def heartbeat_once(
         ml_bgp_peers = body_out.get("desired_metallb_bgp_peers") or []
         ml_bgp_advertisements = body_out.get("desired_metallb_bgp_advertisements") or []
 
+        # The api / worker memory limits and worker concurrency ride along,
+        # sized from this node's RAM (k8s_api.control_plane_resources) — the
+        # chart's BYO-cluster defaults gave way before the VM did on the
+        # appliance, and a kubectl patch never survived a k3s restart.
         cp_changed, cp_err = k8s_api.apply_control_plane_overrides(
-            cp_size, str(ml_vip), web_ui_allowed_cidrs=list(web_ui_cidrs)
+            cp_size,
+            str(ml_vip),
+            web_ui_allowed_cidrs=list(web_ui_cidrs),
+            mem_total_mib=k8s_api.node_memory_mib(),
         )
         if cp_changed:
             log.info(

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -545,7 +545,8 @@ def reclaim_stranded_redis_storage(
             continue
         try:
             status, resp = _request(
-                "DELETE", f"{base}/persistentvolumeclaims/{quote(name)}")
+                "DELETE", f"{base}/persistentvolumeclaims/{quote(name)}"
+            )
         except RuntimeError as exc:
             return reclaimed, str(exc)
         if status not in (200, 202, 404):
@@ -697,7 +698,9 @@ def _helmchartconfig_doc(name: str, *, namespace: str = "kube-system") -> dict |
     try:
         st, resp = _request("GET", path)
     except (RuntimeError, OSError) as exc:
-        log.warning("supervisor.helmchartconfig.read_failed", chart=name, error=str(exc))
+        log.warning(
+            "supervisor.helmchartconfig.read_failed", chart=name, error=str(exc)
+        )
         return None
     if st == 404:
         return {}
@@ -714,7 +717,9 @@ def _helmchartconfig_doc(name: str, *, namespace: str = "kube-system") -> dict |
     try:
         doc = yaml.safe_load(raw)
     except yaml.YAMLError as exc:
-        log.warning("supervisor.helmchartconfig.unparseable_values", chart=name, error=str(exc))
+        log.warning(
+            "supervisor.helmchartconfig.unparseable_values", chart=name, error=str(exc)
+        )
         return None
     if not isinstance(doc, dict):
         # A list or scalar at the top level is not something we can merge
@@ -793,14 +798,81 @@ def _slot_image_mirror_enabled(cp_size: int, current_doc: dict) -> bool:
     return bool(isinstance(block, dict) and block.get("enabled") is True)
 
 
+# Appliance sizing (2026-09 resource-floor campaign). The chart's defaults —
+# api 512Mi, worker 1Gi with four prefork processes — are BYO-cluster
+# defaults, and on the appliance they gave way long before the VM did: the
+# api could not build a 250k-record agent bundle under 512Mi (memcg-killed
+# on every long-poll, so the bundle never reached the data plane), the
+# worker's five ~220 MB processes were OOM-killed under 20k-device lease/DDNS
+# churn with gigabytes free on the node, and any ``kubectl set resources``
+# an operator applied was wiped by the next k3s restart (k3s re-applies the
+# on-disk HelmChart manifest). The supervisor knows the node's RAM, so it
+# sizes the two workloads from it and writes the result where it survives
+# (the same HelmChartConfig as the replica overrides, #272). Fractions and
+# clamps are deliberately simple; ``limits`` only — requests stay the
+# chart's, so scheduling on a small box is unchanged.
+_API_MEM_FRACTION = 0.5
+_API_MEM_MIN_MIB = 1024
+_API_MEM_MAX_MIB = 8192
+_WORKER_MEM_FRACTION = 0.25
+_WORKER_MEM_MIN_MIB = 1024
+_WORKER_MEM_MAX_MIB = 4096
+# Below this much RAM the worker runs two prefork processes instead of the
+# chart's four: the campaign's 8 GiB single node OOMed the 1Gi worker at
+# four, and the queues it serves (ipam/dns/dhcp/default) are latency-, not
+# throughput-bound on an appliance.
+_WORKER_SMALL_NODE_MIB = 12288
+
+
+def _clamp_mib(total_mib: int, fraction: float, lo: int, hi: int) -> int:
+    return int(min(max(total_mib * fraction, lo), hi))
+
+
+def control_plane_resources(mem_total_mib: int | None) -> dict[str, Any]:
+    """PURE: the ``api`` / ``worker`` resource overrides for a node with
+    ``mem_total_mib`` of RAM — ``{}`` when the size is unknown (the chart's
+    defaults then stand, exactly as before)."""
+    if not mem_total_mib or mem_total_mib <= 0:
+        return {}
+    api_mib = _clamp_mib(
+        mem_total_mib, _API_MEM_FRACTION, _API_MEM_MIN_MIB, _API_MEM_MAX_MIB
+    )
+    worker_mib = _clamp_mib(
+        mem_total_mib, _WORKER_MEM_FRACTION, _WORKER_MEM_MIN_MIB, _WORKER_MEM_MAX_MIB
+    )
+    return {
+        "api": {"resources": {"limits": {"memory": f"{api_mib}Mi"}}},
+        "worker": {
+            "concurrency": 2 if mem_total_mib <= _WORKER_SMALL_NODE_MIB else 4,
+            "resources": {"limits": {"memory": f"{worker_mib}Mi"}},
+        },
+    }
+
+
+def node_memory_mib() -> int | None:
+    """MemTotal from /proc/meminfo in MiB; ``None`` when unreadable."""
+    try:
+        with open("/proc/meminfo", encoding="utf-8") as fh:
+            for line in fh:
+                if line.startswith("MemTotal:"):
+                    return int(line.split()[1]) // 1024
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
 def apply_control_plane_overrides(
     cp_size: int,
     control_plane_vip: str,
     web_ui_allowed_cidrs: list[str] | None = None,
+    *,
+    mem_total_mib: int | None = None,
 ) -> tuple[bool, str | None]:
     """Durably set the spatium-control overrides: api / frontend / worker
     replicas + CNPG instances + redis sentinel replicas = ``cp_size``,
-    plus the frontend control-plane VIP. Written to the spatium-control
+    plus the frontend control-plane VIP, plus the api / worker memory
+    limits and worker concurrency sized from ``mem_total_mib`` (see
+    ``control_plane_resources``). Written to the spatium-control
     HelmChartConfig so it survives a k3s restart (#272).
 
     #285 Phase 6 — ``web_ui_allowed_cidrs`` (empty = open) also lands on the
@@ -848,17 +920,26 @@ def apply_control_plane_overrides(
         # Unknown current state — see _helmchartconfig_doc. Writing here
         # would merge onto {} and delete every key we do not own.
         return False, "could not read the current spatium-control values"
+    sized = control_plane_resources(mem_total_mib)
     owned: dict[str, Any] = {
-        "api": dict(scaled),
+        "api": dict(scaled) | sized.get("api", {}),
         "frontend": dict(scaled)
         | {
             "controlPlaneVIP": vip,
             "loadBalancerSourceRanges": cidrs,
         },
-        "worker": dict(scaled),
-        "slotImageMirror": {"enabled": _slot_image_mirror_enabled(cp_size, current_doc)},
+        "worker": dict(scaled) | sized.get("worker", {}),
+        "slotImageMirror": {
+            "enabled": _slot_image_mirror_enabled(cp_size, current_doc)
+        },
         "postgresql": {"cnpg": {"instances": cp_size}},
-        "redis": {"sentinel": {"replicas": cp_size}},
+        # ``kind`` is stated, not assumed: ``sentinel.replicas`` is only
+        # read by the chart under ``kind: sentinel``, and firstboot is the
+        # only place that ever set it. An appliance whose HelmChart values
+        # came from an older firstboot (or an operator's own override)
+        # would scale a key the chart ignores and keep a standalone redis
+        # on a three-node control plane.
+        "redis": {"kind": "sentinel", "sentinel": {"replicas": cp_size}},
     }
     # MERGE onto what is already there rather than replacing the document.
     #
@@ -1076,17 +1157,27 @@ def count_nodes(timeout: float = 5.0) -> tuple[int, int, str | None]:
 _COREDNS_PATH = "/apis/apps/v1/namespaces/kube-system/deployments/coredns"
 _FAST_EVICT_KEYS = ("node.kubernetes.io/unreachable", "node.kubernetes.io/not-ready")
 _FAST_EVICT_TOLERATIONS = [
-    {"key": "node.kubernetes.io/unreachable", "operator": "Exists",
-     "effect": "NoExecute", "tolerationSeconds": 20},
-    {"key": "node.kubernetes.io/not-ready", "operator": "Exists",
-     "effect": "NoExecute", "tolerationSeconds": 20},
+    {
+        "key": "node.kubernetes.io/unreachable",
+        "operator": "Exists",
+        "effect": "NoExecute",
+        "tolerationSeconds": 20,
+    },
+    {
+        "key": "node.kubernetes.io/not-ready",
+        "operator": "Exists",
+        "effect": "NoExecute",
+        "tolerationSeconds": 20,
+    },
 ]
 _COREDNS_SPREAD = {
     "podAntiAffinity": {
-        "requiredDuringSchedulingIgnoredDuringExecution": [{
-            "topologyKey": "kubernetes.io/hostname",
-            "labelSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
-        }],
+        "requiredDuringSchedulingIgnoredDuringExecution": [
+            {
+                "topologyKey": "kubernetes.io/hostname",
+                "labelSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
+            }
+        ],
     },
 }
 
@@ -1246,8 +1337,12 @@ def ensure_coredns_ha(max_replicas: int = 2) -> tuple[bool, str | None]:
     # still differing from the canonical body — and that difference is a new
     # pod-template hash, i.e. a rollout. Deciding the gate on the loose
     # predicate would let exactly that rollout skip the guard it exists to be.
-    want_affinity = None if affinity_patch is None else _merge_patch(affinity, affinity_patch)
-    rewrites_template = want_tolerations != tolerations or want_affinity != (affinity or None)
+    want_affinity = (
+        None if affinity_patch is None else _merge_patch(affinity, affinity_patch)
+    )
+    rewrites_template = want_tolerations != tolerations or want_affinity != (
+        affinity or None
+    )
 
     if current_replicas == desired and not rewrites_template:
         return False, None
@@ -1268,18 +1363,24 @@ def ensure_coredns_ha(max_replicas: int = 2) -> tuple[bool, str | None]:
         )
         return False, None
 
-    payload = json.dumps({
-        "spec": {
-            "replicas": desired,
-            "template": {"spec": {
-                "tolerations": want_tolerations,
-                "affinity": affinity_patch,
-            }},
-        },
-    }).encode("utf-8")
+    payload = json.dumps(
+        {
+            "spec": {
+                "replicas": desired,
+                "template": {
+                    "spec": {
+                        "tolerations": want_tolerations,
+                        "affinity": affinity_patch,
+                    }
+                },
+            },
+        }
+    ).encode("utf-8")
     try:
         status, resp = _request(
-            "PATCH", _COREDNS_PATH, body=payload,
+            "PATCH",
+            _COREDNS_PATH,
+            body=payload,
             content_type="application/merge-patch+json",
         )
     except (RuntimeError, OSError) as exc:

--- a/agent/supervisor/tests/test_control_plane_resources.py
+++ b/agent/supervisor/tests/test_control_plane_resources.py
@@ -1,0 +1,130 @@
+"""Appliance-sized api / worker limits ride the control-plane overrides.
+
+The 2026-09 resource-floor campaign found the chart's BYO-cluster defaults
+(api 512Mi; worker 1Gi at four prefork processes) give way on the appliance
+long before the VM does — the api cannot build a 250k-record bundle under
+512Mi, the worker OOMs under 20k-device churn with gigabytes free — and that
+a ``kubectl set resources`` never survives the next k3s restart. The
+supervisor sizes both from the node's RAM and writes them into the same
+HelmChartConfig as the replica overrides, where they survive (#272).
+"""
+
+from __future__ import annotations
+
+import json
+
+import yaml
+
+from spatium_supervisor import k8s_api
+
+
+class _Recorder:
+    """Stand-in for k8s_api._request (same shape as the mirror tests')."""
+
+    def __init__(self, current: str | None = None):
+        self._current = current
+        self.calls: list[tuple[str, str, bytes | None]] = []
+
+    def __call__(self, method, path, body=None, content_type=None):
+        self.calls.append((method, path, body))
+        if method == "GET":
+            if self._current is None:
+                return (404, "")
+            return (200, json.dumps({"spec": {"valuesContent": self._current}}))
+        return (200 if method == "PATCH" else 201, "{}")
+
+    @property
+    def doc(self) -> dict:
+        for method, _, body in self.calls:
+            if method in ("POST", "PATCH") and body is not None:
+                return yaml.safe_load(json.loads(body)["spec"]["valuesContent"])
+        raise AssertionError("no HelmChartConfig write recorded")
+
+
+def test_sizing_scales_with_ram_inside_the_clamps() -> None:
+    six = k8s_api.control_plane_resources(6144)
+    assert six["api"]["resources"]["limits"]["memory"] == "3072Mi"
+    assert six["worker"]["resources"]["limits"]["memory"] == "1536Mi"
+    assert six["worker"]["concurrency"] == 2
+    # Floors: a 2 GiB box still gets the minimum the bundle build needs.
+    small = k8s_api.control_plane_resources(2048)
+    assert small["api"]["resources"]["limits"]["memory"] == "1024Mi"
+    assert small["worker"]["resources"]["limits"]["memory"] == "1024Mi"
+    # Ceilings: a 64 GiB box does not hand the api half of it.
+    big = k8s_api.control_plane_resources(65536)
+    assert big["api"]["resources"]["limits"]["memory"] == "8192Mi"
+    assert big["worker"]["resources"]["limits"]["memory"] == "4096Mi"
+    assert big["worker"]["concurrency"] == 4
+    # Requests are never set: scheduling on a small node is unchanged.
+    assert "requests" not in six["api"]["resources"]
+    assert "requests" not in six["worker"]["resources"]
+
+
+def test_unknown_ram_leaves_the_chart_defaults_alone() -> None:
+    assert k8s_api.control_plane_resources(None) == {}
+    assert k8s_api.control_plane_resources(0) == {}
+
+
+def test_the_overrides_carry_the_sizing_and_state_the_redis_kind(monkeypatch) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    ok, err = k8s_api.apply_control_plane_overrides(1, "", mem_total_mib=8192)
+
+    assert (ok, err) == (True, None)
+    doc = rec.doc
+    assert doc["api"]["replicas"] == 1
+    assert doc["api"]["resources"] == {"limits": {"memory": "4096Mi"}}
+    assert doc["worker"]["concurrency"] == 2
+    assert doc["worker"]["resources"] == {"limits": {"memory": "2048Mi"}}
+    assert doc["redis"] == {"kind": "sentinel", "sentinel": {"replicas": 1}}
+
+
+def test_without_a_size_the_document_is_what_it_was(monkeypatch) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    ok, _err = k8s_api.apply_control_plane_overrides(3, "10.0.0.9")
+
+    assert ok
+    doc = rec.doc
+    assert "resources" not in doc["api"] and "resources" not in doc["worker"]
+    assert "concurrency" not in doc["worker"]
+    assert doc["redis"]["kind"] == "sentinel"
+
+
+def test_an_operators_own_request_keys_survive_the_merge(monkeypatch) -> None:
+    current = yaml.safe_dump(
+        {
+            "api": {"resources": {"requests": {"cpu": "250m"}, "limits": {"cpu": "2"}}},
+            "image": {"tag": "dev-1"},
+        },
+        sort_keys=True,
+    )
+    rec = _Recorder(current)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    ok, _err = k8s_api.apply_control_plane_overrides(1, "", mem_total_mib=4096)
+
+    assert ok
+    doc = rec.doc
+    # Sibling keys the supervisor does not own are kept, memory is set.
+    assert doc["api"]["resources"] == {
+        "requests": {"cpu": "250m"},
+        "limits": {"cpu": "2", "memory": "2048Mi"},
+    }
+    assert doc["image"]["tag"] == "dev-1"
+
+
+def test_node_memory_reads_meminfo(tmp_path, monkeypatch) -> None:
+    mem = tmp_path / "meminfo"
+    mem.write_text("MemTotal:        8123456 kB\nMemFree:  100 kB\n")
+    real_open = open
+
+    def fake_open(path, *a, **kw):
+        if path == "/proc/meminfo":
+            return real_open(mem, *a, **kw)
+        return real_open(path, *a, **kw)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    assert k8s_api.node_memory_mib() == 8123456 // 1024

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-helm-stuck-recover.service
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-helm-stuck-recover.service
@@ -2,7 +2,11 @@
 Description=Clear wedged k3s HelmChart releases so helm-controller retries (#183 Phase 9)
 Documentation=https://github.com/spatiumddi/spatiumddi/issues/183
 After=k3s.service
-Requires=k3s.service
+# Wants, not Requires: with Requires= every k3s restart (a member join, a
+# slot upgrade, an etcd exit on a wedged cluster) took a running recovery
+# tick down with it — the exact moment the recovery is needed. The runner
+# already bails when the k3s API is not ready.
+Wants=k3s.service
 
 [Service]
 Type=oneshot

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-helm-stuck-recover
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-helm-stuck-recover
@@ -72,10 +72,23 @@ charts_json=$($KUBECTL --request-timeout=10s get helmchart -A -o json 2>/dev/nul
 # is fragile besides (JSON containing ``'''`` would break the literal).
 # ``strict=False`` tolerates the control char (we only read the CRs to
 # find Failed conditions, so lossy value bytes don't matter).
-CHARTS_JSON="$charts_json" python3 - <<PY
+#
+# The JSON goes through a FILE, not the environment: a single environment
+# string is capped at MAX_ARG_STRLEN (128 KiB on Linux), and the
+# spatium-control HelmChart's ``valuesContent`` alone crosses that once a
+# cluster has been promoted (~250 KB of rendered values on the appliance
+# sizing campaign's 3-node clusters, 2026-09-02). ``CHARTS_JSON=... python3``
+# then failed with ``Argument list too long`` (E2BIG) on every tick, so the
+# recovery timer that exists to unwedge helm could never run on exactly the
+# clusters that wedge. Only the path rides in the environment.
+charts_file=$(mktemp /tmp/helm-stuck-recover.XXXXXX)
+trap 'rm -f "$charts_file"' EXIT
+printf '%s' "$charts_json" > "$charts_file"
+CHARTS_FILE="$charts_file" python3 - <<PY
 import json, os, subprocess, time
 
-data = json.loads(os.environ["CHARTS_JSON"], strict=False)
+with open(os.environ["CHARTS_FILE"], encoding="utf-8", errors="replace") as fh:
+    data = json.loads(fh.read(), strict=False)
 now = int(time.time())
 
 def kubectl(*args):

--- a/appliance/tests/test_helm_stuck_recover.py
+++ b/appliance/tests/test_helm_stuck_recover.py
@@ -1,0 +1,152 @@
+"""spatiumddi-helm-stuck-recover — the JSON handoff must survive a big cluster.
+
+The runner shells out for the HelmChart CRs and hands the JSON to an inline
+python3 for the Failed-condition walk. It used to hand it over as ONE
+environment variable. A single environment string is capped at
+MAX_ARG_STRLEN (128 KiB on Linux), and spatium-control's ``valuesContent``
+alone crosses that once a control plane has been promoted (~250 KB of
+rendered values on the sizing campaign's 3-node clusters, 2026-09-02) — so
+the timer failed with ``Argument list too long`` on every tick, on exactly
+the clusters that wedge. The JSON now rides in a temp file.
+
+HOW TO RUN (from the repo root or this directory):
+    python3 -m pytest appliance/tests/test_helm_stuck_recover.py -v
+
+No k3s, no appliance required — the python body is extracted from the real
+script and run against a fixture with a stub kubectl.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).parent.parent
+    / "mkosi.extra"
+    / "usr"
+    / "local"
+    / "bin"
+    / "spatiumddi-helm-stuck-recover"
+)
+UNIT = (
+    Path(__file__).parent.parent
+    / "mkosi.extra"
+    / "etc"
+    / "systemd"
+    / "system"
+    / "spatiumddi-helm-stuck-recover.service"
+)
+
+# Well over MAX_ARG_STRLEN (131072): what a promoted cluster's HelmChart list
+# actually weighs, padded into valuesContent the way helm renders it.
+_BIG = 300 * 1024
+
+
+def _python_body() -> str:
+    """The heredoc between ``python3 - <<PY`` and the closing ``PY``, with the
+    shell's one interpolation (``${STUCK_THRESHOLD_SECONDS}``) resolved."""
+    text = SCRIPT.read_text()
+    m = re.search(r"python3 - <<PY\n(.*?)\nPY\n", text, re.S)
+    assert m, "python heredoc not found in the runner"
+    threshold = re.search(r"^STUCK_THRESHOLD_SECONDS=(\d+)", text, re.M)
+    assert threshold, "STUCK_THRESHOLD_SECONDS not found"
+    return m.group(1).replace("${STUCK_THRESHOLD_SECONDS}", threshold.group(1))
+
+
+def _charts(*, failed_age_s: int, pad: int) -> dict:
+    """One wedged HelmChart (Failed for ``failed_age_s``) beside a healthy one,
+    with ``valuesContent`` padded to ``pad`` bytes like a promoted cluster's."""
+    import datetime as dt
+
+    then = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=failed_age_s)
+    stamp = then.strftime("%Y-%m-%dT%H:%M:%SZ")
+    values = "api:\n  replicas: 3\n" + "".join(
+        f"  pad{i}: {'x' * 60}\n" for i in range(pad // 70)
+    )
+    return {
+        "items": [
+            {
+                "metadata": {"namespace": "kube-system", "name": "spatium-control"},
+                "spec": {"targetNamespace": "spatium", "valuesContent": values},
+                "status": {
+                    "conditions": [
+                        {"type": "Failed", "status": "True", "lastTransitionTime": stamp}
+                    ]
+                },
+            },
+            {
+                "metadata": {"namespace": "kube-system", "name": "spatium-bootstrap"},
+                "spec": {"targetNamespace": "spatium", "valuesContent": values},
+                "status": {"conditions": [{"type": "Failed", "status": "False"}]},
+            },
+        ]
+    }
+
+
+def _run(tmp_path: Path, charts: dict) -> tuple[subprocess.CompletedProcess, list[str]]:
+    """Run the extracted body with a stub ``k3s`` that logs every kubectl call
+    and answers the release-secret listing with one orphan secret."""
+    stub = tmp_path / "k3s"
+    calls = tmp_path / "calls.log"
+    stub.write_text(
+        "#!/bin/sh\n"
+        f'echo "$@" >> "{calls}"\n'
+        'case "$*" in\n'
+        '  *"get secrets"*) echo "sh.helm.release.v1.spatium-control.v1 other-secret";;\n'
+        "esac\n"
+    )
+    stub.chmod(0o755)
+    body = _python_body().replace("/usr/local/bin/k3s", str(stub))
+    charts_file = tmp_path / "charts.json"
+    charts_file.write_text(json.dumps(charts))
+    proc = subprocess.run(
+        [sys.executable, "-c", body],
+        env={**os.environ, "CHARTS_FILE": str(charts_file)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    lines = calls.read_text().splitlines() if calls.exists() else []
+    return proc, lines
+
+
+def test_the_json_rides_in_a_file_not_the_environment() -> None:
+    text = SCRIPT.read_text()
+    assert "CHARTS_FILE=" in text and 'os.environ["CHARTS_FILE"]' in text
+    assert 'CHARTS_JSON="$charts_json" python3' not in text
+    assert "mktemp" in text and "trap 'rm -f" in text
+
+
+def test_a_promoted_clusters_chart_list_is_walked_and_the_wedge_cleared(tmp_path: Path) -> None:
+    charts = _charts(failed_age_s=1200, pad=_BIG)
+    assert len(json.dumps(charts)) > 131072  # the E2BIG regime
+    proc, calls = _run(tmp_path, charts)
+    assert proc.returncode == 0, proc.stderr
+    assert "CLEARING wedged HelmChart kube-system/spatium-control" in proc.stdout
+    assert any("delete job helm-install-spatium-control" in c for c in calls)
+    assert any("delete secret sh.helm.release.v1.spatium-control.v1" in c for c in calls)
+    assert not any("other-secret" in c and "delete" in c for c in calls)
+    # The healthy chart is left alone.
+    assert "spatium-bootstrap" not in proc.stdout
+
+
+def test_a_fresh_failure_is_left_alone_under_the_threshold(tmp_path: Path) -> None:
+    proc, calls = _run(tmp_path, _charts(failed_age_s=60, pad=1024))
+    assert proc.returncode == 0, proc.stderr
+    assert "under threshold, leaving alone" in proc.stdout
+    assert not any("delete" in c for c in calls)
+
+
+def test_the_unit_wants_k3s_instead_of_requiring_it() -> None:
+    """Requires= took a running recovery tick down with every k3s restart —
+    the moment the recovery is needed. The runner already bails when the
+    API is not ready, so Wants= + After= is the whole ordering it needs."""
+    unit = UNIT.read_text()
+    assert "Wants=k3s.service" in unit
+    assert "Requires=k3s.service" not in unit
+    assert "After=k3s.service" in unit


### PR DESCRIPTION
Fixes #946

## Summary

Three appliance-side findings of the sizing campaign (2026-09-02/03; all present on `main` @ 33af6a84), two commits:

1. **`spatiumddi-helm-stuck-recover` hands the chart list to python through a file.** It passed `kubectl get helmchart -A -o json` in ONE environment string; a promoted control plane's `spatium-control.valuesContent` alone exceeds MAX_ARG_STRLEN (128 KiB), so the 5-minute timer failed with `Argument list too long` on every tick — on exactly the clusters that wedge. Only the path rides in the environment now. The unit also moves from `Requires=k3s.service` to `Wants=`: a k3s restart took a running recovery tick down with it, and the runner already bails when the API is not ready.
2. **The supervisor sizes the api and worker limits from the node's RAM, durably.** The chart's defaults (api 512Mi; worker 1Gi at four prefork processes) are BYO-cluster defaults; on the appliance the api could not build a 250k-record bundle under 512Mi and the worker was OOM-killed under 20k-device churn with gigabytes free — and every `kubectl set resources` was wiped by the next k3s restart (k3s re-applies the on-disk HelmChart manifest). On every control-plane override write the supervisor now adds `api.resources.limits.memory` = clamp(RAM/2, 1–8 GiB), `worker.resources.limits.memory` = clamp(RAM/4, 1–4 GiB) and `worker.concurrency` = 2 on nodes of 12 GiB or less, merged into the same `spatium-control` HelmChartConfig as the replica overrides (#272). Limits only; requests stay the chart's; an unknown size leaves the document unchanged. `redis.kind: sentinel` is stated beside `sentinel.replicas` rather than assumed.

## Evidence

- `appliance/tests/test_helm_stuck_recover.py`: the extracted python body against a 300 KB fixture with a stub kubectl (wedge cleared, healthy chart untouched, fresh failure left alone), the file handoff, the unit ordering.
- `agent/supervisor/tests/test_control_plane_resources.py`: clamps, unknown-size no-op, the merged document, an operator's own `requests` keys surviving, `/proc/meminfo` read.
- ddi-pg essential-lane walk of this head (`dev-301eae4`, 12 GiB patch rig): boot 8/8, baseline 38/38, ui 152/152, protocol 9/9, api 1,122 pass / 2 fail / 123 skip — the two fails are red on every build of this `main` in that lane (the #860 drift pin and an MCP tool-inventory pin), and this PR touches no backend code.
- Live (ddi-pg devbuild `dev-301eae4`, single-node appliance with 5,931 MiB): after the first heartbeat the `spatium-control` HelmChartConfig carried `api.resources.limits.memory: 2965Mi`, `worker.resources.limits.memory: 1482Mi`, `worker.concurrency: 2`, `redis.kind: sentinel`; the Deployments carried api 2965Mi / worker 1482Mi and celery `--concurrency=2`; after `systemctl restart k3s` both the HelmChartConfig and the Deployments were unchanged; one tick of `spatiumddi-helm-stuck-recover.service` ended `Result=success ExecMainStatus=0`.

## Notes for review

- The numbers are a starting policy, not a measurement of the maximum: the campaign measured that a 250k-record group needs ~4 GiB of api limit on an 8 GiB node (RAM/2) and that the worker at two processes fits 1.5–2 GiB under churn. Tune the constants at the top of `k8s_api.py` if you prefer a different split.
- BYO-Kubernetes installs are untouched (the appliance supervisor is the only writer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
