### PR TITLE
fix(dns): bulk-delete deletes the rows it dispatched on agent zones; permanent zone delete is set-based and sweeps the zone's queued ops

### DIFF
--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -6587,6 +6587,15 @@ async def bulk_delete_records(
     # failed must NOT remove the DB row — if we delete blindly the user
     # sees "deleted" in the UI but the record is still published, and
     # the next "Sync with server" pulls the zombie back.
+    #
+    # Only ``failed`` blocks, though. Agent-based servers never answer
+    # inline: ``enqueue_record_ops_batch`` queues their rows as ``pending``
+    # and the agent applies them on its next long-poll — exactly what the
+    # singular DELETE route relies on. Gating on ``!= "applied"`` treated
+    # every one of those as a failure, so bulk delete on an agent-based
+    # zone skipped every record and returned ``deleted: 0`` while the
+    # singular route deleted the same rows (appliance sizing campaign,
+    # 2026-09-02).
     deleted = 0
     for rec, op_row in zip(targets, op_rows, strict=True):
         if op_row is None:
@@ -6597,7 +6606,7 @@ async def bulk_delete_records(
                 }
             )
             continue
-        if op_row.state != "applied":
+        if op_row.state == "failed":
             skipped.append(
                 {
                     "record_id": str(rec.id),

--- a/backend/app/services/ai/operations_risky.py
+++ b/backend/app/services/ai/operations_risky.py
@@ -852,6 +852,35 @@ async def _apply_delete_zone(db: AsyncSession, user: User, args: DeleteZoneArgs)
         )
     )
     collect_wake(dns_group_channel(args.group_id))
+    # Set-based first, ORM second. ``db.delete(zone)`` alone cascades through
+    # the ORM: every record row is loaded, tracked and DELETEd one by one
+    # inside the request. On a 250k-1M record zone that is minutes of a
+    # single transaction on the request loop — the api's liveness probes
+    # timed out and the pod was killed mid-delete (appliance sizing
+    # campaign, 2026-09-02). ``dns_record.zone_id`` already cascades at the
+    # FK, so delete the records in one statement and let the ORM cascade
+    # find nothing left to load. The zone's queued record ops go with it
+    # (the sweep zone_move does): a ``pending``/``in_flight`` op for a zone
+    # that no longer exists would only fail on the agent and surface as a
+    # zombie on the next resync.
+    from sqlalchemy import delete as sa_delete
+
+    from app.models.dns import DNSRecord, DNSRecordOp, DNSServer
+
+    group_server_ids = (
+        (await db.execute(select(DNSServer.id).where(DNSServer.group_id == zone.group_id)))
+        .scalars()
+        .all()
+    )
+    if group_server_ids:
+        await db.execute(
+            sa_delete(DNSRecordOp).where(
+                DNSRecordOp.server_id.in_(group_server_ids),
+                DNSRecordOp.zone_name == zone.name,
+                DNSRecordOp.state.in_(("pending", "in_flight")),
+            )
+        )
+    await db.execute(sa_delete(DNSRecord).where(DNSRecord.zone_id == zone.id))
     await db.delete(zone)
     await db.commit()
     return {"zone_id": str(args.zone_id), "mode": "delete"}

