### PR TITLE
perf(orchestrator): bind one relay socket per giaddr so Kea's OFFERs cannot be shared with other UDP/67 listeners

### DIFF
--- a/perf/generators/orchestrator/device_fleet.py
+++ b/perf/generators/orchestrator/device_fleet.py
@@ -1001,9 +1001,17 @@ class Orchestrator:
                 if d.state is not DState.OFFLINE),
         }
         append_ndjson(self.rp.generator(f"orchestrator.shard{self.shard}.summary.ndjson"), summary)
-        if self._sock:
+        # Every socket, not just the wildcard one: relay topology opens one per
+        # giaddr (open_relay_sockets). A giaddr that could not be bound maps to
+        # the wildcard socket, so the values can repeat it — dedupe by identity
+        # rather than closing the same fd twice.
+        seen: set[int] = set()
+        for sock in [self._sock, *self._socks.values()]:
+            if sock is None or id(sock) in seen:
+                continue
+            seen.add(id(sock))
             try:
-                self._sock.close()
+                sock.close()
             except OSError as exc:
                 # Best-effort close during teardown; a socket error here is non-fatal.
                 self.log.debug("socket close failed during finalize: %s", exc)

--- a/perf/generators/orchestrator/device_fleet.py
+++ b/perf/generators/orchestrator/device_fleet.py
@@ -64,6 +64,7 @@ from spddi_perf.runpaths import RunPaths  # noqa: E402
 
 import dhcp_packet as dp  # noqa: E402
 from lifecycle_log import LatencyAccumulator, LifecycleLog  # noqa: E402
+from relay_sockets import open_relay_sockets  # noqa: E402
 
 # dnspython is an off-box runtime dep (perf/requirements.txt: dnspython>=2.6); resolve
 # it once at import so the per-query hot path doesn't re-run the import machinery. When
@@ -318,6 +319,10 @@ class Orchestrator:
 
         self._stop = asyncio.Event()
         self._sock: socket.socket | None = None
+        # Relay topology: giaddr -> the socket bound to that address (see
+        # open_relay_sockets); a giaddr without its own socket sends and receives
+        # on the wildcard ``_sock``.
+        self._socks: dict[str, socket.socket] = {}
         self._last_seen_tick = -1
         self._tick_seen_at = time.monotonic()
         self._arrival_accum = 0.0
@@ -344,33 +349,14 @@ class Orchestrator:
 
     # ---------------- socket ----------------
     def _open_socket(self) -> None:
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        # Multi-homed egress (perf #454). In broadcast topology the DISCOVER goes
-        # to 255.255.255.255; on a box with several NICs (docker bridges, tailscale,
-        # …) the kernel won't necessarily send it out the one facing the appliance.
-        # Bind the socket to the configured device so it does. SO_BINDTODEVICE needs
-        # CAP_NET_RAW (the load-gen already runs as root for the :67/:68 bind).
         iface = getattr(self.m.target.dhcp, "iface", "") or ""
-        if iface:
-            try:
-                s.setsockopt(socket.SOL_SOCKET, socket.SO_BINDTODEVICE, iface.encode())
-                self.log.info("dhcp socket bound to device", extra={"fields": {
-                    "event": "socket_bindtodevice", "iface": iface}})
-            except OSError as exc:
-                self.log.error("SO_BINDTODEVICE(%s) failed: %s — broadcast may not "
-                               "reach the appliance on a multi-homed box", iface, exc,
-                               extra={"fields": {"event": "bindtodevice_failed", "iface": iface}})
         # Relay topology: bind to the relay/server port (67) so Kea unicasts replies
         # to giaddr:67 back to us. Broadcast topology: bind to the client port (68).
         bind_port = 67 if self.relay else 68
-        # 0.0.0.0 is required, not a misconfiguration: a simulated client has no
-        # lease yet, so it must listen on the wildcard address to receive the
-        # broadcast OFFER/ACK. SO_BINDTODEVICE above already pins the socket to the
-        # appliance-facing NIC on multi-homed hosts, so this is not "all interfaces".
+        giaddrs = [s.giaddr for s in self.subnets if s.giaddr] if self.relay else []
         try:
-            s.bind(("0.0.0.0", bind_port))
+            self._sock, self._socks = open_relay_sockets(
+                iface, giaddrs, bind_port, self.log)
         except PermissionError:
             self.log.error(
                 "binding UDP/%d needs CAP_NET_BIND_SERVICE (run the load-gen "
@@ -378,10 +364,15 @@ class Orchestrator:
                 extra={"fields": {"event": "bind_denied", "port": bind_port}},
             )
             raise
