### PR TITLE
fix(dns): serialise the agent config bundle with Starlette's json kwargs, not json.dumps' defaults

### DIFF
--- a/backend/app/api/v1/dns/agents.py
+++ b/backend/app/api/v1/dns/agents.py
@@ -392,10 +392,28 @@ async def agent_config_longpoll(
                 # (appliance sizing campaign, 2026-09-03: the api still hit
                 # 4.18 GB twice serving the first bundle after the paged-ops
                 # and one-query-records fixes). json.dumps of the same dict
-                # is what the ETag already hashes, so nothing changes on the
-                # wire.
+                # is what the ETag already hashes.
+                #
+                # #958 — the kwargs are Starlette ``JSONResponse.render``'s,
+                # not ``json.dumps``'s. They are not cosmetic: the stock
+                # defaults put a space after every ``,`` and ``:``, which on
+                # the 250k-record bundle this path exists to shrink is
+                # +3.5 MB (+13.5%) of string built in-process, and escape
+                # non-ASCII to ``\uXXXX`` (six bytes a character instead of
+                # two) so an IDN or a UTF-8 record value inflates further.
+                # ``allow_nan=False`` restores the guardrail: Python's own
+                # ``json.loads`` ACCEPTS bare ``NaN``, so a stray float would
+                # round-trip control plane → agent unnoticed and fail only on
+                # a strict parser. With these, the body is byte-identical to
+                # what FastAPI sent before the switch.
                 return Response(
-                    content=json.dumps(bundle, default=str),
+                    content=json.dumps(
+                        bundle,
+                        ensure_ascii=False,
+                        allow_nan=False,
+                        separators=(",", ":"),
+                        default=str,
+                    ),
                     media_type="application/json",
                     headers={"ETag": format_etag(etag)},
                 )

--- a/backend/tests/test_dns_agents_config_route.py
+++ b/backend/tests/test_dns_agents_config_route.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import JSONResponse
 
 from app.api.v1.dns import agents as agents_api
 from app.models.dns import DNSRecord, DNSRecordOp, DNSServer, DNSServerGroup, DNSZone
@@ -127,3 +128,46 @@ async def test_pending_ops_take_the_fast_path_a_page_at_a_time(
     body2 = second.json()
     assert [op["record"]["name"] for op in body2["pending_record_ops"]] == ["n4", "n5"]
     assert body2["pending_ops_remaining"] == 0
+
+
+@pytest.mark.asyncio
+async def test_the_body_is_byte_identical_to_starlettes_json_encoding(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    r"""#958 — assert on the BYTES, not on ``resp.json()``.
+
+    The route hand-rolls the serialisation to skip ``jsonable_encoder``. That
+    is only safe while the call reproduces Starlette ``JSONResponse.render``'s
+    kwargs, and every way they can differ is invisible to a parsed
+    comparison: stock ``json.dumps`` spaces its separators (+13.5% on the
+    250k-record bundle this path exists to shrink) and escapes non-ASCII to
+    \uXXXX. Both decode to an equal object, so the sibling tests that go
+    through ``.json()`` cannot see either one — which is how it shipped.
+    """
+    monkeypatch.setattr(agents_api, "LONGPOLL_TIMEOUT_SECONDS", 1)
+    _server, zone, headers = await _agent(db_session, records=2)
+    # A non-ASCII value exercises ensure_ascii; on an all-ASCII payload the
+    # two encodings agree and this would pass on the stock defaults.
+    db_session.add(
+        DNSRecord(
+            zone_id=zone.id,
+            name="cafe-txt",
+            fqdn=f"cafe-txt.{zone.name}",
+            record_type="TXT",
+            value="v=sp\u00e9cial \u00fcnicode",
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.get(CONFIG_URL, headers=headers)
+    assert resp.status_code == 200, resp.text
+
+    body = resp.content
+    # Byte-for-byte what FastAPI produced for this route before it started
+    # returning a prebuilt Response, or the switch was not transparent.
+    assert body == JSONResponse(resp.json()).body
+
+    # Name the two regressions directly so a failure explains itself rather
+    # than printing two multi-megabyte blobs.
+    assert b'"etag":"sha256:' in body, "separators are not compact"
+    assert "sp\u00e9cial".encode() in body, "non-ASCII escaped instead of sent as UTF-8"


### PR DESCRIPTION
Closes #958. Follow-up to #949.

## Summary

#949 replaced the dict return on `GET /api/v1/dns/agents/config` with a prebuilt `Response` to skip `jsonable_encoder`'s walk-and-copy of the whole bundle. That is right and is a real memory win. But the call used `json.dumps`' stock defaults while the comment beside it said "nothing changes on the wire". Three things did. There is no `default_response_class` on this app, so stock Starlette `JSONResponse` is what served the route before:

| | before | #949 as merged | this PR |
|---|---|---|---|
| `separators` | `(",", ":")` compact | default, space after every `,` and `:` | compact |
| `ensure_ascii` | `False`, raw UTF-8 | `True`, escapes to `\uXXXX` | `False` |
| `allow_nan` | `False`, raises | `True`, emits bare `NaN` | `False` |

## Why it matters

The separators change works against #949's own purpose. Measured on a payload matching its 250k-record benchmark shape:

```
FastAPI before the switch :   26,000,068 bytes
949 as merged             :   29,500,077 bytes  (+13.5%)  identical=False
958 fix                   :   26,000,068 bytes  (+0.0%)   identical=True
```

#949 exists because this path was memcg-killed at 4.18 GB. It then built a string 13.5% larger than the one it replaced, in the same process, on the same request. The wire cost is mostly absorbed because the appliance and compose nginx both gzip `application/json`, but the allocation happens in the api before nginx sees a byte. The fix recovers 3.5 MB on that payload and makes the body byte-identical to what FastAPI sent before.

`allow_nan` is the smallest of the three and is a lost guardrail rather than a live bug — the bundle's numerics are integer TTLs, priorities, weights and ports. Worth restoring because Python's own `json.loads` **accepts** bare `NaN`, so a stray float would round-trip control plane to agent unnoticed and fail only on a strict third-party parser.

`default=str` stays. It matches what `_compute_etag` has always hashed, so the ETag and the body remain consistent.

## Test

The regression test asserts on `resp.content` **bytes** against `JSONResponse(...).body`, not on `resp.json()`. Every difference between the two encodings decodes to an equal object, so the sibling tests that go through `.json()` cannot see any of them, which is how this shipped. It carries a non-ASCII record value deliberately: on an all-ASCII payload the two encodings agree and the test would pass on the stock defaults.

## Notes for review

- No behaviour change for the agent. `httpx`'s parser reads both encodings identically; this restores the smaller of the two.
- Nothing else on this route changed: paging, the fast path, the 304 contract and both ETags are untouched.
- `ruff` and `black` clean on both files at the versions `backend/pyproject.toml` pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)