### PR TITLE
fix(appliance): retry transient control-plane joins; let Replace evict a failed joiner

### DIFF
--- a/.github/scripts/ci-backend-must-run.txt
+++ b/.github/scripts/ci-backend-must-run.txt
@@ -17,6 +17,10 @@
 # Editing THIS file runs the suite too (it lives under .github/scripts/).
 
 # test_spatium_console.py loads the console script directly — 52 tests.
+# test_appliance_join_auto_retry.py parses spatium-cluster-join's
+# classify_join_failure and pins each message it can emit against the
+# backend's permanent-vs-transient markers, so rewording the runner has to
+# run the suite that would otherwise silently start misclassifying.
 appliance/mkosi.extra/usr/local/bin/
 
 # test_appliance_firewall_render.py imports the renderer by path.

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -122,19 +122,41 @@ logger = structlog.get_logger(__name__)
 # long after the latest reported failure; then the row is cleared exactly as
 # a permanent failure is, and the operator re-promotes.
 _JOIN_AUTO_RETRY_WINDOW = timedelta(minutes=15)
-# The runner's classifier (appliance/.../spatium-cluster-join
-# classify_join_failure) names the two failures no retry can fix.
+# The three failures no retry can fix, matched against what the runner's
+# classifier (appliance/.../spatium-cluster-join ``classify_join_failure``)
+# EMITS — not against the k3s log lines it matches on. That distinction is
+# the whole content of this constant: ``cluster_join_reason`` is the
+# classifier's output message, so a marker lifted from its ``case`` patterns
+# ("different token", from "bootstrap data already found and encrypted with
+# different token") never matches anything that reaches this function, and
+# the failure it was meant to catch is retried for the full window instead
+# of clearing at once. ``tests/test_appliance_join_auto_retry.py`` pins each
+# marker against the runner's real output so the two cannot drift apart.
 _PERMANENT_JOIN_FAILURE_MARKERS = (
+    # "this hostname is already an etcd member of the target cluster — evict
+    # it (Fleet → Replace, or delete its k8s Node) before re-joining"
     "already an etcd member",
-    "different token",
+    # "stale k3s bootstrap data on disk — the join token does not match the
+    # cluster"
+    "the join token does not match",
+    # "this node's etcd member was removed from the cluster — it must re-join
+    # as a NEW member (leave first)"
+    "must re-join as a new member",
 )
 
 
 def _join_failure_is_permanent(reason: str | None) -> bool:
-    """PURE: a join failure an automatic retry cannot fix (stale etcd member
-    under this hostname, bootstrap-token mismatch). Everything else — the
-    seed unreachable while it adds a learner, a readiness timeout, an
-    unclassified k3s exit — is treated as transient and retried."""
+    """PURE: a join failure an automatic retry cannot fix — a stale etcd
+    member under this hostname, a bootstrap-token mismatch on disk, or an
+    etcd member the cluster has permanently removed. All three need an
+    operator to evict, re-pair or leave first.
+
+    Everything else — the seed unreachable while it adds a learner, a
+    readiness timeout, an unclassified k3s exit — is treated as transient
+    and retried. "the seed rejected the join token" is deliberately in that
+    transient set despite naming the token: the campaign's own drill
+    produced it from a NETWORK block (2026-09-04 00:55Z), and the retry then
+    succeeded once the block lifted."""
     text = (reason or "").lower()
     return any(marker in text for marker in _PERMANENT_JOIN_FAILURE_MARKERS)
 