-        s.setblocking(False)
-        self._sock = s
         self.log.info("dhcp socket bound", extra={"fields": {
-            "event": "socket_open", "bind_port": bind_port, "topology": self.m.target.dhcp.topology}})
+            "event": "socket_open", "bind_port": bind_port,
+            "topology": self.m.target.dhcp.topology,
+            "giaddr_sockets": len(self._socks), "giaddrs": len(set(giaddrs))}})
+
+    def _sock_for(self, dev: Device) -> socket.socket | None:
+        if self.relay and self._socks:
+            return self._socks.get(self.subnets[dev.subnet_idx].giaddr, self._sock)
+        return self._sock
 
     # ---------------- timer wheel ----------------
     def _schedule(self, delay: float, index: int, action: str) -> None:
@@ -407,16 +398,19 @@ class Orchestrator:
         return ((nonce & 0xFF) << 24) | (dev.index & 0xFFFFFF)
 
     def _send(self, pkt: bytes, dev: Device) -> None:
-        if self._sock is None:
+        sock = self._sock_for(dev)
+        if sock is None:
             return
         if self.relay:
-            # Unicast to Kea; subnet selection is by giaddr (kea.py:237-241).
+            # Unicast to Kea; subnet selection is by giaddr (kea.py:237-241). The
+            # socket bound to this device's giaddr sends it, so the datagram's
+            # source address is the relay address Kea answers to.
             dest = (self.node_ip, self.dhcp_port)
         else:
             # Broadcast on the local L2 segment (kea.py interfaces ["*"]).
             dest = ("255.255.255.255", self.dhcp_port)
         try:
-            self._sock.sendto(pkt, dest)
+            sock.sendto(pkt, dest)
         except OSError as exc:
             self.log.debug("send failed: %s", exc,
                            extra={"fields": {"event": "send_error", "index": dev.index}})
@@ -640,12 +634,13 @@ class Orchestrator:
             asyncio.ensure_future(self._run_propagation_probe(dev))
 
     # ---------------- receive loop ----------------
-    async def _recv_loop(self) -> None:
+    async def _recv_loop(self, sock: socket.socket | None = None) -> None:
         loop = asyncio.get_running_loop()
-        assert self._sock
+        sock = sock or self._sock
+        assert sock
         while not self._stop.is_set():
             try:
-                data = await loop.sock_recv(self._sock, 2048)
+                data = await loop.sock_recv(sock, 2048)
             except (BlockingIOError, InterruptedError):
                 await asyncio.sleep(0.001)
                 continue
@@ -971,8 +966,12 @@ class Orchestrator:
                 # add_signal_handler isn't available on every platform / loop;
                 # the _stop event still drives shutdown via other paths.
                 self.log.debug("signal handler unavailable for %s", sig)
