### PR TITLE
perf(dns): agent config bundle — page the pending ops, fetch records in one column-row query, serialise once

### DIFF
--- a/backend/app/api/v1/dns/agents.py
+++ b/backend/app/api/v1/dns/agents.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hmac
+import json
 import os
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -382,8 +383,22 @@ async def agent_config_longpoll(
             if not etag_matches(if_none_match, etag) or has_pending_ops:
                 server.last_config_etag = etag
                 await db.commit()
-                response.headers["ETag"] = format_etag(etag)
-                return bundle
+                # Serialise ONCE and hand the bytes back. Returning the dict
+                # sends it through FastAPI's jsonable_encoder, which walks and
+                # copies the whole structure — for a 250k-record group that is
+                # 500k record dicts duplicated on the request loop before the
+                # JSON is even written, the difference between a bundle that
+                # fits the api's memory limit and one that is memcg-killed
+                # (appliance sizing campaign, 2026-09-03: the api still hit
+                # 4.18 GB twice serving the first bundle after the paged-ops
+                # and one-query-records fixes). json.dumps of the same dict
+                # is what the ETag already hashes, so nothing changes on the
+                # wire.
+                return Response(
+                    content=json.dumps(bundle, default=str),
+                    media_type="application/json",
+                    headers={"ETag": format_etag(etag)},
+                )
             remaining = deadline - asyncio.get_running_loop().time()
             if remaining <= 0:
                 response.status_code = 304

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -96,6 +96,12 @@ class Settings(BaseSettings):
     dns_agent_token_ttl_hours: int = 24
     dns_agent_longpoll_timeout: int = 30
     dns_require_agent_approval: bool = False
+    # Pending record ops shipped per config bundle. The queue is drained a
+    # page at a time (the agent acks a page, the next long-poll ships the
+    # next); unbounded, a bulk seed's backlog was materialised whole into
+    # one response — 500k ops took the api to 4.2 GB and a memcg kill on
+    # every poll (appliance sizing campaign, 2026-09-02/03).
+    dns_agent_ops_batch: int = 5000
 
     # DHCP agent
     dhcp_agent_key: str = ""

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -17,10 +17,11 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.config import settings
 from app.core.crypto import decrypt_str
 from app.models.appliance import ApplianceCertificate
 from app.models.dns import (
@@ -381,6 +382,7 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     # it. Failure ack resets to pending (with attempt++); after 5
     # failures it becomes "failed" and stays out.
     pending_ops: list[dict[str, Any]] = []
+    pending_ops_remaining = 0
     # Issue #182: pause pending-op dispatch when the server is in
     # operator-set maintenance mode. Ops accumulate in ``state=pending``
     # and ship as soon as the operator resumes — no work is lost.
@@ -412,15 +414,39 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         if stale_ops:
             await db.flush()
     else:
+        # One PAGE of the queue, oldest first, never the whole backlog. The
+        # agent applies a page and acks it on its next heartbeat; the page
+        # it was shipped is ``in_flight`` meanwhile, so the next long-poll
+        # (which returns immediately while ops are pending) ships the next
+        # page. Unbounded, a bulk seed's backlog — 500k ops for 250k A+PTR
+        # records on one agent server — was materialised whole into every
+        # response: the api reached 4.2 GB and was memcg-killed on each poll,
+        # the bundle never reached the data plane, and the queue could only
+        # be cleared by hand (appliance sizing campaign, 2026-09-02/03).
+        # ``pending_ops_remaining`` tells the agent (and an operator reading
+        # the bundle) how deep the backlog still is.
+        batch = max(1, int(settings.dns_agent_ops_batch))
         op_res = await db.execute(
             select(DNSRecordOp)
             .where(
                 DNSRecordOp.server_id == server.id,
                 DNSRecordOp.state == "pending",
             )
-            .order_by(DNSRecordOp.created_at)
+            .order_by(DNSRecordOp.created_at, DNSRecordOp.id)
+            .limit(batch)
         )
         ops_to_dispatch = list(op_res.scalars().all())
+        if len(ops_to_dispatch) == batch:
+            pending_ops_remaining = int(
+                (
+                    await db.execute(
+                        select(func.count()).where(
+                            DNSRecordOp.server_id == server.id,
+                            DNSRecordOp.state == "pending",
+                        )
+                    )
+                ).scalar_one()
+            ) - len(ops_to_dispatch)
     for op in ops_to_dispatch:
         pending_ops.append(
             {
@@ -802,6 +828,7 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         "forwarders": options_block["forwarders"],
         "blocklists": blocklists_payload,
         "pending_record_ops": pending_ops,
+        "pending_ops_remaining": pending_ops_remaining,
         "catalog": catalog_block,
         "fleet_upgrade": fleet_upgrade_block,
         "snmp_settings": snmp_block,

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -256,7 +256,37 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
                 }
             )
 
-    def _rec_dict(r: DNSRecord) -> dict[str, Any]:
+    # Every record of every zone in ONE query, as column rows rather than
+    # ORM instances. This was one ``select(DNSRecord)`` per zone inside the
+    # loop below (N+1), and each row came back as a tracked ORM object — on
+    # the sizing campaign's 250k A+PTR zone the build held ~500k instances
+    # in the identity map for the life of the request, most of the api's
+    # working set on every long-poll (2026-09-02/03). Only the eight fields
+    # the bundle and the view filter read are fetched, ordered by (zone,
+    # id) so the rendered payload — and therefore the ETag — is the same
+    # from one poll to the next.
+    records_by_zone: dict[Any, list[Any]] = {}
+    if zone_ids:
+        rec_res = await db.execute(
+            select(
+                DNSRecord.zone_id,
+                DNSRecord.name,
+                DNSRecord.record_type,
+                DNSRecord.ttl,
+                DNSRecord.value,
+                DNSRecord.priority,
+                DNSRecord.weight,
+                DNSRecord.port,
+                DNSRecord.view_id,
+                DNSRecord.pool_member_id,
+            )
+            .where(DNSRecord.zone_id.in_(zone_ids))
+            .order_by(DNSRecord.zone_id, DNSRecord.id)
+        )
+        for rec in rec_res:
+            records_by_zone.setdefault(rec.zone_id, []).append(rec)
+
+    def _rec_dict(r: Any) -> dict[str, Any]:
         return {
             "name": r.name,
             "type": r.record_type,
@@ -325,9 +355,7 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         # historically gated this, but agents need records to render zone
         # files for serving — primary/secondary distinction matters for
         # accepting RFC 2136 updates, not for which server gets the data.
-        rec_rows = list(
-            (await db.execute(select(DNSRecord).where(DNSRecord.zone_id == z.id))).scalars().all()
-        )
+        rec_rows: list[Any] = records_by_zone.get(z.id, [])
 
         if not has_views:
             # Flat render — one zone copy, all records, no view (today's path).

--- a/backend/tests/test_dns_agents_config_ops_paging.py
+++ b/backend/tests/test_dns_agents_config_ops_paging.py
@@ -1,0 +1,144 @@
+"""The agent config bundle ships pending record ops a PAGE at a time.
+
+Found by the appliance sizing campaign (2026-09-02/03): seeding 250k A+PTR
+records into an agent-based group queued 500k ``DNSRecordOp`` rows for the
+one agent server, and the next long-poll materialised every one of them into
+the bundle — the api reached 4.2 GB, was memcg-killed at its 4Gi limit, and
+the same thing happened on every poll, so the bundle never reached the data
+plane and the queue could only be cleared by hand.
+
+The bundle now carries at most ``settings.dns_agent_ops_batch`` ops (oldest
+first) plus ``pending_ops_remaining``; the shipped page is ``in_flight`` so
+the next long-poll — which returns immediately while ops are pending — ships
+the next page. Paging must not touch the structural fingerprint, or every
+page would look like a config change and force a daemon reload.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.models.dns import DNSRecordOp, DNSServer, DNSServerGroup, DNSZone
+from app.services.dns.agent_config import build_config_bundle
+
+
+async def _agent_server(db: AsyncSession) -> tuple[DNSServer, DNSZone]:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    server = DNSServer(
+        group_id=grp.id,
+        driver="bind9",
+        host="10.0.0.1",
+        name=f"srv-{uuid.uuid4().hex[:6]}",
+        is_primary=True,
+        is_enabled=True,
+    )
+    db.add(server)
+    await db.flush()
+    zone = DNSZone(
+        group_id=grp.id,
+        name=f"z{uuid.uuid4().hex[:6]}.example.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.example.",
+        admin_email="admin.example.",
+    )
+    db.add(zone)
+    await db.flush()
+    return server, zone
+
+
+async def _queue_ops(db: AsyncSession, server: DNSServer, zone: DNSZone, n: int) -> None:
+    base = datetime.now(UTC) - timedelta(minutes=n)
+    for i in range(n):
+        db.add(
+            DNSRecordOp(
+                server_id=server.id,
+                zone_name=zone.name,
+                op="create",
+                record={"name": f"h{i:04d}", "type": "A", "value": f"10.0.{i // 250}.{i % 250}"},
+                state="pending",
+                created_at=base + timedelta(seconds=i),
+            )
+        )
+    await db.flush()
+
+
+async def _states(db: AsyncSession, server: DNSServer) -> dict[str, int]:
+    rows = (
+        (await db.execute(select(DNSRecordOp.state).where(DNSRecordOp.server_id == server.id)))
+        .scalars()
+        .all()
+    )
+    out: dict[str, int] = {}
+    for s in rows:
+        out[s] = out.get(s, 0) + 1
+    return out
+
+
+@pytest.mark.asyncio
+async def test_a_backlog_is_shipped_a_page_at_a_time_oldest_first(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "dns_agent_ops_batch", 5)
+    server, zone = await _agent_server(db_session)
+    await _queue_ops(db_session, server, zone, 12)
+    await db_session.commit()
+
+    first = await build_config_bundle(db_session, server)
+    await db_session.commit()
+    page = first["pending_record_ops"]
+    assert len(page) == 5
+    assert [op["record"]["name"] for op in page] == [f"h{i:04d}" for i in range(5)]
+    assert first["pending_ops_remaining"] == 7
+    assert await _states(db_session, server) == {"in_flight": 5, "pending": 7}
+
+    second = await build_config_bundle(db_session, server)
+    await db_session.commit()
+    assert [op["record"]["name"] for op in second["pending_record_ops"]] == [
+        f"h{i:04d}" for i in range(5, 10)
+    ]
+    assert second["pending_ops_remaining"] == 2
+
+    third = await build_config_bundle(db_session, server)
+    await db_session.commit()
+    assert len(third["pending_record_ops"]) == 2
+    assert third["pending_ops_remaining"] == 0
+    assert await _states(db_session, server) == {"in_flight": 12}
+
+    # Paging is invisible to the structural fingerprint: no page looks like
+    # a config change (which would force a full daemon reload per page).
+    assert first["structural_etag"] == second["structural_etag"] == third["structural_etag"]
+    # …but the bundle etag differs per page, so the agent never confuses
+    # one page's ack set with the next.
+    assert len({first["etag"], second["etag"], third["etag"]}) == 3
+
+
+@pytest.mark.asyncio
+async def test_a_backlog_under_the_batch_ships_whole_with_nothing_remaining(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "dns_agent_ops_batch", 5000)
+    server, zone = await _agent_server(db_session)
+    await _queue_ops(db_session, server, zone, 3)
+    await db_session.commit()
+
+    bundle = await build_config_bundle(db_session, server)
+    assert len(bundle["pending_record_ops"]) == 3
+    assert bundle["pending_ops_remaining"] == 0
+
+
+@pytest.mark.asyncio
+async def test_an_empty_queue_reports_no_backlog(db_session: AsyncSession) -> None:
+    server, _zone = await _agent_server(db_session)
+    await db_session.commit()
+    bundle = await build_config_bundle(db_session, server)
+    assert bundle["pending_record_ops"] == []
+    assert bundle["pending_ops_remaining"] == 0

--- a/backend/tests/test_dns_agents_config_records_query.py
+++ b/backend/tests/test_dns_agents_config_records_query.py
@@ -1,0 +1,101 @@
+"""The agent bundle fetches every zone's records in ONE query, in a stable
+order.
+
+This was one ``select(DNSRecord)`` per zone inside the zone loop, each row a
+tracked ORM instance. At the sizing campaign's 250k A+PTR records the build
+held ~500k instances for the life of the request — most of the api's working
+set on every agent long-poll (2026-09-02/03). The rows are now column tuples
+from a single ``WHERE zone_id IN (...)`` ordered by (zone, id), so the
+payload — and the ETag the agent compares — is the same from poll to poll.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dns import DNSRecord, DNSServer, DNSServerGroup, DNSZone
+from app.services.dns.agent_config import build_config_bundle
+
+
+async def _group_with_zones(db: AsyncSession, zones: int, per_zone: int) -> DNSServer:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    server = DNSServer(
+        group_id=grp.id,
+        driver="bind9",
+        host="10.0.0.1",
+        name=f"srv-{uuid.uuid4().hex[:6]}",
+        is_primary=True,
+        is_enabled=True,
+    )
+    db.add(server)
+    await db.flush()
+    for zi in range(zones):
+        zone = DNSZone(
+            group_id=grp.id,
+            name=f"z{zi}-{uuid.uuid4().hex[:4]}.example.",
+            zone_type="primary",
+            kind="forward",
+            primary_ns="ns1.example.",
+            admin_email="admin.example.",
+        )
+        db.add(zone)
+        await db.flush()
+        db.add_all(
+            DNSRecord(
+                zone_id=zone.id,
+                name=f"h{i:03d}",
+                fqdn=f"h{i:03d}.{zone.name}",
+                record_type="A",
+                value=f"10.{zi}.{i // 250}.{i % 250}",
+            )
+            for i in range(per_zone)
+        )
+        await db.flush()
+    return server
+
+
+class _RecordSelects:
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+
+    def __call__(self, conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
+        s = " ".join(statement.split()).upper()
+        if s.startswith("SELECT") and " FROM DNS_RECORD " in s + " " and "DNS_RECORD_OP" not in s:
+            self.statements.append(statement)
+
+
+@pytest.mark.asyncio
+async def test_all_zones_records_come_from_one_query(db_session: AsyncSession) -> None:
+    server = await _group_with_zones(db_session, zones=4, per_zone=30)
+    await db_session.commit()
+
+    counter = _RecordSelects()
+    event.listen(Engine, "before_cursor_execute", counter)
+    try:
+        bundle = await build_config_bundle(db_session, server)
+    finally:
+        event.remove(Engine, "before_cursor_execute", counter)
+
+    assert len(counter.statements) == 1, counter.statements
+    assert sorted(len(z["records"]) for z in bundle["zones"]) == [30, 30, 30, 30]
+    rec = bundle["zones"][0]["records"][0]
+    assert set(rec) == {"name", "type", "ttl", "value", "priority", "weight", "port"}
+
+
+@pytest.mark.asyncio
+async def test_the_payload_and_etag_are_stable_across_polls(db_session: AsyncSession) -> None:
+    server = await _group_with_zones(db_session, zones=2, per_zone=50)
+    await db_session.commit()
+
+    first = await build_config_bundle(db_session, server)
+    second = await build_config_bundle(db_session, server)
+    assert first["zones"] == second["zones"]
+    assert first["etag"] == second["etag"]
+    assert first["structural_etag"] == second["structural_etag"]

--- a/backend/tests/test_dns_agents_config_route.py
+++ b/backend/tests/test_dns_agents_config_route.py
@@ -1,0 +1,129 @@
+"""`GET /api/v1/dns/agents/config` hands the bundle back as bytes serialised
+once, and the fast path / 304 contract is unchanged.
+
+Returning the dict sent it through FastAPI's jsonable_encoder, which walks and
+copies the whole structure before the JSON is written — for a 250k-record
+group that is 500k record dicts duplicated on the request loop, the difference
+between a bundle that fits the api's memory limit and one that is memcg-killed
+(appliance sizing campaign, 2026-09-03). The route now returns a JSON Response
+built from one json.dumps; these tests pin what the agent sees.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.dns import agents as agents_api
+from app.models.dns import DNSRecord, DNSRecordOp, DNSServer, DNSServerGroup, DNSZone
+from app.services.dns.agent_token import mint_agent_token
+
+CONFIG_URL = "/api/v1/dns/agents/config"
+
+
+async def _agent(db: AsyncSession, records: int) -> tuple[DNSServer, DNSZone, dict[str, str]]:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    server = DNSServer(
+        group_id=grp.id,
+        driver="bind9",
+        host="10.0.0.1",
+        name=f"srv-{uuid.uuid4().hex[:6]}",
+        is_primary=True,
+        is_enabled=True,
+        agent_id=uuid.uuid4(),
+    )
+    db.add(server)
+    await db.flush()
+    zone = DNSZone(
+        group_id=grp.id,
+        name=f"z{uuid.uuid4().hex[:6]}.example.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.example.",
+        admin_email="admin.example.",
+    )
+    db.add(zone)
+    await db.flush()
+    db.add_all(
+        DNSRecord(
+            zone_id=zone.id,
+            name=f"h{i:04d}",
+            fqdn=f"h{i:04d}.{zone.name}",
+            record_type="A",
+            value=f"10.0.{i // 250}.{i % 250}",
+        )
+        for i in range(records)
+    )
+    await db.flush()
+    token, _exp = mint_agent_token(str(server.id), str(server.agent_id), "fp")
+    return server, zone, {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_the_bundle_comes_back_as_json_bytes_with_its_etag(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(agents_api, "LONGPOLL_TIMEOUT_SECONDS", 1)
+    _server, zone, headers = await _agent(db_session, records=300)
+    await db_session.commit()
+
+    resp = await client.get(CONFIG_URL, headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("application/json")
+    body = resp.json()
+    assert body["etag"].startswith("sha256:")
+    assert resp.headers["etag"]  # the ETag the agent will send back
+    zones = {z["name"]: z for z in body["zones"]}
+    assert len(zones[zone.name]["records"]) == 300
+    assert body["pending_record_ops"] == []
+    assert body["pending_ops_remaining"] == 0
+
+    # Nothing changed and nothing is pending: the held poll answers 304.
+    again = await client.get(CONFIG_URL, headers={**headers, "If-None-Match": resp.headers["etag"]})
+    assert again.status_code == 304
+    assert again.headers["etag"] == resp.headers["etag"]
+
+
+@pytest.mark.asyncio
+async def test_pending_ops_take_the_fast_path_a_page_at_a_time(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.config import settings
+
+    monkeypatch.setattr(agents_api, "LONGPOLL_TIMEOUT_SECONDS", 5)
+    monkeypatch.setattr(settings, "dns_agent_ops_batch", 4)
+    server, zone, headers = await _agent(db_session, records=10)
+    for i in range(6):
+        db_session.add(
+            DNSRecordOp(
+                server_id=server.id,
+                zone_name=zone.name,
+                op="create",
+                record={"name": f"n{i}", "type": "A", "value": f"10.9.9.{i}"},
+                state="pending",
+                created_at=datetime(2026, 9, 3, 12, 0, i, tzinfo=UTC),
+            )
+        )
+    await db_session.commit()
+
+    first = await client.get(CONFIG_URL, headers=headers)
+    assert first.status_code == 200, first.text
+    body = first.json()
+    # Returned immediately (no 5 s hold) with the first page only.
+    assert [op["record"]["name"] for op in body["pending_record_ops"]] == ["n0", "n1", "n2", "n3"]
+    assert body["pending_ops_remaining"] == 2
+
+    # The next poll — even with the same ETag — ships the next page.
+    second = await client.get(
+        CONFIG_URL, headers={**headers, "If-None-Match": first.headers["etag"]}
+    )
+    assert second.status_code == 200, second.text
+    body2 = second.json()
+    assert [op["record"]["name"] for op in body2["pending_record_ops"]] == ["n4", "n5"]
+    assert body2["pending_ops_remaining"] == 0


### PR DESCRIPTION
Fixes #948

## Summary

A freshly bulk-loaded agent-based DNS group could not converge on the recommended 8 GiB appliance: `GET /api/v1/dns/agents/config` materialised every pending `dns_record_op` for the server into one bundle, and every zone's records with one query per zone as tracked ORM instances (appliance sizing campaign, 2026-09-02/03; reproduced on `main` @ 33af6a84 on 2026-09-03: a 250k A+PTR seed queued 500,000 pending ops → `uvicorn` memcg-killed at anon-rss 4.18 GB, 18 times in 89 minutes, the bundle never reaching the data plane; the same rows with the ops deleted by hand rendered in 2 s).

Three commits, one cause each, in the order the live runs forced them:

1. **Pending ops are shipped a page at a time.** `settings.dns_agent_ops_batch` (default 5000) bounds the ops per bundle, oldest first; the bundle carries `pending_ops_remaining`. The shipped page is `in_flight` while the agent applies and acks it, so the next long-poll — which already returns immediately while ops are pending — ships the next page. Paging stays outside the structural fingerprint, so a page is never a config change (no daemon reload per page).
2. **Every zone's records come from ONE query as column rows**, ordered by (zone, id), instead of one `select(DNSRecord)` per zone as ORM instances — a stable payload (and ETag) from poll to poll, and no 500k-object identity map per request.
3. **The bundle is serialised once.** The route returned the dict, so FastAPI's `jsonable_encoder` walked and copied the whole 500k-record payload a second time before `json.dumps`; it now returns the bytes (`json.dumps(default=str)`) with the same ETag / 304 behaviour.

## Evidence

- Backend Lint & Type Check mirror green; `backend/tests/test_dns_agents_config_ops_paging.py` (page/remaining/in_flight transitions across three polls, structural etag stable, bundle etag distinct per page), `backend/tests/test_dns_agents_config_records_query.py` (one `dns_record` SELECT for a four-zone group; payload + etag stable across polls), `backend/tests/test_dns_agents_config_route.py` (bytes + ETag, 304 on If-None-Match, pages on the fast path).
- Live, same rig image (single node 8 GiB / 4 vCPU, api limit 4Gi), the same fresh 250k A+PTR seed with NO manual purge:
  - `main` 33af6a84: never rendered — uvicorn memcg-killed at anon-rss 4.18 GB, 18 times in 89 minutes, 500,000 ops still pending.
  - commit 1 only (ddi-pg devbuild `dev-ec0aeb9`): same outcome — killed at 4.18 GB inside `build_config_bundle` before the first page shipped, 11 api restarts; the ops were never the whole story.
  - commits 1+2 (`dev-5d08821`): **rendered** — kea scopes and zone answers 655 s after the fill, with two api OOM restarts on the way (the 4Gi cap is still marginal for this seed). The 75-minute 5632 MiB / 3 vCPU load cell that followed on the same appliance: api RSS peaked at 1.13 GB, 0 restarts, BIND 4.93M queries at 100 %.
  - commits 1+2+3 (`dev-f66eb83`, ddi-pg essential-lane walk on a 12 GiB patch rig): boot 4/4, baseline 19/19, ui 152/152, protocol 9/9, api 1,121 pass / 3 fail / 123 skip — the three fails are the two checks red on every build of this `main` in the same lane (the #860 drift pin and an MCP tool-inventory pin) and one dirty-state 500 on `PUT /api/v1/dnsbl/settings`; none touches the agent bundle path. The suite's five agent-config checks (ETag then 304 for dns and dhcp, gzip preserving the ETag, the bundle reflecting a mutation for dns and dhcp) pass.

## Notes for review

- The agent needs no change: it applies `pending_record_ops` and acks them on its heartbeat exactly as before; `pending_ops_remaining` is informational.
- Ops shipped as `in_flight` and never acked follow the existing rules (`ack_op` failure → `pending` again after `attempts`; a full re-render retires them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