--- a/backend/tests/test_dns_zone_lifecycle_at_scale.py
+++ b/backend/tests/test_dns_zone_lifecycle_at_scale.py
@@ -174,3 +174,54 @@ async def test_bulk_delete_keeps_the_row_only_when_the_wire_delete_failed(
     assert "primary refused" in body["skipped"][0]["reason"]
     # The failed one is still published, so it is still in the database.
     assert await _record_count(db_session, zone.id) == 1
+
+
+# ── 2. permanent zone delete at scale ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_permanent_zone_delete_is_set_based_and_sweeps_its_queued_ops(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _admin_headers(db_session)
+    _grp, server, zone = await _agent_group_and_zone(db_session)
+    rows = await _add_records(db_session, zone, 400)
+    # Queued ops the agent has not picked up yet — a zone that no longer
+    # exists must not leave them behind to fail on the agent later.
+    for rec in rows[:5]:
+        db_session.add(
+            DNSRecordOp(
+                server_id=server.id,
+                zone_name=zone.name,
+                op="create",
+                record={"name": rec.name, "type": "A", "value": rec.value},
+                state="pending",
+            )
+        )
+    await db_session.commit()
+    zone_id, zone_name = zone.id, zone.name
+    assert await _record_count(db_session, zone_id) == 400
+    assert len(await _ops(db_session, zone_name)) == 5
+
+    record_deletes: list[str] = []
+
+    def _count(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
+        if statement.lstrip().upper().startswith("DELETE FROM DNS_RECORD "):
+            record_deletes.append(statement)
+
+    event.listen(Engine, "before_cursor_execute", _count)
+    try:
+        resp = await client.delete(f"{_zone_url(zone)}?permanent=true", headers=headers)
+    finally:
+        event.remove(Engine, "before_cursor_execute", _count)
+    assert resp.status_code == 204, resp.text
+
+    db_session.expire_all()
+    assert await _record_count(db_session, zone_id) == 0
+    assert await _ops(db_session, zone_name) == []
+    assert (
+        await db_session.execute(select(DNSZone).where(DNSZone.id == zone_id))
+    ).scalar_one_or_none() is None
+    # ONE statement for the records, never one per row: 400 rows here, 250k-1M
+    # on the appliance the campaign measured.
+    assert len(record_deletes) == 1, record_deletes

--- a/backend/tests/test_dns_zone_lifecycle_at_scale.py
+++ b/backend/tests/test_dns_zone_lifecycle_at_scale.py
@@ -203,11 +203,11 @@ async def test_permanent_zone_delete_is_set_based_and_sweeps_its_queued_ops(
     assert await _record_count(db_session, zone_id) == 400
     assert len(await _ops(db_session, zone_name)) == 5
 
-    record_deletes: list[str] = []
+    record_deletes: list[tuple[str, bool]] = []
 
     def _count(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
         if statement.lstrip().upper().startswith("DELETE FROM DNS_RECORD "):
-            record_deletes.append(statement)
+            record_deletes.append((statement, bool(executemany)))
 
     event.listen(Engine, "before_cursor_execute", _count)
     try:
@@ -224,4 +224,15 @@ async def test_permanent_zone_delete_is_set_based_and_sweeps_its_queued_ops(
     ).scalar_one_or_none() is None
     # ONE statement for the records, never one per row: 400 rows here, 250k-1M
     # on the appliance the campaign measured.
+    #
+    # The statement COUNT alone does not discriminate, and asserting on it
+    # alone would leave this test green against the very regression it exists
+    # to catch: the ORM cascade emits a single ``DELETE FROM dns_record WHERE
+    # dns_record.id = $1`` and hands it one parameter set PER ROW, so
+    # ``before_cursor_execute`` fires exactly once there too. ``executemany``
+    # is what separates them — True is the per-row cascade, False the one
+    # set-based ``WHERE zone_id = $1``. Assert on both.
     assert len(record_deletes) == 1, record_deletes
+    statement, executemany = record_deletes[0]
+    assert not executemany, f"per-row ORM cascade, not a set-based delete: {statement}"
+    assert "ZONE_ID" in statement.upper(), statement

--- a/backend/tests/test_dns_zone_lifecycle_at_scale.py
+++ b/backend/tests/test_dns_zone_lifecycle_at_scale.py
@@ -1,0 +1,176 @@
+"""Zone lifecycle at scale — two findings of the appliance sizing campaign
+(2026-09-02, 250k-1M record zones on agent-based groups).
+
+1. ``POST .../records/bulk-delete`` on an agent-based zone deleted NOTHING
+   (``deleted: 0``, every record "wire delete failed: unknown") while the
+   singular ``DELETE .../records/{id}`` deleted the same rows. Agent-based
+   servers never answer inline: the batch enqueue queues their ops as
+   ``pending`` for the agent's next long-poll, and the route's gate treated
+   anything but ``applied`` as a failure. Only a ``failed`` wire delete may
+   keep the DB row.
+
+2. ``DELETE .../zones/{id}?permanent=true`` cascaded through the ORM — every
+   record row loaded and deleted one by one in the request — so a large zone
+   took minutes of one transaction on the request loop and the api pod was
+   killed by its own probes mid-delete. The records now go in one statement
+   (the FK already cascades), and the zone's queued ops go with them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import event, func, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dns import DNSRecord, DNSRecordOp, DNSServer, DNSServerGroup, DNSZone
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+async def _admin_headers(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"zl-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="Zone Lifecycle Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def _agent_group_and_zone(db: AsyncSession) -> tuple[DNSServerGroup, DNSServer, DNSZone]:
+    """One group, one enabled agent-based (bind9) primary, one zone."""
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    server = DNSServer(
+        group_id=grp.id,
+        driver="bind9",
+        host="10.0.0.1",
+        name=f"srv-{uuid.uuid4().hex[:6]}",
+        is_primary=True,
+        is_enabled=True,
+    )
+    db.add(server)
+    await db.flush()
+    zone = DNSZone(
+        group_id=grp.id,
+        name=f"z{uuid.uuid4().hex[:6]}.example.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.example.",
+        admin_email="admin.example.",
+        ttl=3600,
+    )
+    db.add(zone)
+    await db.flush()
+    return grp, server, zone
+
+
+async def _add_records(db: AsyncSession, zone: DNSZone, count: int) -> list[DNSRecord]:
+    rows = [
+        DNSRecord(
+            zone_id=zone.id,
+            name=f"h{i:06d}",
+            fqdn=f"h{i:06d}.{zone.name}",
+            record_type="A",
+            value=f"10.{(i >> 16) & 255}.{(i >> 8) & 255}.{i & 255}",
+        )
+        for i in range(count)
+    ]
+    db.add_all(rows)
+    await db.flush()
+    return rows
+
+
+def _zone_url(zone: DNSZone) -> str:
+    return f"/api/v1/dns/groups/{zone.group_id}/zones/{zone.id}"
+
+
+async def _record_count(db: AsyncSession, zone_id: uuid.UUID) -> int:
+    return int(
+        (await db.execute(select(func.count()).where(DNSRecord.zone_id == zone_id))).scalar_one()
+    )
+
+
+async def _ops(db: AsyncSession, zone_name: str) -> list[DNSRecordOp]:
+    return list(
+        (await db.execute(select(DNSRecordOp).where(DNSRecordOp.zone_name == zone_name)))
+        .scalars()
+        .all()
+    )
+
+
+# ── 1. bulk delete on an agent-based zone ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_on_an_agent_zone_deletes_the_rows_and_queues_the_ops(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _admin_headers(db_session)
+    _grp, _server, zone = await _agent_group_and_zone(db_session)
+    rows = await _add_records(db_session, zone, 5)
+    await db_session.commit()
+
+    resp = await client.post(
+        f"{_zone_url(zone)}/records/bulk-delete",
+        headers=headers,
+        json={"record_ids": [str(r.id) for r in rows[:3]]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # The wire ops are PENDING on an agent-based server (the agent applies
+    # them on its next long-poll); that is a dispatched delete, not a failed
+    # one, and the DB rows must go.
+    assert body["deleted"] == 3, body
+    assert body["skipped"] == [], body
+    assert await _record_count(db_session, zone.id) == 2
+    ops = [o for o in await _ops(db_session, zone.name) if o.op == "delete"]
+    assert len(ops) == 3
+    assert {o.state for o in ops} == {"pending"}
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_keeps_the_row_only_when_the_wire_delete_failed(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.api.v1.dns import router as dns_router
+
+    headers = await _admin_headers(db_session)
+    _grp, _server, zone = await _agent_group_and_zone(db_session)
+    rows = await _add_records(db_session, zone, 3)
+    await db_session.commit()
+
+    # One failed wire delete, one applied, one still pending.
+    states = ["failed", "applied", "pending"]
+
+    async def fake_batch(db, zone_, ops):  # noqa: ANN001
+        return [
+            SimpleNamespace(state=s, last_error="primary refused" if s == "failed" else None)
+            for s in states
+        ]
+
+    monkeypatch.setattr(dns_router, "enqueue_record_ops_batch", fake_batch)
+    resp = await client.post(
+        f"{_zone_url(zone)}/records/bulk-delete",
+        headers=headers,
+        json={"record_ids": [str(r.id) for r in rows]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["deleted"] == 2, body
+    assert len(body["skipped"]) == 1
+    assert body["skipped"][0]["record_id"] == str(rows[0].id)
+    assert "primary refused" in body["skipped"][0]["reason"]
+    # The failed one is still published, so it is still in the database.
+    assert await _record_count(db_session, zone.id) == 1


### PR DESCRIPTION
Fixes #950

## Summary

Two zone-lifecycle defects found while loading the appliance with 250k-1M records (appliance sizing campaign, 2026-09-02/03; both reproduced on `main` @ 33af6a84 on 2026-09-03), one commit each:

1. **`POST …/records/bulk-delete` on an agent-based zone deletes the rows it dispatched.** The route gated the DB delete on the wire op coming back `applied`; agent-based servers never answer inline (`enqueue_record_ops_batch` queues `pending` rows for the agent's next long-poll — what the singular `DELETE …/records/{id}` relies on), so on an agent-based zone every record was skipped with `wire delete failed: unknown` and the response was `deleted: 0`. Only a `failed` wire delete keeps the row now.
2. **A permanent zone delete is set-based and sweeps the zone's queued ops.** `db.delete(zone)` cascaded through the ORM one record at a time inside the request; on a 250k-record zone the api pod's own liveness probe killed it mid-delete. The records now go in ONE statement (the `dns_record.zone_id` FK already cascades) before the ORM delete, and the zone's `pending` / `in_flight` ops on the group's servers are swept (the sweep `zone_move` already does).

## Evidence

Live drill on a 1000-record agent zone (bulk-delete 500, then permanent delete), same rig image, two builds:

| build | `deleted` | `skipped` | reason | rows after | zone delete |
|---|---|---|---|---|---|
| main 33af6a84 | 0 | 500 | `wire delete failed: unknown` | 1000 | 0.7 s |
| this PR | 500 | 0 | — | 500 | 0.2 s |

- Backend Lint & Type Check mirror (ruff / black / mypy / lint_migrations / lint_appliance_runners) green.
- `backend/tests/test_dns_zone_lifecycle_at_scale.py`: agent-zone bulk delete; the failed-op row is kept; one `DELETE FROM dns_record` statement for a 400-row zone with its ops swept and the zone gone.
- ddi-pg essential-lane walk of this head (`dev-298d15b`, 12 GiB patch rig, sealed 21:46Z): boot 4/4, baseline 19/19, ui 152/152, protocol 9/9, api 1,122 pass / 2 fail / 123 skip — the two fails are red on every build of this `main` in that lane (the #860 drift pin and an MCP tool-inventory pin) and are unrelated to zones.

## Notes for review

- The bulk-delete semantics now match the singular route's: a dispatched delete leaves the database the way it leaves the bundle; a `failed` wire delete is still reported per record in `skipped`.
- The op sweep is scoped to the zone's group servers and to `pending` / `in_flight`, exactly as `zone_move` scopes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