+        # One reader per socket: the wildcard one plus every per-giaddr socket
+        # (relay topology). Kea answers to giaddr:67, and each of those replies
+        # lands on the socket bound to that address.
+        readers = [self._sock] + [s for s in self._socks.values() if s is not self._sock]
         tasks = [
-            asyncio.ensure_future(self._recv_loop()),
+            *(asyncio.ensure_future(self._recv_loop(s)) for s in readers),
             asyncio.ensure_future(self._scheduler_loop()),
             asyncio.ensure_future(self._control_loop()),
             asyncio.ensure_future(self._stats_loop()),

--- a/perf/generators/orchestrator/relay_sockets.py
+++ b/perf/generators/orchestrator/relay_sockets.py
@@ -1,0 +1,117 @@
+"""DHCP sockets for the device fleet — one per relay address in relay topology.
+
+Why per-giaddr sockets: in relay topology Kea unicasts every OFFER/ACK to
+``giaddr:67``. A load-gen host that owns those giaddrs is rarely the only
+process listening on UDP/67 — libvirt's dnsmasq (the appliance VM's own DHCP
+server), a leftover ``dhcrelay``, a lab DHCP server all bind the wildcard
+address on the same device. Two wildcard sockets with the same score share the
+unicast replies according to the kernel's UDP lookup tie-break (in practice a
+CPU-affinity split), so the fleet silently loses a large fraction of the OFFERs
+it was sent and logs them as timeouts (measured 2026-09-03: 58 % seen of 74.8k
+OFFERs on the wire, ~45 % handshake success on a healthy Kea).
+
+A socket bound to the giaddr itself is looked up before any wildcard socket,
+so it receives every reply to that address, deterministically. The wildcard
+socket stays open as the fallback for a giaddr the host cannot bind (the address
+is not local, or the platform refuses), and for the broadcast topology.
+"""
+
+from __future__ import annotations
+
+import errno
+import logging
+import socket
+from collections.abc import Callable
+
+SockFactory = Callable[..., socket.socket]
+
+
+def _new_socket(iface: str, log: logging.Logger, factory: SockFactory) -> socket.socket:
+    s = factory(socket.AF_INET, socket.SOCK_DGRAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    # Multi-homed egress (perf #454). In broadcast topology the DISCOVER goes
+    # to 255.255.255.255; on a box with several NICs (docker bridges, tailscale,
+    # …) the kernel won't necessarily send it out the one facing the appliance.
+    # Bind the socket to the configured device so it does. SO_BINDTODEVICE needs
+    # CAP_NET_RAW (the load-gen already runs as root for the :67/:68 bind).
+    if iface:
+        try:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_BINDTODEVICE, iface.encode())
+        except OSError as exc:
+            log.error(
+                "SO_BINDTODEVICE(%s) failed: %s — broadcast may not "
+                "reach the appliance on a multi-homed box",
+                iface,
+                exc,
+                extra={"fields": {"event": "bindtodevice_failed", "iface": iface}},
+            )
+    return s
+
+
+def open_relay_sockets(
+    iface: str,
+    giaddrs: list[str],
+    port: int,
+    log: logging.Logger,
+    factory: SockFactory = socket.socket,
+) -> tuple[socket.socket, dict[str, socket.socket]]:
+    """Open the wildcard socket on ``port`` plus, for each distinct giaddr, a
+    socket bound to ``(giaddr, port)``. Returns ``(wildcard, {giaddr: socket})``;
+    a giaddr that could not be bound maps to the wildcard socket, so callers can
+    always send and receive through ``socks[giaddr]``.
+
+    ``PermissionError`` from the wildcard bind propagates (the caller explains
+    the capability); a per-giaddr bind failure is logged and falls back."""
+    wildcard = _new_socket(iface, log, factory)
+    # 0.0.0.0 is required for the broadcast topology: a simulated client has no
+    # lease yet, so it must listen on the wildcard address to receive the
+    # broadcast OFFER/ACK. SO_BINDTODEVICE above already pins the socket to the
+    # appliance-facing NIC on multi-homed hosts, so this is not "all interfaces".
+    wildcard.bind(("0.0.0.0", port))
+    wildcard.setblocking(False)
+    socks: dict[str, socket.socket] = {}
+    for giaddr in dict.fromkeys(g for g in giaddrs if g):
+        s = _new_socket(iface, log, factory)
+        try:
+            s.bind((giaddr, port))
+        except OSError as exc:
+            s.close()
+            why = (
+                errno.errorcode.get(exc.errno, str(exc.errno))
+                if exc.errno
+                else str(exc)
+            )
+            log.warning(
+                "relay socket for giaddr %s not bound (%s): falling back to the "
+                "wildcard socket — replies to it can be shared with other UDP/%d "
+                "listeners on the device",
+                giaddr,
+                why,
+                port,
+                extra={
+                    "fields": {
+                        "event": "giaddr_bind_failed",
+                        "giaddr": giaddr,
+                        "errno": exc.errno,
+                    }
+                },
+            )
+            socks[giaddr] = wildcard
+            continue
+        s.setblocking(False)
+        socks[giaddr] = s
+    bound = sum(1 for s in socks.values() if s is not wildcard)
+    if giaddrs:
+        log.info(
+            "relay sockets bound",
+            extra={
+                "fields": {
+                    "event": "giaddr_sockets",
+                    "bound": bound,
+                    "giaddrs": len(socks),
+                    "port": port,
+                }
+            },
+        )
+    return wildcard, socks

--- a/perf/generators/orchestrator/relay_sockets.py
+++ b/perf/generators/orchestrator/relay_sockets.py
@@ -4,16 +4,31 @@ Why per-giaddr sockets: in relay topology Kea unicasts every OFFER/ACK to
 ``giaddr:67``. A load-gen host that owns those giaddrs is rarely the only
 process listening on UDP/67 — libvirt's dnsmasq (the appliance VM's own DHCP
 server), a leftover ``dhcrelay``, a lab DHCP server all bind the wildcard
-address on the same device. Two wildcard sockets with the same score share the
-unicast replies according to the kernel's UDP lookup tie-break (in practice a
-CPU-affinity split), so the fleet silently loses a large fraction of the OFFERs
-it was sent and logs them as timeouts (measured 2026-09-03: 58 % seen of 74.8k
-OFFERs on the wire, ~45 % handshake success on a healthy Kea).
+address on the same device, so which socket the kernel hands a given reply to
+stops being ours to decide and the fleet logs what lands elsewhere as a DORA
+timeout (measured 2026-09-03: 58 % seen of 74.8k OFFERs on the wire, ~45 %
+handshake success on a healthy Kea).
 