@@ -1964,10 +1986,11 @@ async def supervisor_heartbeat(
         # still says "member" and its `.state` says failed, bounded by its
         # per-target attempt ceiling (appliance_state._CLUSTER_JOIN_MAX_
         # ATTEMPTS) — for up to _JOIN_AUTO_RETRY_WINDOW after the latest
-        # failure. A PERMANENT failure (the runner's classifier names the
-        # two: a stale etcd member under this hostname, a token mismatch)
-        # clears immediately as before: no retry can fix those, the
-        # operator has to evict or re-pair.
+        # failure. A PERMANENT failure (the runner's classifier names three:
+        # a stale etcd member under this hostname, a bootstrap-token mismatch
+        # on disk, an etcd member the cluster permanently removed) clears
+        # immediately as before: no retry can fix those, the operator has to
+        # evict, re-pair or leave first.
         if _join_failure_is_permanent(row.cluster_join_reason) or _join_retry_window_elapsed(
             row.cluster_join_state_at
         ):

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -4070,11 +4070,26 @@ async def replace_control_plane_member(
             f"Appliance {row.hostname!r} is the etcd seed — replacing the seed is a "
             "separate migration flow, out of scope here.",
         )
-    if row.cluster_role != CLUSTER_ROLE_MEMBER:
+    # A joiner whose join FAILED is replaceable too. The failure that needs
+    # this flow is the one the classifier names "already an etcd member":
+    # the node's k3s got far enough to register its etcd member (or the
+    # seed kept a stale one under its hostname), then died — so the seed
+    # holds a member nobody serves, every re-promote is refused with
+    # "duplicate node name", and Replace was the one route that evicts the
+    # stale Node/member by name, yet it 409'd on the row not being settled
+    # (appliance sizing campaign, 2026-09-02: a 3-node formation stuck on
+    # one such joiner, cleared only by hand). In-flight joiners still 409.
+    failed_joiner = (
+        row.cluster_role is None
+        and row.cluster_join_state == CLUSTER_JOIN_STATE_FAILED
+        and row.desired_cluster_role is None
+    )
+    if row.cluster_role != CLUSTER_ROLE_MEMBER and not failed_joiner:
         raise HTTPException(
             status.HTTP_409_CONFLICT,
-            f"Appliance {row.hostname!r} isn't a settled control-plane member — nothing "
-            "to evict. (Demote in-flight joiners; this is for replacing a dead member.)",
+            f"Appliance {row.hostname!r} isn't a settled control-plane member or a "
+            "failed joiner — nothing to evict. (Demote in-flight joiners; this is for "
+            "replacing a dead member or clearing a failed join's stale etcd member.)",
         )
 
     # Drop the dead member from the cluster accounting + flag it for the

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -4144,11 +4144,16 @@ async def replace_control_plane_member(
     # stale Node/member by name, yet it 409'd on the row not being settled
     # (appliance sizing campaign, 2026-09-02: a 3-node formation stuck on
     # one such joiner, cleared only by hand). In-flight joiners still 409.
-    failed_joiner = (
-        row.cluster_role is None
-        and row.cluster_join_state == CLUSTER_JOIN_STATE_FAILED
-        and row.desired_cluster_role is None
-    )
+    #
+    # The failed joiner is accepted WHETHER OR NOT its desired-state is still
+    # set: a transient failure keeps `desired_cluster_role` for the
+    # supervisor's automatic retry window (the heartbeat path above), and an
+    # operator who reaches for Replace during that window is overriding the
+    # retry on purpose — refusing them because a retry is pending is exactly
+    # the contradiction this route exists to remove (live 2026-09-04
+    # 01:34Z: a blocked join, desired-state kept, Replace answered 409).
+    # The fields are cleared just below, which also ends the retry.
+    failed_joiner = row.cluster_role is None and row.cluster_join_state == CLUSTER_JOIN_STATE_FAILED
     if row.cluster_role != CLUSTER_ROLE_MEMBER and not failed_joiner:
         raise HTTPException(
             status.HTTP_409_CONFLICT,

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -117,6 +117,39 @@ from app.services.appliance.syslog import syslog_bundle
 
 logger = structlog.get_logger(__name__)
 
+# A transient join failure keeps the promote desired-state (so the supervisor
+# re-fires the join, bounded by its own per-target attempt ceiling) for this
+# long after the latest reported failure; then the row is cleared exactly as
+# a permanent failure is, and the operator re-promotes.
+_JOIN_AUTO_RETRY_WINDOW = timedelta(minutes=15)
+# The runner's classifier (appliance/.../spatium-cluster-join
+# classify_join_failure) names the two failures no retry can fix.
+_PERMANENT_JOIN_FAILURE_MARKERS = (
+    "already an etcd member",
+    "different token",
+)
+
+
+def _join_failure_is_permanent(reason: str | None) -> bool:
+    """PURE: a join failure an automatic retry cannot fix (stale etcd member
+    under this hostname, bootstrap-token mismatch). Everything else — the
+    seed unreachable while it adds a learner, a readiness timeout, an
+    unclassified k3s exit — is treated as transient and retried."""
+    text = (reason or "").lower()
+    return any(marker in text for marker in _PERMANENT_JOIN_FAILURE_MARKERS)
+
+
+def _join_retry_window_elapsed(state_at: datetime | None, now: datetime | None = None) -> bool:
+    """PURE: whether the latest failure is older than the auto-retry window.
+    An unknown clock counts as elapsed — never retry blind."""
+    if state_at is None:
+        return True
+    now = now or datetime.now(UTC)
+    if state_at.tzinfo is None:
+        state_at = state_at.replace(tzinfo=UTC)
+    return now - state_at > _JOIN_AUTO_RETRY_WINDOW
+
+
 router = APIRouter()
 
 
@@ -1917,16 +1950,48 @@ async def supervisor_heartbeat(
         row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER
         and row.cluster_join_state == CLUSTER_JOIN_STATE_FAILED
     ):
-        row.desired_cluster_role = None
-        row.desired_k3s_server_url = None
-        row.desired_k3s_join_token_encrypted = None
-        logger.warning(
-            "control_plane_join_failed",
-            appliance_id=str(row.id),
-            hostname=row.hostname,
-            reason=row.cluster_join_reason,
-            detail="cleared desired-state; re-promote to retry",
-        )
+        # …but not on the FIRST transient failure. Two members promoted
+        # together race each other into the seed's etcd (one of them is a
+        # learner while the other is being added), and the loser's join
+        # dies with "could not reach the seed" / a readiness timeout that a
+        # second attempt a minute later survives. Clearing the desired-state
+        # here turned that flake into an operator round-trip on every third
+        # formation (appliance sizing campaign, 2026-09-02/03: 3-node
+        # formations stuck at 2 until someone re-promoted by hand).
+        #
+        # So a transient failure keeps the desired-state and lets the
+        # supervisor re-fire the join — it does so on its own once the row
+        # still says "member" and its `.state` says failed, bounded by its
+        # per-target attempt ceiling (appliance_state._CLUSTER_JOIN_MAX_
+        # ATTEMPTS) — for up to _JOIN_AUTO_RETRY_WINDOW after the latest
+        # failure. A PERMANENT failure (the runner's classifier names the
+        # two: a stale etcd member under this hostname, a token mismatch)
+        # clears immediately as before: no retry can fix those, the
+        # operator has to evict or re-pair.
+        if _join_failure_is_permanent(row.cluster_join_reason) or _join_retry_window_elapsed(
+            row.cluster_join_state_at
+        ):
+            row.desired_cluster_role = None
+            row.desired_k3s_server_url = None
+            row.desired_k3s_join_token_encrypted = None
+            logger.warning(
+                "control_plane_join_failed",
+                appliance_id=str(row.id),
+                hostname=row.hostname,
+                reason=row.cluster_join_reason,
+                detail="cleared desired-state; re-promote to retry",
+            )
+        else:
+            logger.warning(
+                "control_plane_join_retrying",
+                appliance_id=str(row.id),
+                hostname=row.hostname,
+                reason=row.cluster_join_reason,
+                detail=(
+                    "transient join failure — desired-state kept so the supervisor "
+                    f"re-fires the join (window {_JOIN_AUTO_RETRY_WINDOW})"
+                ),
+            )
     # Auto-clear the demote desired-state once the leave landed: the
     # supervisor reports ``left`` → the node is back to a plain
     # application appliance.

--- a/backend/tests/test_appliance_control_plane_promote.py
+++ b/backend/tests/test_appliance_control_plane_promote.py
@@ -866,3 +866,39 @@ async def test_replace_still_refuses_an_in_flight_joiner(
         headers=_hdr(token),
     )
     assert resp.status_code == 409
+
+
+async def test_replace_accepts_a_failed_joiner_whose_retry_is_still_pending(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """A transient failure keeps the desired-state for the supervisor's
+    automatic retry; an operator who calls Replace inside that window is
+    overriding the retry on purpose. Live 2026-09-04 01:34Z: with the
+    desired-state kept, Replace answered 409 "nothing to evict" — the retry
+    half and the Replace half of the same fix contradicted each other."""
+    token = await _admin(db_session)
+    await _seed(db_session)
+    await _appliance(db_session, "m1", cluster_role=CLUSTER_ROLE_MEMBER, node_ip="10.0.0.2")
+    stuck = await _appliance(
+        db_session,
+        "m2",
+        appliance_variant="appliance",
+        cluster_role=None,
+        desired_cluster_role="member",
+        cluster_join_state="failed",
+        cluster_join_reason="could not reach the seed — check the firewall and tcp/6443 + tcp/2379-2380",
+        node_ip="10.0.0.3",
+    )
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/v1/appliance/fleet/control-plane/{stuck.id}/replace",
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 200, resp.text
+    await db_session.refresh(stuck)
+    assert stuck.evict_requested is True
+    assert stuck.cluster_join_state == "evicting"
+    # Replace ends the pending retry: no desired role, no join coordinates left behind.
+    assert stuck.desired_cluster_role is None
+    assert stuck.desired_k3s_server_url is None

--- a/backend/tests/test_appliance_control_plane_promote.py
+++ b/backend/tests/test_appliance_control_plane_promote.py
@@ -813,3 +813,56 @@ async def test_restore_non_superadmin_refused(
         headers=_hdr(token),
     )
     assert resp.status_code == 403
+
+
+async def test_replace_accepts_a_failed_joiner(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """A joiner whose join died "already an etcd member" holds a stale etcd
+    member under its hostname; Replace is the route that evicts it by name,
+    and it used to 409 on the row not being a settled member (sizing
+    campaign, 2026-09-02)."""
+    token = await _admin(db_session)
+    await _seed(db_session)
+    await _appliance(db_session, "m1", cluster_role=CLUSTER_ROLE_MEMBER, node_ip="10.0.0.2")
+    stuck = await _appliance(
+        db_session,
+        "m2",
+        appliance_variant="appliance",
+        cluster_role=None,
+        desired_cluster_role=None,
+        cluster_join_state="failed",
+        cluster_join_reason="this hostname is already an etcd member of the target cluster — evict it",
+        node_ip="10.0.0.3",
+    )
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/v1/appliance/fleet/control-plane/{stuck.id}/replace",
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 200, resp.text
+    await db_session.refresh(stuck)
+    assert stuck.evict_requested is True
+    assert stuck.cluster_join_state == "evicting"
+
+
+async def test_replace_still_refuses_an_in_flight_joiner(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    token = await _admin(db_session)
+    await _seed(db_session)
+    joining = await _appliance(
+        db_session,
+        "m3",
+        appliance_variant="appliance",
+        desired_cluster_role="member",
+        cluster_join_state="joining",
+    )
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/v1/appliance/fleet/control-plane/{joining.id}/replace",
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 409

--- a/backend/tests/test_appliance_join_auto_retry.py
+++ b/backend/tests/test_appliance_join_auto_retry.py
@@ -10,14 +10,17 @@ nothing retried until somebody re-promoted by hand.
 Now a reported ``failed`` keeps the desired-state — so the supervisor
 re-fires the join on its next heartbeat, bounded by its own per-target
 attempt ceiling — unless the runner's classifier says no retry can fix it
-(a stale etcd member under this hostname, a bootstrap-token mismatch) or the
-latest failure is older than the auto-retry window.
+(a stale etcd member under this hostname, a bootstrap-token mismatch on disk,
+an etcd member the cluster permanently removed) or the latest failure is older
+than the auto-retry window.
 """
 
 from __future__ import annotations
 
+import re
 import uuid
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import pytest
 from httpx import AsyncClient
@@ -87,12 +90,67 @@ async def _report_failed(client: AsyncClient, row: Appliance, token: str, reason
 # ── the pure helpers ────────────────────────────────────────────────────────
 
 
-def test_the_classifier_names_the_two_permanent_failures() -> None:
+# Every message ``classify_join_failure`` can emit, read out of the runner
+# script itself, paired with whether an automatic retry could ever fix it.
+#
+# Parsed rather than pasted because the bug this replaces was a marker taken
+# from the classifier's ``case`` PATTERNS ("different token") instead of the
+# message it prints — which passes a hand-written test and matches nothing in
+# production, since ``cluster_join_reason`` carries the printed message. A
+# reworded runner now fails this test instead of silently reclassifying a
+# permanent failure as retryable.
+_RUNNER = (
+    Path(__file__).resolve().parents[2]
+    / "appliance/mkosi.extra/usr/local/bin/spatium-cluster-join"
+)
+# reason substring -> needs an operator (evict / re-pair / leave first)
+_NEEDS_OPERATOR = {
+    "already an etcd member": True,
+    "the join token does not match": True,
+    "must re-join as a NEW member": True,
+    "the seed rejected the join token": False,
+    "could not reach the seed": False,
+}
+
+
+def _runner_reasons() -> list[str] | None:
+    """Every ``printf`` payload inside ``classify_join_failure``, or None on a
+    backend-only checkout (the api image ships ``backend/`` alone) — same
+    graceful skip as ``test_appliance_firewall_render``."""
+    if not _RUNNER.exists():
+        return None
+    body = _RUNNER.read_text(encoding="utf-8").split("classify_join_failure() {", 1)[1]
+    body = body.split("\n}", 1)[0]
+    return [m for m in re.findall(r"printf '%s' \"([^\"]+)\"", body) if m]
+
+
+def test_the_classifier_markers_match_what_the_runner_actually_emits() -> None:
+    reasons = _runner_reasons()
+    if reasons is None:
+        pytest.skip("spatium-cluster-join not on disk (backend-only checkout)")
+    # Guard the parse itself: an empty list would make every assertion vacuous.
+    assert len(reasons) == len(_NEEDS_OPERATOR), reasons
+    for reason in reasons:
+        expected = next(
+            (v for k, v in _NEEDS_OPERATOR.items() if k.lower() in reason.lower()), None
+        )
+        assert expected is not None, f"unclassified runner reason: {reason}"
+        assert sup._join_failure_is_permanent(reason) is expected, reason
+
+
+def test_the_classifier_names_the_permanent_failures() -> None:
     assert sup._join_failure_is_permanent(_PERMANENT)
     assert sup._join_failure_is_permanent(
-        "bootstrap data already found and encrypted with a different token"
+        "stale k3s bootstrap data on disk — the join token does not match the cluster"
+    )
+    assert sup._join_failure_is_permanent(
+        "this node's etcd member was removed from the cluster — it must "
+        "re-join as a NEW member (leave first)"
     )
     assert not sup._join_failure_is_permanent(_TRANSIENT)
+    # Names the token, but the campaign drill produced it from a NETWORK block
+    # and the retry then succeeded — transient on purpose.
+    assert not sup._join_failure_is_permanent("the seed rejected the join token")
     assert not sup._join_failure_is_permanent("k3s did not come Ready within 180s")
     assert not sup._join_failure_is_permanent(None)
 

--- a/backend/tests/test_appliance_join_auto_retry.py
+++ b/backend/tests/test_appliance_join_auto_retry.py
@@ -1,0 +1,163 @@
+"""A transient control-plane join failure is retried, a permanent one is not.
+
+The 3-node formations of the appliance sizing campaign (2026-09-02/03) lost
+one member in three: two members promoted together race each other into the
+seed's etcd, the loser dies with "could not reach the seed" / a readiness
+timeout, and the backend's clear-on-failed (#590) turned that flake into an
+operator round-trip — the row read "failed", the desired-state was gone, and
+nothing retried until somebody re-promoted by hand.
+
+Now a reported ``failed`` keeps the desired-state — so the supervisor
+re-fires the join on its next heartbeat, bounded by its own per-target
+attempt ceiling — unless the runner's classifier says no retry can fix it
+(a stale etcd member under this hostname, a bootstrap-token mismatch) or the
+latest failure is older than the auto-retry window.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.appliance import supervisor as sup
+from app.models.appliance import (
+    APPLIANCE_STATE_APPROVED,
+    CLUSTER_JOIN_STATE_FAILED,
+    CLUSTER_JOIN_STATE_JOINING,
+    DESIRED_CLUSTER_ROLE_MEMBER,
+    Appliance,
+)
+from app.models.settings import PlatformSettings
+from app.services.appliance.ca import generate_session_token
+
+_TRANSIENT = "could not reach the seed — check the firewall and tcp/6443 + tcp/2379-2380"
+_PERMANENT = (
+    "this hostname is already an etcd member of the target cluster — evict it "
+    "(Fleet → Replace, or delete its k8s Node) before re-joining"
+)
+
+
+async def _joiner(
+    db: AsyncSession, *, failed_since: timedelta | None = None
+) -> tuple[Appliance, str]:
+    settings_row = await db.get(PlatformSettings, 1)
+    if settings_row is None:
+        settings_row = PlatformSettings(id=1)
+        db.add(settings_row)
+    settings_row.supervisor_registration_enabled = True
+    token, token_hash = generate_session_token()
+    row = Appliance(
+        id=uuid.uuid4(),
+        hostname=f"m-{uuid.uuid4().hex[:6]}",
+        state=APPLIANCE_STATE_APPROVED,
+        public_key_der=b"fake-key",
+        public_key_fingerprint="ee" * 32,
+        cert_serial="0001",
+        deployment_kind="appliance",
+        appliance_variant="appliance",
+        desired_cluster_role=DESIRED_CLUSTER_ROLE_MEMBER,
+        desired_k3s_server_url="https://10.0.0.1:6443",
+        desired_k3s_join_token_encrypted=b"enc",
+        cluster_join_state=CLUSTER_JOIN_STATE_JOINING,
+        cluster_join_state_at=datetime.now(UTC) - (failed_since or timedelta(0)),
+        session_token_hash=token_hash,
+    )
+    db.add(row)
+    await db.flush()
+    return row, token
+
+
+async def _report_failed(client: AsyncClient, row: Appliance, token: str, reason: str) -> None:
+    resp = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={
+            "appliance_id": str(row.id),
+            "session_token": token,
+            "cluster_join_state": CLUSTER_JOIN_STATE_FAILED,
+            "cluster_join_reason": reason,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ── the pure helpers ────────────────────────────────────────────────────────
+
+
+def test_the_classifier_names_the_two_permanent_failures() -> None:
+    assert sup._join_failure_is_permanent(_PERMANENT)
+    assert sup._join_failure_is_permanent(
+        "bootstrap data already found and encrypted with a different token"
+    )
+    assert not sup._join_failure_is_permanent(_TRANSIENT)
+    assert not sup._join_failure_is_permanent("k3s did not come Ready within 180s")
+    assert not sup._join_failure_is_permanent(None)
+
+
+def test_the_retry_window_is_measured_from_the_latest_failure() -> None:
+    now = datetime(2026, 9, 3, 12, 0, tzinfo=UTC)
+    assert not sup._join_retry_window_elapsed(now - timedelta(minutes=3), now)
+    assert sup._join_retry_window_elapsed(now - timedelta(minutes=16), now)
+    assert sup._join_retry_window_elapsed(None, now)  # unknown clock: never retry blind
+    # A naive stamp is read as UTC rather than blowing up the heartbeat.
+    assert not sup._join_retry_window_elapsed(datetime(2026, 9, 3, 11, 58), now)
+
+
+# ── the heartbeat path ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_transient_failure_keeps_the_desired_state_for_a_retry(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    row, token = await _joiner(db_session)
+    await db_session.commit()
+
+    await _report_failed(client, row, token, _TRANSIENT)
+
+    await db_session.refresh(row)
+    assert row.cluster_join_state == CLUSTER_JOIN_STATE_FAILED
+    assert row.cluster_join_reason == _TRANSIENT
+    # Still asked to join: the supervisor re-fires on its next heartbeat.
+    assert row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER
+    assert row.desired_k3s_server_url == "https://10.0.0.1:6443"
+    assert row.desired_k3s_join_token_encrypted == b"enc"
+
+
+@pytest.mark.asyncio
+async def test_a_permanent_failure_clears_the_desired_state_at_once(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    row, token = await _joiner(db_session)
+    await db_session.commit()
+
+    await _report_failed(client, row, token, _PERMANENT)
+
+    await db_session.refresh(row)
+    assert row.cluster_join_state == CLUSTER_JOIN_STATE_FAILED
+    assert row.desired_cluster_role is None
+    assert row.desired_k3s_server_url is None
+    assert row.desired_k3s_join_token_encrypted is None
+    # The reason survives so the Fleet UI can say WHY (and what to do).
+    assert "evict" in (row.cluster_join_reason or "")
+
+
+@pytest.mark.asyncio
+async def test_a_transient_failure_older_than_the_window_clears(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # The row has already been `failed` for longer than the window (the
+    # supervisor's own attempt ceiling stopped the re-fires): give up the
+    # way #590 does, and let the operator re-promote.
+    row, token = await _joiner(db_session, failed_since=timedelta(minutes=20))
+    row.cluster_join_state = CLUSTER_JOIN_STATE_FAILED
+    await db_session.commit()
+
+    await _report_failed(client, row, token, _TRANSIENT)
+
+    await db_session.refresh(row)
+    assert row.desired_cluster_role is None
+    assert row.desired_k3s_server_url is None

--- a/backend/tests/test_appliance_join_auto_retry.py
+++ b/backend/tests/test_appliance_join_auto_retry.py
@@ -100,8 +100,7 @@ async def _report_failed(client: AsyncClient, row: Appliance, token: str, reason
 # reworded runner now fails this test instead of silently reclassifying a
 # permanent failure as retryable.
 _RUNNER = (
-    Path(__file__).resolve().parents[2]
-    / "appliance/mkosi.extra/usr/local/bin/spatium-cluster-join"
+    Path(__file__).resolve().parents[2] / "appliance/mkosi.extra/usr/local/bin/spatium-cluster-join"
 )
 # reason substring -> needs an operator (evict / re-pair / leave first)
 _NEEDS_OPERATOR = {

--- a/backend/tests/test_ci_backend_relevant.py
+++ b/backend/tests/test_ci_backend_relevant.py
@@ -39,6 +39,9 @@ _MANIFEST = _REPO_ROOT / ".github" / "scripts" / "ci-backend-must-run.txt"
 # changes that break the test doing the reading.
 _KNOWN_REPO_ROOT_READS: dict[str, str] = {
     "test_spatium_console.py": "appliance/mkosi.extra/usr/local/bin/spatium-console",
+    "test_appliance_join_auto_retry.py": (
+        "appliance/mkosi.extra/usr/local/bin/spatium-cluster-join"
+    ),
     "test_webui_selfcheck.py": ("appliance/mkosi.extra/usr/local/bin/spatiumddi-webui-selfcheck"),
     "test_appliance_firewall_render.py": (
         "agent/supervisor/spatium_supervisor/firewall_renderer.py"


### PR DESCRIPTION
Fixes #960

## Summary

Two control-plane join defects from the sizing campaign's 3-node formations (2026-09-02/03; both present on `main` @ 33af6a84), one commit each:

1. **Replace accepts a joiner whose join failed.** After a concurrent join dies, a re-promote is refused with *"already an etcd member … evict it (Fleet → Replace, or delete its k8s Node)"*; there is no k8s Node for it, and Replace answered `409 … isn't a settled control-plane member`. Neither route the product offers could remove the stale etcd member. Replace now accepts `cluster_role = null` + `cluster_join_state = failed` — with or without a desired role still set (an operator calling Replace during the automatic-retry window of commit 2 is overriding that retry on purpose; Replace clears the desired-state as part of the eviction): it evicts the stale Node/etcd member by hostname and mints the replacement pairing code, exactly as for a dead member. In-flight joiners still 409.
2. **A transient join failure is retried instead of given up on.** `promote` refuses an even node count, so a 3-node cluster is always two members promoted in one call, joining concurrently — and one regularly dies with "could not reach the seed" (or a readiness timeout) while the other reaches `ready`. The backend cleared the promote desired-state on the first reported `failed` (#590), so nothing retried until an operator re-promoted by hand; one formation in three lost a member this way. A reported `failed` now keeps the desired-state — the supervisor re-fires the join on its next heartbeat, bounded by its own per-target attempt ceiling — for up to 15 minutes after the latest failure, unless the runner's classifier names a failure no retry can fix (stale etcd member under this hostname, token mismatch), which clears at once as before.

## Evidence

- Backend Lint & Type Check mirror green; `backend/tests/test_appliance_join_auto_retry.py` (classifier, window, the three heartbeat paths), `backend/tests/test_appliance_control_plane_promote.py` (Replace on a failed joiner → 200 + evicting; an in-flight joiner still 409).
- ddi-pg essential-lane walks: the two-commit head (`dev-d80cd0a`, sealed 21:41Z) boot 4/4, baseline 19/19, ui 152/152, protocol 9/9, api 1,122 pass / 2 fail — the two fails being red on every build of this `main` in that lane (the #860 drift pin and an MCP tool-inventory pin since refreshed); the three-commit head (`dev-997ace0`, sealed 02:30Z next day) the same with api 1,123 pass / 1 fail (the #860 pin only). Nothing in the appliance/supervisor path.
- Live, ddi-pg twin rig of this build (3-node formations from a 250k-record golden, both members promoted in ONE call, the campaign's real shape), with the formation runner's own repair switched off so only the product acts:
  - Unblocked formation: both members `ready` (21:42Z / 21:45Z), no failure to retry.
  - Formation with member-2's path to the seed's tcp 6443/2379/2380 dropped at the seed (two runs, 22:46Z and 00:55Z): member-1 joined; member-2's join reported `failed` (runner reason "the seed rejected the join token") and **the row kept `desired_cluster_role = member`** — on `main` the first `failed` heartbeat clears it (#590).
  - Block lifted 90 s after the failure (00:57:32Z): member-2's supervisor re-fired the join on its own 53 s later — `cluster-join.log`: `00:58:25 JOIN: server=https://192.168.122.232:6443 (joining the control-plane cluster)` … `restarting k3s to join (fresh identity)` — and the registry showed member-2 `ready` / `cluster_role = member` at 01:00:46Z, 3 min 14 s after the block lifted, with no operator action. The api log carries the new `control_plane_join_retrying` event for that member ("transient join failure — desired-state kept so the supervisor re-fires the join"). Drill transcript: `{"m1_ready": true, "m2_failed_while_blocked": true, "desired_kept_on_failure": true, "auto_rejoined": true}`.
  - Replace on a failed joiner (three-commit head, fresh formation, member-2 blocked the same way): member-2's join reported `failed` at 03:14:51Z with `desired_cluster_role = member` still set (commit 2's retry window open, member-1 `ready`). Replace called at once: **`200 OK`** with `{"evicted": {hostname "ddipg-member-2", cluster_role null, desired_cluster_role null, cluster_join_state "evicting"}, "pairing_code": …, "pairing_expires_at": +1 h}` and the api's `control_plane_replace` event; 20 s later the registry row read `role=None desired=None join=evicting` — desired-state cleared, eviction under way, replacement pairing code minted. The identical call on the two-commit head (same drill, previous day) answered `409 … isn't a settled control-plane member`.

## Notes for review

- No new column: the retry window is measured from `cluster_join_state_at`, which the heartbeat stamps only on a state CHANGE (#590's staleness clock), and the re-fire count is the supervisor's existing per-target ledger (`_CLUSTER_JOIN_MAX_ATTEMPTS`). After the ceiling the row sits `failed` until the window elapses, then clears as before and the supervisor resets its ledger for the next promote.
- The seed's ~15-minute k3s cycling and the api liveness kills in HA mode (campaign items 9 and 12) are being diagnosed separately; this PR does not claim them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