-A socket bound to the giaddr itself is looked up before any wildcard socket,
-so it receives every reply to that address, deterministically. The wildcard
-socket stays open as the fallback for a giaddr the host cannot bind (the address
-is not local, or the platform refuses), and for the broadcast topology.
+What the kernel does with two equally-scored wildcard sockets depends on how
+the OTHER listener opened its own, and neither outcome is one to depend on
+(verified on Linux 6.x, 200 datagrams per case):
+
+  * ``SO_REUSEADDR`` only — the LAST socket bound takes every datagram and the
+    other receives nothing, so whether the fleet sees its replies at all is
+    decided by process start order.
+  * ``SO_REUSEPORT`` — the group splits by a hash of the 4-tuple
+    (``reuseport_select_sock`` → ``udp_ehashfn``): replies to different
+    giaddrs land on different sockets, and a constant 4-tuple always lands on
+    the same one. Not a per-packet or CPU-affinity split.
+
+A socket bound to the giaddr itself moots both. ``compute_score`` ranks a
+matching ``inet_rcv_saddr`` above a wildcard, so it is chosen ahead of any
+wildcard socket — including one in a ``SO_REUSEPORT`` group, and regardless of
+bind order — and receives every reply to that address, deterministically.
+
+The wildcard socket stays open as the fallback for a giaddr the host cannot
+bind (the address is not local, or the platform refuses), and for the
+broadcast topology.
 """
 
 from __future__ import annotations

--- a/perf/generators/orchestrator/tests/test_relay_sockets.py
+++ b/perf/generators/orchestrator/tests/test_relay_sockets.py
@@ -1,0 +1,124 @@
+"""open_relay_sockets: one socket per giaddr, wildcard fallback, broadcast unchanged."""
+
+from __future__ import annotations
+
+import errno
+import logging
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from relay_sockets import open_relay_sockets  # noqa: E402
+
+
+class FakeSocket:
+    def __init__(self, family, kind, *, refuse: set[str]):
+        self.family, self.kind = family, kind
+        self.opts: list[tuple[int, int, object]] = []
+        self.bound: tuple[str, int] | None = None
+        self.blocking: bool | None = None
+        self.closed = False
+        self._refuse = refuse
+
+    def setsockopt(self, level, name, value):
+        self.opts.append((level, name, value))
+
+    def bind(self, addr):
+        if addr[0] in self._refuse:
+            raise OSError(errno.EADDRNOTAVAIL, "Cannot assign requested address")
+        self.bound = addr
+
+    def setblocking(self, flag):
+        self.blocking = flag
+
+    def close(self):
+        self.closed = True
+
+
+def factory(refuse: set[str] = frozenset()):
+    made: list[FakeSocket] = []
+
+    def make(family, kind):
+        s = FakeSocket(family, kind, refuse=set(refuse))
+        made.append(s)
+        return s
+
+    make.made = made  # type: ignore[attr-defined]
+    return make
+
+
+@pytest.fixture
+def log():
+    return logging.getLogger("test.relay_sockets")
+
+
+def test_relay_binds_one_socket_per_giaddr_plus_wildcard(log):
+    make = factory()
+    wildcard, socks = open_relay_sockets(
+        "virbr0", ["10.9.0.1", "10.9.1.1", "10.9.2.1"], 67, log, factory=make
+    )
+    assert wildcard.bound == ("0.0.0.0", 67)
+    assert {g: s.bound for g, s in socks.items()} == {
+        "10.9.0.1": ("10.9.0.1", 67),
+        "10.9.1.1": ("10.9.1.1", 67),
+        "10.9.2.1": ("10.9.2.1", 67),
+    }
+    assert all(s is not wildcard for s in socks.values())
+    assert all(s.blocking is False for s in [wildcard, *socks.values()])
+    # every socket carries the device pin and the reuse/broadcast options
+    for s in make.made:
+        names = {name for _lvl, name, _val in s.opts}
+        assert {
+            socket.SO_REUSEADDR,
+            socket.SO_BROADCAST,
+            socket.SO_BINDTODEVICE,
+        } <= names
+        assert (socket.SOL_SOCKET, socket.SO_BINDTODEVICE, b"virbr0") in s.opts
+
+
+def test_unbindable_giaddr_falls_back_to_the_wildcard_socket(log):
+    make = factory(refuse={"10.9.1.1"})
+    wildcard, socks = open_relay_sockets(
+        "", ["10.9.0.1", "10.9.1.1"], 67, log, factory=make
+    )
+    assert socks["10.9.0.1"].bound == ("10.9.0.1", 67)
+    assert socks["10.9.1.1"] is wildcard
+    refused = [s for s in make.made if s.bound is None and s is not wildcard]
+    assert len(refused) == 1 and refused[0].closed
+    # no device pin was requested, so none was set
+    assert all(
+        name != socket.SO_BINDTODEVICE for s in make.made for _l, name, _v in s.opts
+    )
+
+
+def test_duplicate_and_empty_giaddrs_collapse(log):
+    make = factory()
+    wildcard, socks = open_relay_sockets(
+        "", ["10.9.0.1", "", "10.9.0.1"], 67, log, factory=make
+    )
+    assert list(socks) == ["10.9.0.1"]
+    assert len(make.made) == 2  # wildcard + one giaddr socket
+
+
+def test_broadcast_topology_opens_only_the_wildcard_client_socket(log):
+    make = factory()
+    wildcard, socks = open_relay_sockets("eth0", [], 68, log, factory=make)
+    assert wildcard.bound == ("0.0.0.0", 68)
+    assert socks == {}
+    assert len(make.made) == 1
+
+
+def test_wildcard_permission_error_propagates(log):
+    class Denied(FakeSocket):
+        def bind(self, addr):
+            raise PermissionError(errno.EACCES, "Permission denied")
+
+    def make(family, kind):
+        return Denied(family, kind, refuse=set())
+
+    with pytest.raises(PermissionError):
+        open_relay_sockets("", ["10.9.0.1"], 67, log, factory=make)


### PR DESCRIPTION
Fixes #954

## Summary

In relay topology the device fleet received Kea's unicast OFFER/ACKs on a single wildcard UDP/67 socket. Any other wildcard UDP/67 listener on the same device (libvirt's dnsmasq on every rig, a `dhcrelay`, a lab DHCP server) has the same lookup score, and the kernel hands each reply to one of them by its tie-break — the fleet logs what lands elsewhere as DORA timeouts (measured on an idle rig: 98–99 % of OFFERs received on the wildcard socket, 100 % on per-giaddr sockets; details in the issue). A small, host-dependent error, removed deterministically.

One commit:

- `perf/generators/orchestrator/relay_sockets.py` — `open_relay_sockets(iface, giaddrs, port, log)`: the wildcard socket plus one socket per distinct giaddr bound to `(giaddr, port)`; a giaddr the host cannot bind (EADDRNOTAVAIL, an address that is not local) is logged and mapped to the wildcard socket, so nothing that worked before stops working.
- `device_fleet.py` — `_open_socket` uses it; `_send` goes through the subnet's socket (`_sock_for`), so the datagram's source address is the relay address Kea answers to; one `_recv_loop(sock)` per socket. Broadcast topology is unchanged (one wildcard `:68` socket).

## Evidence

- `perf/generators/orchestrator/tests/test_relay_sockets.py` — per-giaddr binds with the device pin, wildcard fallback on a refused bind, duplicate/empty giaddrs collapse, broadcast topology opens only the client socket, a permission error on the wildcard bind still propagates. (perf/ is not in CI; run with `python -m pytest perf/generators/orchestrator/tests`.)
- Live A/B on the same idle rig and Kea, minutes apart (`dora_bind_ab.py`, 2,000 DISCOVERs per run over the manifest's 8 giaddrs at 400/s, two rounds): the harness's wildcard socket received 98.25 % and 99.0 % of the OFFERs; per-giaddr sockets received 100 % and 100 % (250 per socket, p50 1.5 ms). Idle, the wildcard socket loses 1–2 %; under the 35k-device cell the two sockets behaved the same (next bullet).
- Live cell with the fixed harness (same appliance, same 5632 MiB / 3 vCPU cell, 35k devices): `dhcp_handshake_success` 51.1 % against 55.5 % with the old socket an hour earlier — no change under load, as expected: on that appliance the loss is Kea's own socket overflow (the api starves the BestEffort Kea pod; #952), which no client-side change can recover. The fix's effect is the deterministic delivery the idle A/B shows, not the large number.

## Notes for review

- Kernel behaviour relied on: UDP lookup prefers a socket bound to the destination address over wildcard sockets (`__udp4_lib_lookup` tries the address-specific hash slot first). That is what makes the per-giaddr socket deterministic where the wildcard one was a coin toss.
- The relay host must own the giaddrs (it always had to — Kea answers to them); the campaign tooling adds them as /32s on the appliance-facing device before the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
