### PR TITLE
fix: close #962–#968 — DNS delete gates, appliance chart QoS, chart + perf CI gates

### DIFF
--- a/.github/scripts/chart-no-besteffort.py
+++ b/.github/scripts/chart-no-besteffort.py
@@ -1,22 +1,29 @@
 #!/usr/bin/env python3
-"""Refuse a rendered chart in which any container would run BestEffort (#965).
+"""Refuse a rendered chart in which a serving container would run BestEffort (#965).
 
 Reads one or more ``helm template`` streams (files, or stdin when given ``-``)
 and fails if a Pod template — Deployment / StatefulSet / DaemonSet / Job /
-CronJob, or a bare Pod — carries a container or init container with no
-``resources.requests.cpu`` *and* ``memory``.
+CronJob, or a bare Pod — carries a container with neither a request nor a
+limit for CPU, or for memory (each is reported separately; a container with
+``limits`` and no ``requests`` passes, since Kubernetes defaults the request
+to the limit). Init containers are exempt: they finish before the pod
+serves, so their CFS weight cannot starve anything that matters.
 
-Why a render-time check and not a review rule: BestEffort is the lowest CFS
-weight on the node, and #952 / #953 / #965 were three rounds of finding the
-serving pods the control plane could starve. Two of the three #965 workloads
-had been left out of #953 on purpose and one by omission; nothing but reading
-every template again would have told them apart. This does that on every PR.
+The check is per serving container, deliberately stricter than the pod-level
+QoS class: the CFS weight that decides who gets the CPU under contention is
+the container cgroup's own, so one sidecar with no request is at weight 2
+whatever its neighbours declare.
 
-A ``with .Values.x.resources`` guard that tests the wrong path renders a pod
-with no ``resources:`` at all and passes ``helm lint`` and ``kubeconform``
-both — which is the shape this script exists to catch.
+Why a render-time check and not a review rule: #952 / #953 / #965 were three
+rounds of finding the serving pods the control plane could starve. Two of
+the three #965 workloads had been left out of #953 on purpose and one by
+omission; nothing but reading every template again would have told them
+apart. This does that on every PR. A ``with .Values.x.resources`` guard that
+tests the wrong path renders a pod with no ``resources:`` at all and passes
+``helm lint`` and ``kubeconform`` both — which is the shape this exists to
+catch.
 
-Exit 0 when every container has both requests, 1 with one line per offender.
+Exit 0 when every serving container is covered, 1 with one line per offender.
 """
 
 from __future__ import annotations
@@ -27,7 +34,7 @@ from typing import Any
 
 import yaml
 
-_POD_TEMPLATE_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "Job", "ReplicaSet"}
+_POD_TEMPLATE_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "Job"}
 
 
 def _pod_specs(doc: dict[str, Any]) -> Iterator[tuple[str, dict[str, Any]]]:
@@ -49,15 +56,16 @@ def _offenders(docs: Iterable[dict[str, Any] | None]) -> list[str]:
         if not isinstance(doc, dict):
             continue
         for name, pod in _pod_specs(doc):
-            for field in ("initContainers", "containers"):
-                for c in pod.get(field) or []:
-                    requests = ((c.get("resources") or {}).get("requests")) or {}
-                    missing = [k for k in ("cpu", "memory") if not requests.get(k)]
-                    if missing:
-                        out.append(
-                            f"{name} {field[:-1]} {c.get('name', '?')}: "
-                            f"no requests.{' / requests.'.join(missing)} — BestEffort"
-                        )
+            for c in pod.get("containers") or []:
+                res = c.get("resources") or {}
+                requests = res.get("requests") or {}
+                limits = res.get("limits") or {}
+                missing = [k for k in ("cpu", "memory") if not (requests.get(k) or limits.get(k))]
+                if missing:
+                    out.append(
+                        f"{name} container {c.get('name', '?')}: "
+                        f"no request or limit for {' / '.join(missing)} — BestEffort"
+                    )
     return out
 
 

--- a/.github/scripts/chart-no-besteffort.py
+++ b/.github/scripts/chart-no-besteffort.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Refuse a rendered chart in which any container would run BestEffort (#965).
+
+Reads one or more ``helm template`` streams (files, or stdin when given ``-``)
+and fails if a Pod template — Deployment / StatefulSet / DaemonSet / Job /
+CronJob, or a bare Pod — carries a container or init container with no
+``resources.requests.cpu`` *and* ``memory``.
+
+Why a render-time check and not a review rule: BestEffort is the lowest CFS
+weight on the node, and #952 / #953 / #965 were three rounds of finding the
+serving pods the control plane could starve. Two of the three #965 workloads
+had been left out of #953 on purpose and one by omission; nothing but reading
+every template again would have told them apart. This does that on every PR.
+
+A ``with .Values.x.resources`` guard that tests the wrong path renders a pod
+with no ``resources:`` at all and passes ``helm lint`` and ``kubeconform``
+both — which is the shape this script exists to catch.
+
+Exit 0 when every container has both requests, 1 with one line per offender.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+import yaml
+
+_POD_TEMPLATE_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "Job", "ReplicaSet"}
+
+
+def _pod_specs(doc: dict[str, Any]) -> Iterator[tuple[str, dict[str, Any]]]:
+    kind = doc.get("kind")
+    name = f"{kind}/{doc.get('metadata', {}).get('name', '?')}"
+    spec = doc.get("spec") or {}
+    if kind == "Pod":
+        yield name, spec
+    elif kind in _POD_TEMPLATE_KINDS:
+        yield name, (spec.get("template") or {}).get("spec") or {}
+    elif kind == "CronJob":
+        job = (spec.get("jobTemplate") or {}).get("spec") or {}
+        yield name, (job.get("template") or {}).get("spec") or {}
+
+
+def _offenders(docs: Iterable[dict[str, Any] | None]) -> list[str]:
+    out: list[str] = []
+    for doc in docs:
+        if not isinstance(doc, dict):
+            continue
+        for name, pod in _pod_specs(doc):
+            for field in ("initContainers", "containers"):
+                for c in pod.get(field) or []:
+                    requests = ((c.get("resources") or {}).get("requests")) or {}
+                    missing = [k for k in ("cpu", "memory") if not requests.get(k)]
+                    if missing:
+                        out.append(
+                            f"{name} {field[:-1]} {c.get('name', '?')}: "
+                            f"no requests.{' / requests.'.join(missing)} — BestEffort"
+                        )
+    return out
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:] or ["-"]
+    failures: list[str] = []
+    for path in paths:
+        stream = sys.stdin if path == "-" else open(path, encoding="utf-8")  # noqa: SIM115
+        with stream:
+            failures.extend(f"{path}: {line}" for line in _offenders(yaml.safe_load_all(stream)))
+    for line in failures:
+        print(line, file=sys.stderr)
+    if failures:
+        print(f"{len(failures)} container(s) would run BestEffort", file=sys.stderr)
+        return 1
+    print("no BestEffort containers")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/chart-toggle-coverage.py
+++ b/.github/scripts/chart-toggle-coverage.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Fail if a chart template is gated on a values key no render flips (#966).
+
+The render gate in ``charts-render-check.sh`` templates each chart with a
+hand-maintained list of ``--set`` toggles. Hand-maintained lists drift: the
+first version of that list missed nine umbrella gates — the CNPG ``Cluster``
+and Redis Sentinel HA shapes among them — so the job that exists to render
+every template was rendering a subset and would have stayed green while a
+broken HA template shipped. This script closes the loop.
+
+Usage::
+
+    chart-toggle-coverage.py <chart dir> [--set key=value ...]
+
+It greps the chart's own templates for ``.Values.<path>.enabled`` and
+``.Values.<path>.kind`` references and, for each, checks that at least one
+render exercises the non-default branch:
+
+* an ``.enabled`` key whose ``values.yaml`` default is ``false`` must appear
+  in a ``--set`` as ``true`` (default-``true`` keys render on their own);
+* a ``.kind`` key must appear in a ``--set`` with a value different from its
+  default, since ``kind`` selects between whole templates.
+
+Pass every ``--set`` from every render of that chart, together. Exit 1 with
+one line per uncovered key.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REF = re.compile(r"\.Values\.((?:[A-Za-z0-9_]+\.)+)(enabled|kind)\b")
+
+
+def _lookup(values: dict[str, Any], dotted: str) -> Any:
+    node: Any = values
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    chart = Path(argv[1])
+    flipped: dict[str, str] = {}
+    args = iter(argv[2:])
+    for a in args:
+        if a == "--set":
+            k, _, v = next(args).partition("=")
+            flipped[k] = v
+    values = yaml.safe_load((chart / "values.yaml").read_text(encoding="utf-8")) or {}
+
+    refs: set[tuple[str, str]] = set()
+    for tpl in sorted((chart / "templates").rglob("*.yaml")) + sorted(
+        (chart / "templates").rglob("*.tpl")
+    ):
+        for m in _REF.finditer(tpl.read_text(encoding="utf-8")):
+            refs.add((m.group(1).rstrip("."), m.group(2)))
+
+    missing: list[str] = []
+    for path, leaf in sorted(refs):
+        key = f"{path}.{leaf}"
+        default = _lookup(values, key)
+        if leaf == "enabled":
+            if default is True or flipped.get(key) == "true":
+                continue
+            missing.append(f"{key} (default {default!r}) is never set to true")
+        else:
+            if key in flipped and flipped[key] != str(default):
+                continue
+            missing.append(f"{key} (default {default!r}) is never rendered with another value")
+    for line in missing:
+        print(f"{chart.name}: {line}", file=sys.stderr)
+    if missing:
+        print(
+            f"{len(missing)} template gate(s) never exercised by the render matrix", file=sys.stderr
+        )
+        return 1
+    print(f"{chart.name}: all {len(refs)} template gates covered")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/charts-render-check.sh
+++ b/.github/scripts/charts-render-check.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# Lint, render and schema-check both Helm charts (#966).
+#
+# Until this existed nothing on a PR parsed the charts at all: the one
+# PR-time helm job (agent-e2e) is path-filtered to charts/spatiumddi/** and
+# installs only the umbrella chart, so charts/spatiumddi-appliance/ was first
+# read by helm during ``release.yml``'s ``helm package`` — a template that
+# failed to render broke the release, not the PR that introduced it. And no
+# job ran ``helm lint`` for either chart.
+#
+# Three gates per render, each catching what the previous cannot:
+#
+#   helm lint        — template syntax, values schema, chart metadata.
+#   helm template    — the render itself, with the role / feature toggles
+#                      flipped ON, because a template that only renders at
+#                      defaults has not been rendered (every appliance role
+#                      is ``enabled: false`` by default).
+#   kubeconform      — the rendered objects against the Kubernetes API
+#                      schemas, -strict so an unknown field (a key indented
+#                      under the wrong parent, the classic helm mistake) is
+#                      an error rather than something the apiserver would
+#                      silently drop. CRDs (the CNPG ``Cluster``) resolve
+#                      through the datreeio CRDs-catalog.
+#   no-besteffort    — appliance renders only: every container must carry
+#                      CPU + memory requests (#965). A ``with`` guard that
+#                      tests the wrong values path renders no ``resources:``
+#                      block and passes the three gates above.
+#
+# Runs anywhere helm + kubeconform + python3 (with PyYAML) are on PATH; the
+# CI job and ``make charts-lint`` both call it. Rendered manifests are left
+# in $OUT for inspection.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT="${OUT:-$(mktemp -d)}"
+K8S_VERSION="${K8S_VERSION:-1.31.0}"
+# Group/kind/version-templated so any CRD in the catalog resolves; the one
+# we render today is postgresql.cnpg.io/Cluster.
+CRD_SCHEMAS='https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+
+UMBRELLA="$ROOT/charts/spatiumddi"
+APPLIANCE="$ROOT/charts/spatiumddi-appliance"
+
+for tool in helm kubeconform python3; do
+    command -v "$tool" >/dev/null || { echo "missing: $tool" >&2; exit 1; }
+done
+
+failures=0
+
+lint() { # chart [helm --set args...]
+    local chart="$1"; shift
+    echo "── helm lint $(basename "$chart") $*"
+    helm lint --strict "$chart" "$@" || failures=$((failures + 1))
+}
+
+render() { # name chart check_besteffort [helm --set args...]
+    local name="$1" chart="$2" besteffort="$3"; shift 3
+    local file="$OUT/$name.yaml"
+    echo "── helm template $name ($(basename "$chart")) $*"
+    if ! helm template "$name" "$chart" --kube-version "$K8S_VERSION" "$@" > "$file"; then
+        failures=$((failures + 1)); return
+    fi
+    echo "   $(grep -c '^kind:' "$file") objects → $file"
+    # CustomResourceDefinition is skipped: the only CRDs rendered are the
+    # CNPG operator's, vendored from upstream via the subchart — not ours to
+    # validate, and the upstream schema set carries no strict variant for
+    # the kind. Every CR *instance* (the ``Cluster``) is still checked.
+    kubeconform -strict -summary \
+        -kubernetes-version "$K8S_VERSION" \
+        -schema-location default \
+        -schema-location "$CRD_SCHEMAS" \
+        -skip CustomResourceDefinition \
+        "$file" || failures=$((failures + 1))
+    if [ "$besteffort" = "yes" ]; then
+        python3 "$ROOT/.github/scripts/chart-no-besteffort.py" "$file" || failures=$((failures + 1))
+    fi
+}
+
+# Subcharts. The umbrella has none today; the appliance vendors CNPG (#272)
+# and this is the first time the dependency resolves before release.
+helm dependency update "$UMBRELLA"
+helm dependency update "$APPLIANCE"
+
+# ── Umbrella chart ──────────────────────────────────────────────────────────
+UMBRELLA_ALL_ON=(
+    --set dnsAgents.enabled=true
+    --set dhcpAgents.enabled=true
+    --set ingress.enabled=true
+    --set slotImageMirror.enabled=true
+    --set api.autoscaling.enabled=true
+)
+lint "$UMBRELLA"
+lint "$UMBRELLA" "${UMBRELLA_ALL_ON[@]}"
+render umbrella-defaults "$UMBRELLA" no
+render umbrella-all-on "$UMBRELLA" no "${UMBRELLA_ALL_ON[@]}"
+# Bring-your-own database + Redis: the shape HA installs use (k8s/ha/).
+render umbrella-external-db "$UMBRELLA" no \
+    --set postgresql.enabled=false --set externalDatabase.host=pg.example \
+    --set redis.enabled=false --set externalRedis.host=redis.example
+
+# ── Appliance chart ─────────────────────────────────────────────────────────
+# Every role + every feature on at once. This is not a valid appliance (one
+# node never runs all three DNS drivers) — it is the render that exercises
+# every template, which is what matters here.
+APPLIANCE_ALL_ON=(
+    --set dnsBind9.enabled=true
+    --set dnsPowerdns.enabled=true
+    --set dnsTechnitium.enabled=true
+    --set dhcpKea.enabled=true
+    --set dhcpKea.relayVIP=10.0.0.5
+    --set lookingGlass.enabled=true
+    --set supervisor.enabled=true
+    --set observer.enabled=true
+    --set observability.kubeStateMetrics.enabled=true
+    --set observability.nodeExporter.enabled=true
+    --set dns.useMetalLBVIP=true
+    --set cnpg.enabled=true
+)
+lint "$APPLIANCE"
+lint "$APPLIANCE" "${APPLIANCE_ALL_ON[@]}"
+render appliance-defaults "$APPLIANCE" yes
+render appliance-all-on "$APPLIANCE" yes "${APPLIANCE_ALL_ON[@]}"
+# The single-node default install shape: one DNS driver + DHCP + supervisor.
+render appliance-full-stack "$APPLIANCE" yes \
+    --set dnsBind9.enabled=true --set dhcpKea.enabled=true --set supervisor.enabled=true
+
+if [ "$failures" -ne 0 ]; then
+    echo "charts: $failures gate(s) failed" >&2
+    exit 1
+fi
+echo "charts: all gates passed (renders in $OUT)"

--- a/.github/scripts/charts-render-check.sh
+++ b/.github/scripts/charts-render-check.sh
@@ -22,10 +22,13 @@
 #                      an error rather than something the apiserver would
 #                      silently drop. CRDs (the CNPG ``Cluster``) resolve
 #                      through the datreeio CRDs-catalog.
-#   no-besteffort    — appliance renders only: every container must carry
-#                      CPU + memory requests (#965). A ``with`` guard that
-#                      tests the wrong values path renders no ``resources:``
-#                      block and passes the three gates above.
+#   no-besteffort    — every render: each serving container must carry a
+#                      CPU + memory request or limit (#965). A ``with`` guard
+#                      that tests the wrong values path renders no
+#                      ``resources:`` block and passes the three gates above.
+#   toggle-coverage  — every ``.Values.x.enabled`` / ``.kind`` a template is
+#                      gated on must be flipped by at least one render, so a
+#                      new gate cannot silently fall out of the matrix.
 #
 # Runs anywhere helm + kubeconform + python3 (with PyYAML) are on PATH; the
 # CI job and ``make charts-lint`` both call it. Rendered manifests are left
@@ -55,8 +58,14 @@ lint() { # chart [helm --set args...]
     helm lint --strict "$chart" "$@" || failures=$((failures + 1))
 }
 
-render() { # name chart check_besteffort [helm --set args...]
-    local name="$1" chart="$2" besteffort="$3"; shift 3
+# kubeconform caches fetched schemas only in memory, per invocation; six
+# invocations would fetch every kind's schema six times from GitHub raw. A
+# disk cache makes renders 2-6 free, and CI persists it across runs.
+KUBECONFORM_CACHE="${KUBECONFORM_CACHE:-$OUT/.schema-cache}"
+mkdir -p "$KUBECONFORM_CACHE"
+
+render() { # name chart [helm --set args...]
+    local name="$1" chart="$2"; shift 2
     local file="$OUT/$name.yaml"
     echo "── helm template $name ($(basename "$chart")) $*"
     if ! helm template "$name" "$chart" --kube-version "$K8S_VERSION" "$@" > "$file"; then
@@ -72,10 +81,15 @@ render() { # name chart check_besteffort [helm --set args...]
         -schema-location default \
         -schema-location "$CRD_SCHEMAS" \
         -skip CustomResourceDefinition \
+        -cache "$KUBECONFORM_CACHE" \
         "$file" || failures=$((failures + 1))
-    if [ "$besteffort" = "yes" ]; then
-        python3 "$ROOT/.github/scripts/chart-no-besteffort.py" "$file" || failures=$((failures + 1))
-    fi
+    python3 "$ROOT/.github/scripts/chart-no-besteffort.py" "$file" || failures=$((failures + 1))
+}
+
+coverage() { # chart [every --set arg from every render of that chart...]
+    local chart="$1"; shift
+    echo "── toggle coverage $(basename "$chart")"
+    python3 "$ROOT/.github/scripts/chart-toggle-coverage.py" "$chart" "$@" || failures=$((failures + 1))
 }
 
 # Subcharts. The umbrella has none today; the appliance vendors CNPG (#272)
@@ -84,21 +98,46 @@ helm dependency update "$UMBRELLA"
 helm dependency update "$APPLIANCE"
 
 # ── Umbrella chart ──────────────────────────────────────────────────────────
+# Every template gate on: the agents, ingress, the slot-image mirror, HPA, the
+# three RBAC toggles + service control + appliance host mounts, frontend TLS,
+# Redis auth. ``chart-toggle-coverage.py`` fails this script if a template
+# grows a gate that no set below flips.
 UMBRELLA_ALL_ON=(
     --set dnsAgents.enabled=true
     --set dhcpAgents.enabled=true
     --set ingress.enabled=true
     --set slotImageMirror.enabled=true
     --set api.autoscaling.enabled=true
+    --set api.serviceAccount.enabled=true
+    --set api.serviceControl.enabled=true
+    --set api.serviceControlRBAC.enabled=true
+    --set api.upgradeOrchestratorRBAC.enabled=true
+    --set api.applianceHostMounts.enabled=true
+    --set frontend.tls.enabled=true
+    --set redis.auth.enabled=true
+)
+# The HA topology docs/deployment/KUBERNETES.md points operators at: a
+# CloudNativePG ``Cluster`` CR (the one CRD instance either chart renders —
+# the datreeio schema location exists for it) + Redis Sentinel, with CNPG
+# backups on.
+UMBRELLA_HA=(
+    --set postgresql.kind=cnpg
+    --set postgresql.cnpg.backup.enabled=true
+    --set redis.kind=sentinel
+)
+UMBRELLA_EXTERNAL=(
+    --set postgresql.enabled=false --set externalDatabase.host=pg.example
+    --set redis.enabled=false --set externalRedis.host=redis.example
 )
 lint "$UMBRELLA"
 lint "$UMBRELLA" "${UMBRELLA_ALL_ON[@]}"
-render umbrella-defaults "$UMBRELLA" no
-render umbrella-all-on "$UMBRELLA" no "${UMBRELLA_ALL_ON[@]}"
-# Bring-your-own database + Redis: the shape HA installs use (k8s/ha/).
-render umbrella-external-db "$UMBRELLA" no \
-    --set postgresql.enabled=false --set externalDatabase.host=pg.example \
-    --set redis.enabled=false --set externalRedis.host=redis.example
+lint "$UMBRELLA" "${UMBRELLA_HA[@]}"
+render umbrella-defaults "$UMBRELLA"
+render umbrella-all-on "$UMBRELLA" "${UMBRELLA_ALL_ON[@]}"
+render umbrella-ha "$UMBRELLA" "${UMBRELLA_HA[@]}"
+# Bring-your-own database + Redis: the shape k8s/ha/ installs use.
+render umbrella-external-db "$UMBRELLA" "${UMBRELLA_EXTERNAL[@]}"
+coverage "$UMBRELLA" "${UMBRELLA_ALL_ON[@]}" "${UMBRELLA_HA[@]}" "${UMBRELLA_EXTERNAL[@]}"
 
 # ── Appliance chart ─────────────────────────────────────────────────────────
 # Every role + every feature on at once. This is not a valid appliance (one
@@ -112,7 +151,6 @@ APPLIANCE_ALL_ON=(
     --set dhcpKea.relayVIP=10.0.0.5
     --set lookingGlass.enabled=true
     --set supervisor.enabled=true
-    --set observer.enabled=true
     --set observability.kubeStateMetrics.enabled=true
     --set observability.nodeExporter.enabled=true
     --set dns.useMetalLBVIP=true
@@ -120,11 +158,12 @@ APPLIANCE_ALL_ON=(
 )
 lint "$APPLIANCE"
 lint "$APPLIANCE" "${APPLIANCE_ALL_ON[@]}"
-render appliance-defaults "$APPLIANCE" yes
-render appliance-all-on "$APPLIANCE" yes "${APPLIANCE_ALL_ON[@]}"
+render appliance-defaults "$APPLIANCE"
+render appliance-all-on "$APPLIANCE" "${APPLIANCE_ALL_ON[@]}"
 # The single-node default install shape: one DNS driver + DHCP + supervisor.
-render appliance-full-stack "$APPLIANCE" yes \
+render appliance-full-stack "$APPLIANCE" \
     --set dnsBind9.enabled=true --set dhcpKea.enabled=true --set supervisor.enabled=true
+coverage "$APPLIANCE" "${APPLIANCE_ALL_ON[@]}"
 
 if [ "$failures" -ne 0 ]; then
     echo "charts: $failures gate(s) failed" >&2

--- a/.github/scripts/ci-backend-relevant.sh
+++ b/.github/scripts/ci-backend-relevant.sh
@@ -73,9 +73,15 @@ set -euo pipefail
 #   *.md        Root-level prose (README, CHANGELOG, CLAUDE.md, ...). Nested
 #               *.md are covered by their own directory's entry, or fall
 #               through and run the suite — which is the safe direction.
+#   perf/       Off-box load-generation + campaign tooling (#968). Nothing in
+#               backend/ imports it and no backend test reads it; it has its
+#               own Perf — Tests job. Before this entry a perf-only PR fell
+#               through to "unrecognised → run" and spent all 8 shards on
+#               tests that could not be affected, while running none that
+#               could — exactly inverted.
 #   NOTICE      Third-party attribution.
 #   LICENSE     Apache 2.0 text.
-IRRELEVANT='^(docs/|website/|frontend/|charts/|k8s/|agent/|appliance/|\.github/|[^/]+\.md$|NOTICE$|LICENSE$)'
+IRRELEVANT='^(docs/|website/|frontend/|charts/|k8s/|agent/|appliance/|perf/|\.github/|[^/]+\.md$|NOTICE$|LICENSE$)'
 
 # Load the must-run carve-outs. A missing or unreadable manifest fails toward
 # running the suite — same direction as every other failure here.

--- a/.github/scripts/install-kubeconform.sh
+++ b/.github/scripts/install-kubeconform.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Install a pinned, checksum-verified kubeconform (#966).
+#
+# Shared by the ``Charts — Lint & Template`` CI job and ``make charts-lint``
+# (which runs the same gate in a helm container, because the dev box has no
+# helm). One pin, one place: bump KUBECONFORM_VERSION here and both move.
+#
+# Verifies the tarball against the release's CHECKSUMS file before
+# extracting — a supply-chain gate on a binary CI downloads on every PR.
+
+set -euo pipefail
+
+KUBECONFORM_VERSION="${KUBECONFORM_VERSION:-v0.8.0}"
+BIN_DIR="${KUBECONFORM_BIN_DIR:-/usr/local/bin}"
+
+case "$(uname -m)" in
+    x86_64 | amd64) arch=amd64 ;;
+    aarch64 | arm64) arch=arm64 ;;
+    *)
+        echo "unsupported architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+tarball="kubeconform-linux-${arch}.tar.gz"
+base="https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+cd "$tmp"
+curl -fsSL -o "$tarball" "${base}/${tarball}"
+curl -fsSL -o CHECKSUMS "${base}/CHECKSUMS"
+grep -E " ${tarball}\$" CHECKSUMS | sha256sum -c -
+tar -xzf "$tarball" kubeconform
+install -m 0755 kubeconform "${BIN_DIR}/kubeconform"
+"${BIN_DIR}/kubeconform" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,85 @@ jobs:
       - name: Run tests
         run: python -m pytest appliance/tests -q
 
+  # ── Helm charts (#966) ──────────────────────────────────────────────────────
+  # Nothing on a PR used to parse either chart: the one PR-time helm job
+  # (agent-e2e) is path-filtered to ``charts/spatiumddi/**`` and installs only
+  # the umbrella chart, so ``charts/spatiumddi-appliance/`` was first read by
+  # helm during ``release.yml``'s ``helm package`` — a template that failed to
+  # render broke the RELEASE, not the PR that introduced it — and no job ran
+  # ``helm lint`` at all. #953 (three chart files) went green on 17 checks,
+  # none of which opened a file it changed.
+  #
+  # The gate lives in ``.github/scripts/charts-render-check.sh`` so ``make
+  # charts-lint`` runs the identical thing locally: helm lint, helm template
+  # with every role / feature toggle ON, kubeconform -strict against the K8s
+  # + CRD schemas, and a no-BestEffort check on the appliance renders (#965).
+  # Unconditional like every other job here — see the header on why ``paths``
+  # filters are absent — and ~1 min.
+  charts-lint:
+    name: Charts — Lint & Template
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.20.2
+
+      - name: Install kubeconform
+        run: .github/scripts/install-kubeconform.sh
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Lint, render and validate both charts
+        env:
+          OUT: ${{ runner.temp }}/charts
+        run: |
+          mkdir -p "$OUT"
+          .github/scripts/charts-render-check.sh
+
+      - name: Upload rendered manifests
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rendered-charts
+          path: ${{ runner.temp }}/charts
+          retention-days: 7
+
+  # ── Perf tooling (#968) ─────────────────────────────────────────────────────
+  # ``perf/`` — the off-box load generators + campaign harness the appliance
+  # sizing work runs on — was referenced by no workflow, so its tests never
+  # ran (#955 merged on 25 green checks that opened none of its files) while
+  # the backend path filter, which did not know ``perf/`` either, spent all 8
+  # backend shards on it. Hermetic: the tests use a fake socket, no network,
+  # no appliance, ~0.01 s.
+  #
+  # Tests only, like the agent + appliance jobs: ``perf/`` is outside the
+  # Backend Lint scope and carries pre-existing ruff/black drift (25 findings,
+  # 39 of 42 files black would reformat, measured 2026-09-04) — bringing it
+  # under lint is a formatting-only change of its own.
+  perf-test:
+    name: Perf — Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pytest
+
+      - name: Run tests
+        run: python -m pytest perf -q
+
   # Required-status-check aggregator: branch protection can gate on the stable
   # name "Agent — Tests"; this job passes only if all three agent suites did.
   # Keep this name (and the matrix above) in sync with the required check.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,9 +470,19 @@ jobs:
       - name: Install dependencies
         run: pip install pyyaml
 
+      - name: Cache kubeconform schemas
+        # kubeconform caches fetched schemas only in memory, per invocation;
+        # persisting its disk cache means a steady-state PR fetches nothing
+        # from raw.githubusercontent.com — the job's only flake source.
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/kubeconform-schemas
+          key: kubeconform-schemas-v0.8.0-k8s-1.31.0-${{ hashFiles('.github/scripts/charts-render-check.sh') }}
+
       - name: Lint, render and validate both charts
         env:
           OUT: ${{ runner.temp }}/charts
+          KUBECONFORM_CACHE: ${{ runner.temp }}/kubeconform-schemas
         run: |
           mkdir -p "$OUT"
           .github/scripts/charts-render-check.sh

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ docs/_site/
 docs/.jekyll-cache/
 docs/.jekyll-metadata
 /openapi.json
+
+# Local `make charts-lint` renders (#966)
+.charts-render/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1651,6 +1651,11 @@ make openapi VERSION=2026.08.22-1      # export the OpenAPI contract the release
 make docs                              # local Jekyll preview of docs/ on :4000 (DOCS_PORT to override); docs-down stops it.
 make docs-verify                       # diagram-geometry gate — same check CI's "Docs — Diagram Geometry" job runs.
                                        #   Run before pushing ANY docs/assets/**.svg change. Needs chromium on PATH.
+make charts-lint                       # Charts — Lint & Template gate (#966), via a helm container: helm lint + template
+                                       #   with every toggle on + kubeconform -strict + the no-BestEffort check (#965).
+                                       #   Run before pushing ANY charts/** change; renders land in .charts-render/.
+make perf-test                         # Perf — Tests (#968), via Docker. perf/ is denied by the backend path filter,
+                                       #   so a perf-only PR runs this and NOT the 8 backend shards.
 make trivy IMAGE=kea                   #   ...one image only. Same gate CI uses (HIGH/CRITICAL, ignore-unfixed).
                                        #   CI's Trivy is path-filtered + PR-only, so touching a Dockerfile can surface a
                                        #   PRE-EXISTING CVE. Note golang:X.Y.Z pins are SECURITY pins — Go static-links its

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1643,7 +1643,8 @@ make migrate                           # apply
 
 # Lint, typecheck, test
 make lint                              # ruff + black + mypy, eslint + prettier
-make ci                                # same three lint jobs CI runs (backend-lint + frontend-lint + frontend-build). Run before pushing.
+make ci                                # the lint/build/chart/perf jobs CI runs (backend-lint + frontend-lint + frontend-build
+                                       #   + charts-lint + perf-test). Run before pushing.
 make trivy                             # container-image CVE scan — run before pushing ANY agent Dockerfile change.
 make openapi VERSION=2026.08.22-1      # export the OpenAPI contract the release attaches (#903). Byte-identical
                                        #   to the release asset at the same tag; runs --network none, so it also proves

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help up down dev build build-supervisor migrate lint test lint-backend lint-frontend test-backend \
+.PHONY: charts-lint perf-test help up down dev build build-supervisor migrate lint test lint-backend lint-frontend test-backend \
         openapi \
         lint-untyped-routes \
         lint-untyped-routes-baseline \
@@ -346,6 +346,24 @@ ci-frontend-lint:
 ci-frontend-build:
 	@echo "→ Frontend — Build"
 	cd $(FRONTEND_DIR) && npm run build
+
+# Charts — Lint & Template (#966): the same script CI's job runs, inside a
+# helm container so a dev box with no helm / kubeconform can run it. Renders
+# land in ./.charts-render/ (gitignored) for inspection.
+HELM_IMAGE ?= alpine/helm:3.20.2
+charts-lint:
+	@echo "→ Charts — Lint & Template (matches .github/workflows/ci.yml)"
+	@mkdir -p .charts-render
+	docker run --rm --entrypoint sh -v "$(PWD):/repo" -w /repo -e HOME=/tmp -e OUT=/repo/.charts-render \
+	  $(HELM_IMAGE) -c 'apk add -q --no-cache bash curl python3 py3-yaml \
+	    && .github/scripts/install-kubeconform.sh \
+	    && .github/scripts/charts-render-check.sh'
+
+# Perf — Tests (#968): hermetic, stdlib-only tests under perf/.
+perf-test:
+	@echo "→ Perf — Tests (matches .github/workflows/ci.yml)"
+	docker run --rm -v "$(PWD):/repo" -w /repo python:3.12-slim sh -c \
+	  'pip -q install pytest >/dev/null && python -m pytest perf -q'
 
 # ── Screenshots ────────────────────────────────────────────────────────────────
 # Re-captures the README screenshots via headless chromium. The dev stack must

--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ lint-untyped-routes-baseline: $(UNTYPED_LIST)
 
 FORCE:
 
-ci: ci-backend-lint ci-frontend-lint ci-frontend-build
+ci: ci-backend-lint ci-frontend-lint ci-frontend-build charts-lint perf-test
 	@echo ""
 	@echo "✓ All CI checks passed — safe to push."
 

--- a/backend/app/api/v1/admin/trash.py
+++ b/backend/app/api/v1/admin/trash.py
@@ -33,6 +33,7 @@ from app.services.dns.record_ops import push_records_restore
 from app.services.soft_delete import (  # noqa: PLC2701 — canonical labels, keep in one place
     SOFT_DELETE_RESOURCE_TYPES,
     TYPE_TO_MODEL,
+    batch_resource_types,
     default_conflict_check,
     restore_batch,
 )
@@ -190,6 +191,20 @@ async def list_trash(
     return TrashListResponse(items=items[offset : offset + limit], total=total)
 
 
+# Types a partial restore is safe for (#963 review). ``skip_conflicts`` leaves
+# the clashing rows in the trash, which is only sound when the batch is a FLAT
+# set of independent siblings — every row a leaf, none the parent of another.
+#
+# ``dns_record`` is the only such batch anyone produces today: bulk record
+# delete stamps N records under one id, and ``_collect_descendants`` has no
+# DNSRecord branch, so a record never drags children along. Every other batch
+# is a cascade (a zone AND its records, a scope AND its pools), where skipping
+# a row can restore a child whose parent stayed deleted — records pointing at
+# a soft-deleted zone, hidden by the zone's own filter and re-pushed to the
+# provider as if live. Add a type here only with the same argument.
+_PARTIAL_RESTORE_TYPES = frozenset({"dns_record"})
+
+
 @router.post("/trash/{type}/{row_id}/restore", response_model=RestoreResponse)
 async def restore_row(
     type: str,
@@ -203,7 +218,8 @@ async def restore_row(
     ``skip_conflicts`` restores every sibling that does NOT clash with a live
     row and reports the ones left behind, instead of refusing the whole batch
     — for a bulk record delete (#963), where one record re-created by hand
-    must not make the other N unrestorable.
+    must not make the other N unrestorable. It is refused (422) on a cascade
+    batch; see ``_PARTIAL_RESTORE_TYPES``.
     """
 
     if type not in SOFT_DELETE_RESOURCE_TYPES:
@@ -227,6 +243,22 @@ async def restore_row(
         # Defensive: stamp a fresh batch and restore just this row.
         batch_id = uuid.uuid4()
         target.deletion_batch_id = batch_id
+
+    if skip_conflicts:
+        # Checked BEFORE the restore: a partial restore of a cascade batch is
+        # not something to undo afterwards. The UI hides the option for these
+        # types; this is what enforces it.
+        cascade = await batch_resource_types(db, batch_id) - _PARTIAL_RESTORE_TYPES
+        if cascade:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "skip_conflicts is only available for a flat batch of independent "
+                    f"rows; this batch also holds {', '.join(sorted(cascade))}, whose "
+                    "children would be restored without their parent. Resolve the "
+                    "clash and restore the batch whole."
+                ),
+            )
 
     async def _check(obj: Any) -> str | None:
         return await default_conflict_check(db, obj)

--- a/backend/app/api/v1/admin/trash.py
+++ b/backend/app/api/v1/admin/trash.py
@@ -29,7 +29,7 @@ from app.services.dhcp.static_ipam import (
     remove_ipam_for_scope_statics,
 )
 from app.services.dhcp.windows_writethrough import push_scope_restore
-from app.services.dns.record_ops import push_record_restore
+from app.services.dns.record_ops import push_records_restore
 from app.services.soft_delete import (  # noqa: PLC2701 — canonical labels, keep in one place
     SOFT_DELETE_RESOURCE_TYPES,
     TYPE_TO_MODEL,
@@ -68,16 +68,19 @@ class TrashListResponse(BaseModel):
     total: int
 
 
-class RestoreResponse(BaseModel):
-    batch_id: uuid.UUID
-    restored: int
-
-
 class RestoreConflict(BaseModel):
     type: str
     id: str
     display: str
     reason: str
+
+
+class RestoreResponse(BaseModel):
+    batch_id: uuid.UUID
+    restored: int
+    # Rows left in the trash because a live duplicate exists — only ever
+    # non-empty with ``?skip_conflicts=true``; without it a conflict is a 409.
+    skipped: list[RestoreConflict] = []
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────
@@ -193,8 +196,15 @@ async def restore_row(
     row_id: uuid.UUID,
     db: DB,
     current_user: SuperAdmin,
+    skip_conflicts: bool = False,
 ) -> RestoreResponse:
-    """Restore a soft-deleted row and every sibling in its deletion batch."""
+    """Restore a soft-deleted row and every sibling in its deletion batch.
+
+    ``skip_conflicts`` restores every sibling that does NOT clash with a live
+    row and reports the ones left behind, instead of refusing the whole batch
+    — for a bulk record delete (#963), where one record re-created by hand
+    must not make the other N unrestorable.
+    """
 
     if type not in SOFT_DELETE_RESOURCE_TYPES:
         raise HTTPException(
@@ -221,8 +231,10 @@ async def restore_row(
     async def _check(obj: Any) -> str | None:
         return await default_conflict_check(db, obj)
 
-    restored, conflicts = await restore_batch(db, batch_id, conflict_check=_check)
-    if conflicts:
+    restored, conflicts = await restore_batch(
+        db, batch_id, conflict_check=_check, skip_conflicts=skip_conflicts
+    )
+    if conflicts and not skip_conflicts:
         raise HTTPException(
             status_code=409,
             detail={"message": "Restore would clash with active rows", "conflicts": conflicts},
@@ -240,6 +252,11 @@ async def restore_row(
     # teardown on soft-delete, to avoid cloud zone-ID / NS churn), so its
     # cascade-deleted records are still live there and need no re-push.
     restored_has_zone = any(isinstance(o, DNSZone) for o in restored)
+    # Records re-push per ZONE in one batch, not per record: a #963 bulk delete
+    # restores as one batch of N independent records, and N singular pushes
+    # would be N serial bumps and, on an agentless driver, N WinRM round trips
+    # inside one request — the cost the bulk-delete route exists to avoid.
+    records_by_zone: dict[uuid.UUID, list[DNSRecord]] = {}
     for obj in restored:
         if isinstance(obj, DHCPScope):
             await push_scope_restore(db, obj)
@@ -250,7 +267,7 @@ async def restore_row(
             # re-populates them.
             await remirror_scope_statics(db, obj)
         elif isinstance(obj, DNSRecord) and not restored_has_zone:
-            await push_record_restore(db, obj)
+            records_by_zone.setdefault(obj.zone_id, []).append(obj)
         db.add(
             AuditLog(
                 user_id=current_user.id,
@@ -265,14 +282,22 @@ async def restore_row(
             )
         )
 
+    for zone_id, recs in records_by_zone.items():
+        await push_records_restore(db, zone_id, recs)
+
     await db.commit()
     logger.info(
         "trash.restore",
         batch_id=str(batch_id),
         restored=len(restored),
+        skipped=len(conflicts),
         user_id=str(current_user.id),
     )
-    return RestoreResponse(batch_id=batch_id, restored=len(restored))
+    return RestoreResponse(
+        batch_id=batch_id,
+        restored=len(restored),
+        skipped=[RestoreConflict(**c) for c in conflicts],
+    )
 
 
 @router.delete("/trash/{type}/{row_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -131,6 +131,7 @@ from app.services.dns_io import (
 )
 from app.services.feature_modules import require_module
 from app.services.soft_delete import (
+    SoftDeleteBatch,
     apply_soft_delete,
     collect_soft_delete_batch,
 )
@@ -6506,6 +6507,11 @@ class BulkDeleteRecordsRequest(BaseModel):
 class BulkDeleteRecordsResponse(BaseModel):
     deleted: int
     skipped: list[dict[str, str]]  # each: {record_id, reason}
+    # Set on the default soft-delete path: every record in the batch shares
+    # it, so "undo that bulk delete" is ONE restore from /admin/trash (the
+    # per-record singular route cannot offer that). ``None`` when
+    # ``permanent=true`` — there is nothing to restore.
+    deletion_batch_id: uuid.UUID | None = None
 
 
 @router.post(
@@ -6518,6 +6524,7 @@ async def bulk_delete_records(
     body: BulkDeleteRecordsRequest,
     db: DB,
     current_user: CurrentUser,
+    permanent: bool = False,
 ) -> BulkDeleteRecordsResponse:
     """Delete many records from one zone in a single transaction.
 
@@ -6526,11 +6533,27 @@ async def bulk_delete_records(
     so agentless Windows DNS sees one WinRM round trip for the whole
     batch instead of one per record. BIND9 still writes N queued rows
     (the agent will batch-ship on its next poll).
+
+    Same contract as the singular ``DELETE .../records/{id}`` (#963): the
+    default is a **soft** delete — every record stamped with ONE shared
+    ``deletion_batch_id`` so the whole batch restores from /admin/trash in
+    one action — and ``?permanent=true`` is superadmin-only. Before #963
+    this route hard-deleted under a plain ``CurrentUser`` while the
+    singular route soft-deleted, so the same rows had two authorization
+    bars and two retention outcomes depending on which button was pressed.
+    Both paths push the wire retraction (#632) and both keep a row whose
+    wire delete came back ``failed``.
     """
     if not body.record_ids:
         return BulkDeleteRecordsResponse(deleted=0, skipped=[])
 
     zone = await _require_zone(group_id, zone_id, db, current_user)
+    if permanent:
+        # Gate BEFORE any wire op is enqueued: a 403 must leave nothing queued
+        # for the agent.
+        from app.api.deps import require_superadmin  # noqa: PLC0415
+
+        require_superadmin(current_user)
 
     res = await db.execute(select(DNSRecord).where(DNSRecord.id.in_(body.record_ids)))
     records = list(res.scalars().all())
@@ -6545,6 +6568,13 @@ async def bulk_delete_records(
             continue
         if rec.zone_id != zone_id:
             skipped.append({"record_id": str(rid), "reason": "wrong zone"})
+            continue
+        # Same gate the singular route applies: an integration-synthesised
+        # record is overwritten on the next sync, so deleting it is a no-op
+        # that reads as a success. Skip with the reason instead of 422-ing
+        # the whole batch.
+        if rec.tailscale_tenant_id is not None or rec.netbird_instance_id is not None:
+            skipped.append({"record_id": str(rid), "reason": "synthesised by an integration"})
             continue
         targets.append(rec)
 
@@ -6596,7 +6626,7 @@ async def bulk_delete_records(
     # zone skipped every record and returned ``deleted: 0`` while the
     # singular route deleted the same rows (appliance sizing campaign,
     # 2026-09-02).
-    deleted = 0
+    kept: list[DNSRecord] = []
     for rec, op_row in zip(targets, op_rows, strict=True):
         if op_row is None:
             skipped.append(
@@ -6614,23 +6644,53 @@ async def bulk_delete_records(
                 }
             )
             continue
+        kept.append(rec)
+
+    if permanent:
+        for rec in kept:
+            db.add(
+                AuditLog(
+                    user_id=current_user.id,
+                    user_display_name=current_user.display_name,
+                    auth_source=current_user.auth_source,
+                    action="delete",
+                    resource_type="dns_record",
+                    resource_id=str(rec.id),
+                    resource_display=rec.fqdn,
+                    result="success",
+                )
+            )
+            await db.delete(rec)
+        await db.commit()
+        return BulkDeleteRecordsResponse(deleted=len(kept), skipped=skipped)
+
+    # One batch id across the whole selection. ``collect_soft_delete_batch``
+    # mints a fresh id per root, so collect each record's cascade set and
+    # re-home the rows under a single batch before stamping.
+    batch = SoftDeleteBatch(batch_id=uuid.uuid4())
+    for rec in kept:
+        batch.rows.extend((await collect_soft_delete_batch(db, rec)).rows)
+    apply_soft_delete(batch, current_user.id)
+    for row in batch.rows:
         db.add(
             AuditLog(
                 user_id=current_user.id,
                 user_display_name=current_user.display_name,
                 auth_source=current_user.auth_source,
-                action="delete",
-                resource_type="dns_record",
-                resource_id=str(rec.id),
-                resource_display=rec.fqdn,
+                action="soft_delete",
+                resource_type=row.resource_type,
+                resource_id=str(row.obj.id),
+                resource_display=row.display,
+                old_value={"deletion_batch_id": str(batch.batch_id)},
                 result="success",
             )
         )
-        await db.delete(rec)
-        deleted += 1
-
     await db.commit()
-    return BulkDeleteRecordsResponse(deleted=deleted, skipped=skipped)
+    return BulkDeleteRecordsResponse(
+        deleted=len(kept),
+        skipped=skipped,
+        deletion_batch_id=batch.batch_id if kept else None,
+    )
 
 
 # Cap on records per bulk-create call. Keeps the single transaction (and the

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -19,7 +19,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy import update as sa_update
 from sqlalchemy.orm import selectinload
 
-from app.api.deps import DB, CurrentUser, SuperAdmin
+from app.api.deps import DB, CurrentUser, SuperAdmin, require_superadmin
 from app.api.pagination import (
     DEFAULT_PAGE_SIZE,
     MAX_PAGE,
@@ -6471,8 +6471,6 @@ async def delete_record(
         await db.commit()
         return
 
-    from app.api.deps import require_superadmin  # noqa: PLC0415
-
     require_superadmin(current_user)
 
     db.add(
@@ -6492,16 +6490,32 @@ async def delete_record(
     await db.commit()
 
 
+# Cap on ids per bulk-delete call — the bulk-create cap's twin. Each id costs
+# a wire op per agent-based server plus an audit row inside ONE transaction
+# that holds the zone's serial-bump row lock; callers with more loop in
+# chunks of this size (the UI does).
+BULK_DELETE_RECORDS_MAX = 2000
+
+
 class BulkDeleteRecordsRequest(BaseModel):
     """IDs of auto- or manually-created records to delete in one shot.
 
     All IDs must belong to the zone in the URL — cross-zone deletion
     isn't allowed here (the UI scopes bulk ops to a single zone). Any
     record ID that doesn't belong to the zone is skipped with a reason
-    so a partial payload doesn't fail the whole batch.
+    so a partial payload doesn't fail the whole batch. Duplicate ids count
+    once: ``[X, X]`` must not enqueue two ops, write two audit rows and
+    report ``deleted: 2`` for one row.
     """
 
     record_ids: list[uuid.UUID]
+
+    @field_validator("record_ids")
+    @classmethod
+    def _validate_record_ids(cls, v: list[uuid.UUID]) -> list[uuid.UUID]:
+        if len(v) > BULK_DELETE_RECORDS_MAX:
+            raise ValueError(f"at most {BULK_DELETE_RECORDS_MAX} record ids per bulk-delete call")
+        return list(dict.fromkeys(v))  # de-duplicate, order-preserving
 
 
 class BulkDeleteRecordsResponse(BaseModel):
@@ -6541,8 +6555,15 @@ async def bulk_delete_records(
     this route hard-deleted under a plain ``CurrentUser`` while the
     singular route soft-deleted, so the same rows had two authorization
     bars and two retention outcomes depending on which button was pressed.
-    Both paths push the wire retraction (#632) and both keep a row whose
-    wire delete came back ``failed``.
+    Both paths push the wire retraction (#632). A row whose wire delete came
+    back ``failed`` stays live — which only an agentless driver can answer
+    inline; an agent-based server queues ``pending`` and a later NACK marks
+    the op ``failed`` after the row is already in the trash (restorable) or
+    gone (permanent). Same window the singular route accepts.
+
+    No ``propose_*`` copilot tool for this route (explicit decision per
+    non-negotiable #13): a bulk delete is the broad-blast-radius shape that
+    guidance keeps off the chat window.
     """
     if not body.record_ids:
         return BulkDeleteRecordsResponse(deleted=0, skipped=[])
@@ -6551,8 +6572,6 @@ async def bulk_delete_records(
     if permanent:
         # Gate BEFORE any wire op is enqueued: a 403 must leave nothing queued
         # for the agent.
-        from app.api.deps import require_superadmin  # noqa: PLC0415
-
         require_superadmin(current_user)
 
     res = await db.execute(select(DNSRecord).where(DNSRecord.id.in_(body.record_ids)))
@@ -6569,12 +6588,15 @@ async def bulk_delete_records(
         if rec.zone_id != zone_id:
             skipped.append({"record_id": str(rid), "reason": "wrong zone"})
             continue
-        # Same gate the singular route applies: an integration-synthesised
-        # record is overwritten on the next sync, so deleting it is a no-op
-        # that reads as a success. Skip with the reason instead of 422-ing
-        # the whole batch.
-        if rec.tailscale_tenant_id is not None or rec.netbird_instance_id is not None:
-            skipped.append({"record_id": str(rid), "reason": "synthesised by an integration"})
+        # The singular route's gate, verbatim — Tailscale / NetBird synthesised
+        # records AND pool-managed ones. A pool member's record is re-created
+        # by the next health pass, which would then make the trashed copy
+        # unrestorable ("identical record already exists"). Skip with the
+        # gate's own reason instead of 422-ing the whole batch.
+        try:
+            _reject_if_synthesised_record(rec, "delete")
+        except HTTPException as exc:
+            skipped.append({"record_id": str(rid), "reason": str(exc.detail)})
             continue
         targets.append(rec)
 
@@ -6626,7 +6648,10 @@ async def bulk_delete_records(
     # zone skipped every record and returned ``deleted: 0`` while the
     # singular route deleted the same rows (appliance sizing campaign,
     # 2026-09-02).
-    kept: list[DNSRecord] = []
+    # Rows whose wire delete was DISPATCHED (queued or applied) — the ones
+    # about to leave the live table. Not "kept in the DB": that is the
+    # ``failed`` branch above.
+    dispatched: list[DNSRecord] = []
     for rec, op_row in zip(targets, op_rows, strict=True):
         if op_row is None:
             skipped.append(
@@ -6644,10 +6669,10 @@ async def bulk_delete_records(
                 }
             )
             continue
-        kept.append(rec)
+        dispatched.append(rec)
 
     if permanent:
-        for rec in kept:
+        for rec in dispatched:
             db.add(
                 AuditLog(
                     user_id=current_user.id,
@@ -6662,13 +6687,13 @@ async def bulk_delete_records(
             )
             await db.delete(rec)
         await db.commit()
-        return BulkDeleteRecordsResponse(deleted=len(kept), skipped=skipped)
+        return BulkDeleteRecordsResponse(deleted=len(dispatched), skipped=skipped)
 
     # One batch id across the whole selection. ``collect_soft_delete_batch``
     # mints a fresh id per root, so collect each record's cascade set and
     # re-home the rows under a single batch before stamping.
     batch = SoftDeleteBatch(batch_id=uuid.uuid4())
-    for rec in kept:
+    for rec in dispatched:
         batch.rows.extend((await collect_soft_delete_batch(db, rec)).rows)
     apply_soft_delete(batch, current_user.id)
     for row in batch.rows:
@@ -6687,9 +6712,9 @@ async def bulk_delete_records(
         )
     await db.commit()
     return BulkDeleteRecordsResponse(
-        deleted=len(kept),
+        deleted=len(dispatched),
         skipped=skipped,
-        deletion_batch_id=batch.batch_id if kept else None,
+        deletion_batch_id=batch.batch_id if dispatched else None,
     )
 
 

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -6432,9 +6432,18 @@ async def _apply_dns_sync(
             # Honor per-op state. A failed wire op must NOT remove the
             # DB row — otherwise the UI tells the user "deleted" but the
             # record is still published on the DNS server, and a later
-            # "Sync with server" pulls the zombie back into IPAM. Only
-            # state=="applied" (or a zone-less orphan with no wire op to
-            # begin with) is safe to delete locally.
+            # "Sync with server" pulls the zombie back into IPAM.
+            #
+            # Only ``failed`` blocks, though (#962 — the same defect #950
+            # fixed in the DNS bulk-delete route). Agent-based servers
+            # never answer inline: ``enqueue_record_ops_batch`` queues
+            # their rows as ``pending`` and the agent applies them on its
+            # next long-poll. Gating on ``!= "applied"`` reported every one
+            # of those as "wire delete failed — unknown" and kept the row,
+            # while the op still queued and the agent still removed the
+            # record from the served zone — so the next drift report
+            # listed it as missing-on-server and invited the operator to
+            # re-create the record they had just asked to delete.
             for r, op_row in zip(recs, op_rows, strict=True):
                 if op_row is None:
                     # No server in the zone's group will apply the op (no
@@ -6457,7 +6466,7 @@ async def _apply_dns_sync(
                     except Exception as exc:  # noqa: BLE001
                         errors.append(f"record {r.id}: {exc}")
                     continue
-                if op_row.state != "applied":
+                if op_row.state == "failed":
                     errors.append(
                         f"{r.record_type} {r.name}.{zone.name}: "
                         f"wire delete failed — {op_row.last_error or 'unknown'}"

--- a/backend/app/services/ai/operations_risky.py
+++ b/backend/app/services/ai/operations_risky.py
@@ -860,26 +860,20 @@ async def _apply_delete_zone(db: AsyncSession, user: User, args: DeleteZoneArgs)
     # campaign, 2026-09-02). ``dns_record.zone_id`` already cascades at the
     # FK, so delete the records in one statement and let the ORM cascade
     # find nothing left to load. The zone's queued record ops go with it
-    # (the sweep zone_move does): a ``pending``/``in_flight`` op for a zone
-    # that no longer exists would only fail on the agent and surface as a
-    # zombie on the next resync.
+    # (``sweep_zone_ops``, shared with zone_move): a ``pending``/``in_flight``
+    # op for a zone that no longer exists would only fail on the agent and
+    # surface as a zombie on the next resync.
     from sqlalchemy import delete as sa_delete
 
-    from app.models.dns import DNSRecord, DNSRecordOp, DNSServer
+    from app.models.dns import DNSRecord, DNSServer
+    from app.services.dns.record_ops import sweep_zone_ops
 
     group_server_ids = (
         (await db.execute(select(DNSServer.id).where(DNSServer.group_id == zone.group_id)))
         .scalars()
         .all()
     )
-    if group_server_ids:
-        await db.execute(
-            sa_delete(DNSRecordOp).where(
-                DNSRecordOp.server_id.in_(group_server_ids),
-                DNSRecordOp.zone_name == zone.name,
-                DNSRecordOp.state.in_(("pending", "in_flight")),
-            )
-        )
+    await sweep_zone_ops(db, zone, group_server_ids)
     await db.execute(sa_delete(DNSRecord).where(DNSRecord.zone_id == zone.id))
     await db.delete(zone)
     await db.commit()

--- a/backend/app/services/ai/operations_risky.py
+++ b/backend/app/services/ai/operations_risky.py
@@ -818,6 +818,15 @@ async def _apply_delete_zone(db: AsyncSession, user: User, args: DeleteZoneArgs)
     _reject_if_synthesised_zone(zone, "delete")
 
     if not args.permanent:
+        # Soft-delete is the moment the zone leaves the bundle, so it is the
+        # moment its queued ops become unapplyable: left behind, each one is
+        # shipped up to five times against a zone the agent no longer serves,
+        # then parks as ``failed`` forever (review of #964). Sweep here — the
+        # trash purge and permanent-delete-from-trash only ever see rows that
+        # came through this path.
+        from app.services.dns.record_ops import sweep_zone_ops  # noqa: PLC0415
+
+        await sweep_zone_ops(db, zone, zone.group_id)
         batch = await collect_soft_delete_batch(db, zone)
         apply_soft_delete(batch, user.id)
         for row in batch.rows:
@@ -865,15 +874,10 @@ async def _apply_delete_zone(db: AsyncSession, user: User, args: DeleteZoneArgs)
     # surface as a zombie on the next resync.
     from sqlalchemy import delete as sa_delete
 
-    from app.models.dns import DNSRecord, DNSServer
+    from app.models.dns import DNSRecord
     from app.services.dns.record_ops import sweep_zone_ops
 
-    group_server_ids = (
-        (await db.execute(select(DNSServer.id).where(DNSServer.group_id == zone.group_id)))
-        .scalars()
-        .all()
-    )
-    await sweep_zone_ops(db, zone, group_server_ids)
+    await sweep_zone_ops(db, zone, zone.group_id)
     await db.execute(sa_delete(DNSRecord).where(DNSRecord.zone_id == zone.id))
     await db.delete(zone)
     await db.commit()

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -53,6 +53,7 @@ from app.services.dns.pool_geo import (
     build_view_descriptors,
     records_for_view,
 )
+from app.services.dns.record_ops import QUEUED_OP_STATES
 from app.services.dns_blocklist import (
     build_effective_for_group,
     build_effective_for_view,
@@ -430,7 +431,7 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
                 await db.execute(
                     select(DNSRecordOp).where(
                         DNSRecordOp.server_id == server.id,
-                        DNSRecordOp.state.in_(("pending", "in_flight")),
+                        DNSRecordOp.state.in_(QUEUED_OP_STATES),
                     )
                 )
             )

--- a/backend/app/services/dns/record_ops.py
+++ b/backend/app/services/dns/record_ops.py
@@ -12,7 +12,6 @@ plane applies the change directly at enqueue time and writes the row as
 from __future__ import annotations
 
 import uuid
-from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import Any
 
@@ -37,8 +36,12 @@ logger = structlog.get_logger(__name__)
 QUEUED_OP_STATES: tuple[str, ...] = ("pending", "in_flight")
 
 
-def queued_zone_ops_where(zone: DNSZone, server_ids: Sequence[uuid.UUID]) -> list[Any]:
-    """WHERE clauses selecting the live (queued) ops for ``zone`` on ``server_ids``.
+def queued_zone_ops_where(zone: DNSZone, group_id: uuid.UUID) -> list[Any]:
+    """WHERE clauses selecting the live (queued) ops for ``zone`` on the servers
+    of ``group_id`` — every server, as a correlated subquery, so no caller has
+    to prefetch an id list (and none can pass a partial one: a sweep that
+    reaches only the primary leaves secondaries' queues behind, the fan-out
+    bug #934 fixed).
 
     **This predicate is name-scoped, and that is a decision, not an accident
     of the schema (#964).** ``DNSRecordOp`` carries ``server_id`` +
@@ -48,58 +51,54 @@ def queued_zone_ops_where(zone: DNSZone, server_ids: Sequence[uuid.UUID]) -> lis
     ``example.com.`` also discards ``external``'s queued ops on the same
     servers.
 
-    Why that is accepted rather than fixed with a view column: the op
-    *payload* carries no view either. An RFC 2136 update for ``example.com.``
-    lands in whichever view the agent's update source matches, so under
-    split-horizon the queued ops for two same-named zones are already
-    indistinguishable at the agent — what converges both views is the
-    ConfigBundle re-render, which rebuilds full zone state from the database
-    on the next drop. A discarded incremental op therefore costs delayed
-    convergence, never permanent divergence, on every agent-based driver; on
-    agentless drivers ops are applied inline and never sit queued, so the
-    sweep never matches them. A ``zone_id`` column would need a migration plus
-    a name-scoped fallback for every pre-upgrade row, i.e. this predicate
-    again, to buy back a window the bundle already closes.
+    Why that is accepted rather than fixed with a view column: under
+    split-horizon the incremental op path does not run at all. When a group
+    has views (or geo steering) ``agent_config.build_config_bundle`` folds
+    records INTO the structural fingerprint, so every record change is a full
+    view-correct re-render from the database — and it ships no
+    ``pending_record_ops``, retiring every queued op for the server as
+    ``applied`` on each bundle build instead. A sibling view's op the sweep
+    discards was therefore never going to reach ``nsupdate``: the over-sweep
+    costs nothing. In a flat group the same name cannot exist twice (the
+    create route 409s it), so the predicate is exact there. A ``zone_id``
+    column would need a migration plus a name-scoped fallback for every
+    pre-upgrade row, i.e. this predicate again, to guard a path that is
+    already bypassed.
 
     Every zone-scoped sweep and count goes through here so the decision lives
     in one place; ``tests/test_dns_record_ops_sweep.py`` pins both the
-    behaviour and that the call sites do not carry their own copy.
+    behaviour and that no other module carries its own copy.
     """
     return [
-        DNSRecordOp.server_id.in_(list(server_ids)),
+        DNSRecordOp.server_id.in_(select(DNSServer.id).where(DNSServer.group_id == group_id)),
         DNSRecordOp.zone_name == zone.name,
         DNSRecordOp.state.in_(QUEUED_OP_STATES),
     ]
 
 
-async def count_queued_zone_ops(
-    db: AsyncSession, zone: DNSZone, server_ids: Sequence[uuid.UUID]
-) -> int:
+async def count_queued_zone_ops(db: AsyncSession, zone: DNSZone, group_id: uuid.UUID) -> int:
     """How many queued ops :func:`sweep_zone_ops` would discard. See its caveat."""
-    if not server_ids:
-        return 0
     return int(
         (
             await db.execute(
                 select(func.count())
                 .select_from(DNSRecordOp)
-                .where(*queued_zone_ops_where(zone, server_ids))
+                .where(*queued_zone_ops_where(zone, group_id))
             )
         ).scalar_one()
     )
 
 
-async def sweep_zone_ops(db: AsyncSession, zone: DNSZone, server_ids: Sequence[uuid.UUID]) -> int:
-    """Discard the queued ops for ``zone`` on ``server_ids``; returns the count.
+async def sweep_zone_ops(db: AsyncSession, zone: DNSZone, group_id: uuid.UUID) -> int:
+    """Discard the queued ops for ``zone`` on ``group_id``'s servers; returns the count.
 
     Used when the ops can no longer apply: the zone is being permanently
-    deleted, or moved out of the group whose servers they target. Applied /
-    failed rows are history, not queued work, and are kept. Name-scoped — see
-    :func:`queued_zone_ops_where` for the split-horizon caveat (#964).
+    deleted, or moved out of the group whose servers they target (pass the
+    OLD group). Applied / failed rows are history, not queued work, and are
+    kept. Name-scoped — see :func:`queued_zone_ops_where` for the
+    split-horizon caveat (#964).
     """
-    if not server_ids:
-        return 0
-    res = await db.execute(sa_delete(DNSRecordOp).where(*queued_zone_ops_where(zone, server_ids)))
+    res = await db.execute(sa_delete(DNSRecordOp).where(*queued_zone_ops_where(zone, group_id)))
     return int(res.rowcount or 0)
 
 
@@ -443,6 +442,101 @@ async def push_record_restore(db: AsyncSession, record: DNSRecord) -> DNSRecordO
     )
 
 
+async def push_records_restore(
+    db: AsyncSession, zone_id: uuid.UUID, records: list[DNSRecord]
+) -> list[DNSRecordOp | None]:
+    """Batch form of :func:`push_record_restore`: one serial bump and one
+    :func:`enqueue_record_ops_batch` call for every restored record of a zone.
+    Same ``[]`` outcome when the zone cannot be resolved."""
+    if not records:
+        return []
+    zone = await db.get(DNSZone, zone_id)
+    if zone is None:
+        return []
+    target_serial = bump_zone_serial(zone)
+    ops = [
+        {"op": "create", "record": record_op_payload(r), "target_serial": target_serial}
+        for r in records
+    ]
+    return await enqueue_record_ops_batch(db, zone, ops)
+
+
+async def _fanout_agent_ops(
+    db: AsyncSession,
+    zone: DNSZone,
+    primary: DNSServer,
+    ops: list[dict[str, Any]],
+) -> list[DNSRecordOp | None]:
+    """Queue ``ops`` for every ENABLED agent-based server in the zone's group.
+
+    The one fan-out both batch entry points share. Resolves the server set
+    ONCE, stamps the RRsets ONCE (#773), inserts every row in one ``add_all``
+    + one flush, wakes the group once. Returns, per input op, the row created
+    for ``primary`` when it is among the enabled servers, else the first
+    enabled agent's row — the same truthy-when-dispatched contract as
+    :func:`enqueue_record_op` (#481), which is what lets a caller gate a DB
+    delete on "was a wire op dispatched?". ``[None] * len(ops)`` when every
+    agent-based server is disabled.
+
+    Before this helper ``enqueue_record_ops_batch`` looped the singular path
+    per op: two identical server SELECTs and a flush for EVERY record, i.e.
+    ~4,000 round trips for a 2,000-record bulk delete on a two-agent group,
+    all inside one transaction holding the zone's serial-bump row lock.
+    """
+    if not ops:
+        return []
+    agent_rows = (
+        (
+            await db.execute(
+                select(DNSServer)
+                .where(
+                    DNSServer.group_id == zone.group_id,
+                    DNSServer.is_enabled.is_(True),
+                )
+                .order_by(DNSServer.is_primary.desc(), DNSServer.created_at)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    agent_servers = [s for s in agent_rows if not is_agentless(s.driver)]
+    if not agent_servers:
+        logger.warning(
+            "record_op_batch_dropped_no_enabled_agent",
+            zone=zone.name,
+            group_id=str(zone.group_id),
+            count=len(ops),
+        )
+        return [None] * len(ops)
+    ops = [{**o, "record": dict(o["record"])} for o in ops]
+    await stamp_rrsets_for_ops(db, zone, ops)
+    # The row we hand back per op: the primary's if enabled, else the first
+    # enabled agent's (``agent_servers`` is ordered is_primary DESC).
+    returned = next((s for s in agent_servers if s.id == primary.id), agent_servers[0])
+    result: list[DNSRecordOp | None] = []
+    rows: list[DNSRecordOp] = []
+    for srv in agent_servers:
+        for o in ops:
+            row = DNSRecordOp(
+                server_id=srv.id,
+                zone_name=zone.name,
+                op=o["op"],
+                record=o["record"],
+                target_serial=o.get("target_serial"),
+                state="pending",
+            )
+            rows.append(row)
+            if srv.id == returned.id:
+                result.append(row)
+    db.add_all(rows)
+    await db.flush()
+    # #358 — wake every agent in the group so they drain the queued ops on the
+    # next poll instead of the belt-and-braces tick. Flushed after the outer
+    # commit by the request's ``wake_publishing`` dependency.
+    collect_wake(dns_group_channel(zone.group_id))
+    return result
+
+
 async def enqueue_record_ops_batch(
     db: AsyncSession,
     zone: DNSZone,
@@ -452,8 +546,8 @@ async def enqueue_record_ops_batch(
 
     Groups all ops for a single zone into one driver call when the zone's
     primary is agentless — cuts an N-record sync from N WinRM round trips
-    to one. Agent-based primaries fall through to the per-op path since
-    they queue in the DB and the agent batches at poll time.
+    to one. Agent-based groups fan out in one ``add_all`` + flush via
+    :func:`_fanout_agent_ops`, and the agent batches at poll time.
 
     ``ops`` is a list of ``{op, record, target_serial?}`` dicts matching
     the singular ``enqueue_record_op`` arg shape.
@@ -487,18 +581,12 @@ async def enqueue_record_ops_batch(
             return [None] * len(ops)
         return await _apply_agentless_batch(db, primary, zone, ops)
 
-    # Agent-based: DB rows only; agent will batch at poll time. Delegates to
-    # enqueue_record_op per op, which fans out to every ENABLED agent-based
-    # server regardless of whether the designated primary is disabled (#481).
-    # The RRsets are resolved for the whole batch first (#773) — one query
-    # instead of one per op, and every op at a shared (name, type) then carries
-    # the same complete set, so none of them depends on the order the agent
-    # drains them in.
-    ops = [{**o, "record": dict(o["record"])} for o in ops]
-    await stamp_rrsets_for_ops(db, zone, ops)
-    return [
-        await enqueue_record_op(db, zone, o["op"], o["record"], o.get("target_serial")) for o in ops
-    ]
+    # Agent-based: DB rows only; the agent batches at poll time. One fan-out
+    # to every ENABLED agent-based server regardless of whether the designated
+    # primary is disabled (#481), with the RRsets resolved for the whole batch
+    # first (#773) so every op at a shared (name, type) carries the same
+    # complete set whatever order the agent drains them in.
+    return await _fanout_agent_ops(db, zone, primary, ops)
 
 
 async def enqueue_record_ops_bulk(
@@ -508,12 +596,9 @@ async def enqueue_record_ops_bulk(
 ) -> int:
     """Enqueue many ops for a SINGLE zone with one server-set resolution.
 
-    The seeding / bulk-import fast-path. :func:`enqueue_record_ops_batch`
-    re-resolves the agent server list once *per op* (it loops the singular
-    path), which is fine for a handful of records but quadratic-feeling at
-    seed scale. This resolves the enabled agent-based servers once and inserts
-    all ``DNSRecordOp`` rows in a single ``add_all`` + flush; agentless
-    primaries delegate to the existing batched driver call.
+    The seeding / bulk-import fast-path: the same fan-out as
+    :func:`enqueue_record_ops_batch` but returning a count rather than per-op
+    rows, for callers that own idempotency and write one summary audit row.
 
     Returns the number of ops dispatched (0 if no enabled primary).
     """
@@ -544,51 +629,10 @@ async def enqueue_record_ops_bulk(
             return 0
         rows = await _apply_agentless_batch(db, primary, zone, ops)
         return sum(1 for r in rows if r is not None)
-    # Agent-based falls through: the fan-out below queues to every ENABLED
-    # agent-based server regardless of whether the primary is disabled (#481).
-
-    # Agent-based: every enabled agent-based server in the group renders an
-    # independent authoritative copy, so each needs its own op rows. Resolve
-    # the set ONCE (mirrors enqueue_record_op's fan-out query).
-    agent_rows = (
-        (
-            await db.execute(
-                select(DNSServer).where(
-                    DNSServer.group_id == zone.group_id,
-                    DNSServer.is_enabled.is_(True),
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
-    agent_servers = [s for s in agent_rows if not is_agentless(s.driver)]
-    if not agent_servers:
-        return 0
-    # #773 — one query resolves every touched RRset for the whole batch, so the
-    # seed/import fast-path stays a fast path.
-    ops = [{**o, "record": dict(o["record"])} for o in ops]
-    await stamp_rrsets_for_ops(db, zone, ops)
-    for srv in agent_servers:
-        db.add_all(
-            [
-                DNSRecordOp(
-                    server_id=srv.id,
-                    zone_name=zone.name,
-                    op=o["op"],
-                    record=o["record"],
-                    target_serial=o.get("target_serial"),
-                    state="pending",
-                )
-                for o in ops
-            ]
-        )
-    await db.flush()
-    # #358 — wake every agent in the group so they drain the queued ops on the
-    # next poll instead of the belt-and-braces tick. Flushed after the outer
-    # commit by the request's ``wake_publishing`` dependency.
-    collect_wake(dns_group_channel(zone.group_id))
-    return len(ops)
+    # Agent-based: same fan-out as the batch path — every enabled agent-based
+    # server, resolved once, one add_all + flush (#481 semantics included).
+    rows = await _fanout_agent_ops(db, zone, primary, ops)
+    return sum(1 for r in rows if r is not None)
 
 
 async def _apply_agentless_batch(

--- a/backend/app/services/dns/record_ops.py
+++ b/backend/app/services/dns/record_ops.py
@@ -11,12 +11,14 @@ plane applies the change directly at enqueue time and writes the row as
 
 from __future__ import annotations
 
+import uuid
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import Any
 
 import structlog
 from sqlalchemy import delete as sa_delete
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.agent_wake import collect_wake, dns_group_channel
@@ -27,6 +29,78 @@ from app.services.dns.rrset import stamp_rrsets_for_ops
 from app.services.dns.serial import bump_zone_serial
 
 logger = structlog.get_logger(__name__)
+
+
+# Queued-op states. ``in_flight`` is queued work too: an op already shipped is
+# not finished with — ``ack_op`` returns a NACKed one to ``pending`` — so any
+# sweep of a zone's queue must cover both (the #934 review finding).
+QUEUED_OP_STATES: tuple[str, ...] = ("pending", "in_flight")
+
+
+def queued_zone_ops_where(zone: DNSZone, server_ids: Sequence[uuid.UUID]) -> list[Any]:
+    """WHERE clauses selecting the live (queued) ops for ``zone`` on ``server_ids``.
+
+    **This predicate is name-scoped, and that is a decision, not an accident
+    of the schema (#964).** ``DNSRecordOp`` carries ``server_id`` +
+    ``zone_name`` and no view discriminator, while ``DNSZone`` is unique on
+    ``(group_id, view_id, name)`` — so under split-horizon (#24) the same name
+    legitimately exists twice in one group, and a sweep for ``internal``'s
+    ``example.com.`` also discards ``external``'s queued ops on the same
+    servers.
+
+    Why that is accepted rather than fixed with a view column: the op
+    *payload* carries no view either. An RFC 2136 update for ``example.com.``
+    lands in whichever view the agent's update source matches, so under
+    split-horizon the queued ops for two same-named zones are already
+    indistinguishable at the agent — what converges both views is the
+    ConfigBundle re-render, which rebuilds full zone state from the database
+    on the next drop. A discarded incremental op therefore costs delayed
+    convergence, never permanent divergence, on every agent-based driver; on
+    agentless drivers ops are applied inline and never sit queued, so the
+    sweep never matches them. A ``zone_id`` column would need a migration plus
+    a name-scoped fallback for every pre-upgrade row, i.e. this predicate
+    again, to buy back a window the bundle already closes.
+
+    Every zone-scoped sweep and count goes through here so the decision lives
+    in one place; ``tests/test_dns_record_ops_sweep.py`` pins both the
+    behaviour and that the call sites do not carry their own copy.
+    """
+    return [
+        DNSRecordOp.server_id.in_(list(server_ids)),
+        DNSRecordOp.zone_name == zone.name,
+        DNSRecordOp.state.in_(QUEUED_OP_STATES),
+    ]
+
+
+async def count_queued_zone_ops(
+    db: AsyncSession, zone: DNSZone, server_ids: Sequence[uuid.UUID]
+) -> int:
+    """How many queued ops :func:`sweep_zone_ops` would discard. See its caveat."""
+    if not server_ids:
+        return 0
+    return int(
+        (
+            await db.execute(
+                select(func.count())
+                .select_from(DNSRecordOp)
+                .where(*queued_zone_ops_where(zone, server_ids))
+            )
+        ).scalar_one()
+    )
+
+
+async def sweep_zone_ops(db: AsyncSession, zone: DNSZone, server_ids: Sequence[uuid.UUID]) -> int:
+    """Discard the queued ops for ``zone`` on ``server_ids``; returns the count.
+
+    Used when the ops can no longer apply: the zone is being permanently
+    deleted, or moved out of the group whose servers they target. Applied /
+    failed rows are history, not queued work, and are kept. Name-scoped — see
+    :func:`queued_zone_ops_where` for the split-horizon caveat (#964).
+    """
+    if not server_ids:
+        return 0
+    res = await db.execute(sa_delete(DNSRecordOp).where(*queued_zone_ops_where(zone, server_ids)))
+    return int(res.rowcount or 0)
 
 
 async def resolve_primary_server(db: AsyncSession, zone: DNSZone) -> DNSServer | None:

--- a/backend/app/services/dns/server_move.py
+++ b/backend/app/services/dns/server_move.py
@@ -52,6 +52,7 @@ from app.models.dns import (
     DNSServerGroup,
     DNSServerZoneState,
 )
+from app.services.dns.record_ops import QUEUED_OP_STATES
 from app.services.dns.tsig import ensure_group_tsig_key
 
 logger = structlog.get_logger(__name__)
@@ -222,7 +223,7 @@ async def move_server_to_group(
         await db.execute(
             sa_delete(DNSRecordOp).where(
                 DNSRecordOp.server_id == server.id,
-                DNSRecordOp.state.in_(("pending", "in_flight")),
+                DNSRecordOp.state.in_(QUEUED_OP_STATES),
             )
         )
     ).rowcount or 0

--- a/backend/app/services/dns/zone_move.py
+++ b/backend/app/services/dns/zone_move.py
@@ -45,7 +45,6 @@ from app.models.dns import (
     DNSKey,
     DNSPool,
     DNSRecord,
-    DNSRecordOp,
     DNSServer,
     DNSServerGroup,
     DNSServerZoneState,
@@ -56,7 +55,11 @@ from app.models.dns import (
 )
 from app.services.dns.named_conf_validation import is_name_reference
 from app.services.dns.pool_geo import build_geo_steering
-from app.services.dns.record_ops import clear_dnssec_key_state
+from app.services.dns.record_ops import (
+    clear_dnssec_key_state,
+    count_queued_zone_ops,
+    sweep_zone_ops,
+)
 from app.services.dns.tsig import ensure_group_tsig_key
 
 logger = structlog.get_logger(__name__)
@@ -464,20 +467,18 @@ async def _count_pending_ops(db: AsyncSession, zone: DNSZone) -> int:
 
     Keyed by ``(server_id, zone_name)`` rather than by zone id — that is
     how ``DNSRecordOp`` is shaped — so it is scoped to the source group's
-    servers to avoid touching an identically-named zone's ops elsewhere.
+    servers. Within the group it is name-scoped, which under split-horizon
+    also counts a sibling view's same-named zone: see
+    ``record_ops.queued_zone_ops_where`` for why that is accepted (#964).
     """
-    return len(
-        (
-            await db.execute(
-                select(DNSRecordOp.id)
-                .join(DNSServer, DNSServer.id == DNSRecordOp.server_id)
-                .where(
-                    DNSServer.group_id == zone.group_id,
-                    DNSRecordOp.zone_name == zone.name,
-                    DNSRecordOp.state.in_(("pending", "in_flight")),
-                )
-            )
-        ).all()
+    return await count_queued_zone_ops(db, zone, await _group_server_ids(db, zone.group_id))
+
+
+async def _group_server_ids(db: AsyncSession, group_id: uuid.UUID) -> list[uuid.UUID]:
+    return list(
+        (await db.execute(select(DNSServer.id).where(DNSServer.group_id == group_id)))
+        .scalars()
+        .all()
     )
 
 
@@ -741,19 +742,7 @@ async def commit_move(
 
     # ── Purge state belonging to the old group ────────────────────────
     await db.execute(sa_delete(DNSServerZoneState).where(DNSServerZoneState.zone_id == zone.id))
-    old_server_ids = (
-        (await db.execute(select(DNSServer.id).where(DNSServer.group_id == old_group_id)))
-        .scalars()
-        .all()
-    )
-    if old_server_ids:
-        await db.execute(
-            sa_delete(DNSRecordOp).where(
-                DNSRecordOp.server_id.in_(old_server_ids),
-                DNSRecordOp.zone_name == zone.name,
-                DNSRecordOp.state.in_(("pending", "in_flight")),
-            )
-        )
+    await sweep_zone_ops(db, zone, await _group_server_ids(db, old_group_id))
     # DNSSEC key state is a read-only mirror of what the OLD group's agents
     # reported. The target signs from scratch, so leaving it would show the
     # operator keys that no server holds — and, worse, a cached

--- a/backend/app/services/dns/zone_move.py
+++ b/backend/app/services/dns/zone_move.py
@@ -471,15 +471,7 @@ async def _count_pending_ops(db: AsyncSession, zone: DNSZone) -> int:
     also counts a sibling view's same-named zone: see
     ``record_ops.queued_zone_ops_where`` for why that is accepted (#964).
     """
-    return await count_queued_zone_ops(db, zone, await _group_server_ids(db, zone.group_id))
-
-
-async def _group_server_ids(db: AsyncSession, group_id: uuid.UUID) -> list[uuid.UUID]:
-    return list(
-        (await db.execute(select(DNSServer.id).where(DNSServer.group_id == group_id)))
-        .scalars()
-        .all()
-    )
+    return await count_queued_zone_ops(db, zone, zone.group_id)
 
 
 def _fill_warnings(plan: ZoneMovePlan) -> None:
@@ -742,7 +734,7 @@ async def commit_move(
 
     # ── Purge state belonging to the old group ────────────────────────
     await db.execute(sa_delete(DNSServerZoneState).where(DNSServerZoneState.zone_id == zone.id))
-    await sweep_zone_ops(db, zone, await _group_server_ids(db, old_group_id))
+    await sweep_zone_ops(db, zone, old_group_id)
     # DNSSEC key state is a read-only mirror of what the OLD group's agents
     # reported. The target signs from scratch, so leaving it would show the
     # operator keys that no server holds — and, worse, a cached

--- a/backend/app/services/soft_delete.py
+++ b/backend/app/services/soft_delete.py
@@ -220,6 +220,27 @@ def apply_soft_delete(batch: SoftDeleteBatch, user_id: uuid.UUID | None) -> date
     return now
 
 
+async def batch_resource_types(db: AsyncSession, batch_id: uuid.UUID) -> set[str]:
+    """Which resource types a deletion batch holds.
+
+    Lets a caller tell a FLAT batch of independent siblings (a #963 bulk
+    record delete — every row a ``dns_record``) from a CASCADE batch (a zone
+    and its records, a scope and its pools), which is the difference between
+    a partial restore being safe and it leaving a dangling child.
+    """
+    types: set[str] = set()
+    for resource_type, model in TYPE_TO_MODEL.items():
+        stmt: Any = (
+            select(model.id)
+            .where(model.deletion_batch_id == batch_id)
+            .limit(1)
+            .execution_options(include_deleted=True)
+        )
+        if (await db.execute(stmt)).first() is not None:
+            types.add(resource_type)
+    return types
+
+
 async def restore_batch(
     db: AsyncSession,
     batch_id: uuid.UUID,

--- a/backend/app/services/soft_delete.py
+++ b/backend/app/services/soft_delete.py
@@ -225,11 +225,17 @@ async def restore_batch(
     batch_id: uuid.UUID,
     *,
     conflict_check: Callable[[Any], Awaitable[str | None]] | None = None,
+    skip_conflicts: bool = False,
 ) -> tuple[list[Any], list[dict[str, str]]]:
     """Restore every row sharing ``batch_id``.
 
-    Returns ``(restored_objs, conflicts)``. When ``conflicts`` is non-empty
-    the caller should roll back and 409 with the conflict list.
+    Returns ``(restored_objs, conflicts)``. By default a non-empty
+    ``conflicts`` means NOTHING was restored and the caller should 409 with
+    the list — right for a cascade batch (a zone with a hole is worse than a
+    refusal). With ``skip_conflicts`` the conflicting rows are left in the
+    trash and every other row is restored — the shape a bulk record delete
+    (#963) needs, where the rows are independent siblings and one hand-made
+    duplicate must not pin the other N in the trash forever.
     """
 
     restored: list[Any] = []
@@ -260,7 +266,7 @@ async def restore_batch(
                     continue
             restored.append(obj)
 
-    if conflicts:
+    if conflicts and not skip_conflicts:
         return [], conflicts
 
     for obj in restored:
@@ -268,7 +274,7 @@ async def restore_batch(
         obj.deleted_by_user_id = None
         obj.deletion_batch_id = None
 
-    return restored, []
+    return restored, conflicts
 
 
 async def default_conflict_check(db: AsyncSession, obj: Any) -> str | None:

--- a/backend/app/tasks/trash_purge.py
+++ b/backend/app/tasks/trash_purge.py
@@ -205,6 +205,7 @@ async def _purge_dns_zones(db: Any, cutoff: datetime) -> tuple[int, int]:
     separately.
     """
     from app.api.v1.dns.router import _push_zone_to_agentless_servers  # noqa: PLC0415
+    from app.services.dns.record_ops import sweep_zone_ops  # noqa: PLC0415
 
     res = await db.execute(
         select(DNSZone)
@@ -229,6 +230,10 @@ async def _purge_dns_zones(db: Any, cutoff: datetime) -> tuple[int, int]:
                 hint="left soft-deleted; next daily sweep retries the provider push",
             )
             continue
+        # Ops queued before the soft-delete started sweeping them (#964 review)
+        # have no zone FK to cascade through; sweep defensively so a pre-fix
+        # trash row does not leave a failed queue behind.
+        await sweep_zone_ops(db, zone, zone.group_id)
         # Core DELETE (not ORM ``db.delete``) — leans on the DB-level FK ON
         # DELETE CASCADE to remove this zone's still-present soft-deleted records
         # (they were excluded from the record pass precisely so they'd ride this

--- a/backend/tests/test_ci_backend_relevant.py
+++ b/backend/tests/test_ci_backend_relevant.py
@@ -151,6 +151,12 @@ def test_must_run_carveouts_run_the_suite(path: str, why: str) -> None:
         "frontend/package.json",
         "charts/spatiumddi/values.yaml",
         "k8s/base/api.yaml",
+        # #968 — perf/ has its own Perf — Tests job; before it was denied a
+        # perf-only PR ran all 8 backend shards (PR #955, measured).
+        "perf/generators/orchestrator/relay_sockets.py",
+        "perf/generators/orchestrator/tests/test_relay_sockets.py",
+        "perf/requirements.txt",
+        "perf/README.md",
         "CHANGELOG.md",
         "README.md",
         "CLAUDE.md",
@@ -217,7 +223,9 @@ def test_an_empty_change_set_runs_the_suite() -> None:
     [
         "terraform/main.tf",
         "ansible/playbook.yml",
-        "perf/locustfile.py",
+        # (``perf/locustfile.py`` used to sit here as the example of an
+        # unrecognised subtree — #968 made perf/ a recognised, denied one.)
+        "loadtest/locustfile.py",
         "some-new-top-level-thing/x.py",
         "Makefile",
         "docker-compose.yml",

--- a/backend/tests/test_dns_agentless_soft_delete_632.py
+++ b/backend/tests/test_dns_agentless_soft_delete_632.py
@@ -53,6 +53,18 @@ class _RecordingDriver:
     async def apply_record_change(self, _server: Any, change: Any) -> None:
         self.changes.append((change.op, change.record.name, change.record.record_type))
 
+    async def apply_record_changes(self, server: Any, changes: list[Any]) -> list[Any]:
+        # The batched entry point every real driver has (the ABC default loops
+        # the singular one); the trash restore re-pushes a zone's records
+        # through it in one call (#963 review).
+        from app.drivers.dns.base import RecordChangeResult
+
+        results = []
+        for change in changes:
+            await self.apply_record_change(server, change)
+            results.append(RecordChangeResult(ok=True))
+        return results
+
 
 def _patch_record_driver(monkeypatch: pytest.MonkeyPatch) -> _RecordingDriver:
     """Route every agentless record push through one recorder (the seam

--- a/backend/tests/test_dns_bulk_delete_soft_963.py
+++ b/backend/tests/test_dns_bulk_delete_soft_963.py
@@ -228,7 +228,7 @@ async def test_failed_wire_delete_keeps_the_row_on_the_soft_path(
 ) -> None:
     """A server that REJECTED the delete still serves the record; trashing the
     row would tell the operator it is gone. Same rule as #951's permanent path."""
-    import app.api.v1.dns.router as dns_router
+    from app.api.v1.dns import router as dns_router
 
     headers = await _user(db_session, superadmin=False)
     _server, zone = await _agent_zone(db_session)
@@ -289,9 +289,9 @@ async def test_duplicate_ids_count_once_and_the_batch_is_capped(
     )
     assert len(audits) == 1
 
-    from app.api.v1.dns.router import BULK_DELETE_RECORDS_MAX
+    from app.api.v1.dns import router as dns_router
 
-    too_many = [str(uuid.uuid4()) for _ in range(BULK_DELETE_RECORDS_MAX + 1)]
+    too_many = [str(uuid.uuid4()) for _ in range(dns_router.BULK_DELETE_RECORDS_MAX + 1)]
     resp = await client.post(_url(zone), headers=headers, json={"record_ids": too_many})
     assert resp.status_code == 422, resp.text
 
@@ -379,3 +379,39 @@ async def test_bulk_batch_restores_together_and_skip_conflicts_leaves_only_the_d
     creates = [o for o in await _ops(db_session, server_id) if o.op == "create"]
     assert len(creates) == 2
     assert len({o.target_serial for o in creates}) == 1
+
+
+@pytest.mark.asyncio
+async def test_skip_conflicts_is_refused_on_a_cascade_batch(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A zone's batch holds the zone AND its records. Skipping a row there can
+    restore a child whose parent stayed deleted — records pointing at a
+    soft-deleted zone, hidden by the zone's own filter and re-pushed to the
+    provider as if live. Only a flat batch of independent siblings (a bulk
+    record delete) may be partially restored."""
+    headers = await _user(db_session, superadmin=True)
+    _server, zone = await _agent_zone(db_session)
+    ids = await _records(db_session, zone, 2)
+    group_id, zone_id = zone.group_id, zone.id
+    await db_session.commit()
+
+    resp = await client.delete(f"/api/v1/dns/groups/{group_id}/zones/{zone_id}", headers=headers)
+    assert resp.status_code == 204, resp.text
+    rows = await _rows_including_deleted(db_session, ids)
+    batch_ids = {r.deletion_batch_id for r in rows}
+    assert len(batch_ids) == 1 and None not in batch_ids, "records ride the zone's batch"
+
+    restore = f"/api/v1/admin/trash/dns_record/{ids[0]}/restore"
+    resp = await client.post(f"{restore}?skip_conflicts=true", headers=headers)
+    assert resp.status_code == 422, resp.text
+    assert "dns_zone" in resp.json()["detail"], resp.text
+    # Nothing was restored on the way to the refusal.
+    rows = await _rows_including_deleted(db_session, ids)
+    assert all(r.deleted_at is not None for r in rows)
+
+    # The whole-batch restore still works — that is the supported path here.
+    resp = await client.post(restore, headers=headers)
+    assert resp.status_code == 200, resp.text
+    rows = await _rows_including_deleted(db_session, ids)
+    assert all(r.deleted_at is None for r in rows)

--- a/backend/tests/test_dns_bulk_delete_soft_963.py
+++ b/backend/tests/test_dns_bulk_delete_soft_963.py
@@ -254,3 +254,128 @@ async def test_failed_wire_delete_keeps_the_row_on_the_soft_path(
     rows = {r.id: r for r in await _rows_including_deleted(db_session, ids)}
     assert rows[ids[0]].deleted_at is None
     assert rows[ids[1]].deleted_at is not None
+
+
+# ── review findings on #963 ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_duplicate_ids_count_once_and_the_batch_is_capped(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _user(db_session, superadmin=False)
+    server, zone = await _agent_zone(db_session)
+    server_id = server.id
+    ids = await _records(db_session, zone, 1)
+    await db_session.commit()
+
+    resp = await client.post(
+        _url(zone), headers=headers, json={"record_ids": [str(ids[0]), str(ids[0])]}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["deleted"] == 1, resp.json()
+    # One op, one audit row — not two of each for one row.
+    assert len(await _ops(db_session, server_id)) == 1
+    audits = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(
+                    AuditLog.action == "soft_delete", AuditLog.resource_id == str(ids[0])
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 1
+
+    from app.api.v1.dns.router import BULK_DELETE_RECORDS_MAX
+
+    too_many = [str(uuid.uuid4()) for _ in range(BULK_DELETE_RECORDS_MAX + 1)]
+    resp = await client.post(_url(zone), headers=headers, json={"record_ids": too_many})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_pool_managed_record_is_skipped_like_the_singular_route(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The singular route 422s a pool member's record; the bulk route skips it
+    with that reason. Trashing it would let the next health pass re-create the
+    record and make the trashed copy unrestorable."""
+    from app.models.dns import DNSPool, DNSPoolMember
+
+    headers = await _user(db_session, superadmin=False)
+    _server, zone = await _agent_zone(db_session)
+    ids = await _records(db_session, zone, 2)
+    pool = DNSPool(group_id=zone.group_id, zone_id=zone.id, name="p", record_name="svc")
+    db_session.add(pool)
+    await db_session.flush()
+    member = DNSPoolMember(pool_id=pool.id, address="10.9.9.9")
+    db_session.add(member)
+    await db_session.flush()
+    rec = await db_session.get(DNSRecord, ids[0])
+    assert rec is not None
+    rec.pool_member_id = member.id
+    await db_session.commit()
+
+    resp = await client.post(
+        _url(zone), headers=headers, json={"record_ids": [str(i) for i in ids]}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["deleted"] == 1, body
+    assert [s["record_id"] for s in body["skipped"]] == [str(ids[0])]
+    assert "pool" in body["skipped"][0]["reason"].lower()
+    rows = {r.id: r for r in await _rows_including_deleted(db_session, ids)}
+    assert rows[ids[0]].deleted_at is None
+    assert rows[ids[1]].deleted_at is not None
+
+
+@pytest.mark.asyncio
+async def test_bulk_batch_restores_together_and_skip_conflicts_leaves_only_the_duplicate(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """One batch id makes the bulk delete one restore — and a record the
+    operator re-created by hand must not pin the other N in the trash."""
+    headers = await _user(db_session, superadmin=True)
+    server, zone = await _agent_zone(db_session)
+    server_id, zone_id = server.id, zone.id
+    ids = await _records(db_session, zone, 3)
+    await db_session.commit()
+
+    resp = await client.post(
+        _url(zone), headers=headers, json={"record_ids": [str(i) for i in ids]}
+    )
+    assert resp.status_code == 200, resp.text
+    # Hand-recreate the first record while the batch sits in the trash.
+    trashed = await _rows_including_deleted(db_session, ids)
+    first = next(r for r in trashed if r.id == ids[0])
+    db_session.add(
+        DNSRecord(
+            zone_id=zone_id,
+            name=first.name,
+            fqdn=first.fqdn,
+            record_type=first.record_type,
+            value=first.value,
+        )
+    )
+    await db_session.commit()
+
+    restore = f"/api/v1/admin/trash/dns_record/{ids[1]}/restore"
+    resp = await client.post(restore, headers=headers)
+    assert resp.status_code == 409, resp.text  # default: all-or-nothing, as before
+
+    resp = await client.post(f"{restore}?skip_conflicts=true", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["restored"] == 2, body
+    assert [s["id"] for s in body["skipped"]] == [str(ids[0])]
+    rows = {r.id: r for r in await _rows_including_deleted(db_session, ids)}
+    assert rows[ids[0]].deleted_at is not None
+    assert rows[ids[1]].deleted_at is None and rows[ids[2]].deleted_at is None
+    # The re-push went out as ONE batch: one create op per restored record,
+    # all carrying the same target serial (one bump, not one per record).
+    creates = [o for o in await _ops(db_session, server_id) if o.op == "create"]
+    assert len(creates) == 2
+    assert len({o.target_serial for o in creates}) == 1

--- a/backend/tests/test_dns_bulk_delete_soft_963.py
+++ b/backend/tests/test_dns_bulk_delete_soft_963.py
@@ -1,0 +1,256 @@
+"""#963 — bulk-delete records shares the singular route's contract.
+
+Before: ``POST .../records/bulk-delete`` hard-deleted under a plain
+``CurrentUser`` while ``DELETE .../records/{id}`` soft-deleted by default and
+required superadmin for ``?permanent=true``. #951 made the bulk route work on
+agent-based zones (the default deployment shape), which is when the asymmetry
+started to matter: a DNS editor selecting rows in the grid permanently
+destroyed records the singular route would have put in the trash.
+
+Now: default is a soft delete under ONE ``deletion_batch_id`` (so the whole
+selection restores together), ``permanent=true`` is superadmin-only, and the
+403 fires before any wire op is enqueued.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.audit import AuditLog
+from app.models.auth import Group, Role, User
+from app.models.dns import DNSRecord, DNSRecordOp, DNSServer, DNSServerGroup, DNSZone
+
+
+async def _user(db: AsyncSession, *, superadmin: bool) -> dict[str, str]:
+    tag = uuid.uuid4().hex[:8]
+    user = User(
+        username=f"bd-{tag}",
+        email=f"{tag}@example.test",
+        display_name="Bulk Delete",
+        hashed_password=hash_password("x"),
+        is_superadmin=superadmin,
+    )
+    if not superadmin:
+        # A DNS Editor: every action on the three DNS resource types, and
+        # nothing else. NOT the ``{"*", "*"}`` wildcard — ``require_superadmin``
+        # admits that as an *effective* superadmin (LDAP/OIDC users mapped to a
+        # Superadmin-role group), which is exactly the bar this route must hold.
+        role = Role(
+            name=f"r-{tag}",
+            description="",
+            permissions=[
+                {"action": "*", "resource_type": rt}
+                for rt in ("dns_group", "dns_zone", "dns_record")
+            ],
+        )
+        group = Group(name=f"g-{tag}", description="")
+        group.roles = [role]
+        group.users = [user]
+        db.add_all([role, group])
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def _agent_zone(db: AsyncSession) -> tuple[DNSServer, DNSZone]:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    server = DNSServer(
+        group_id=grp.id,
+        driver="bind9",
+        host="10.0.0.1",
+        name=f"srv-{uuid.uuid4().hex[:6]}",
+        is_primary=True,
+        is_enabled=True,
+    )
+    db.add(server)
+    await db.flush()
+    zone = DNSZone(
+        group_id=grp.id,
+        name=f"z{uuid.uuid4().hex[:6]}.example.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.example.",
+        admin_email="admin.example.",
+    )
+    db.add(zone)
+    await db.flush()
+    return server, zone
+
+
+async def _records(db: AsyncSession, zone: DNSZone, n: int) -> list[uuid.UUID]:
+    rows = [
+        DNSRecord(
+            zone_id=zone.id,
+            name=f"h{i}",
+            fqdn=f"h{i}.{zone.name}",
+            record_type="A",
+            value=f"10.1.0.{i + 1}",
+        )
+        for i in range(n)
+    ]
+    db.add_all(rows)
+    await db.flush()
+    return [r.id for r in rows]
+
+
+def _url(zone: DNSZone, *, permanent: bool = False) -> str:
+    base = f"/api/v1/dns/groups/{zone.group_id}/zones/{zone.id}/records/bulk-delete"
+    return f"{base}?permanent=true" if permanent else base
+
+
+async def _rows_including_deleted(db: AsyncSession, ids: list[uuid.UUID]) -> list[DNSRecord]:
+    db.expire_all()
+    return list(
+        (
+            await db.execute(
+                select(DNSRecord)
+                .where(DNSRecord.id.in_(ids))
+                .execution_options(include_deleted=True)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def _ops(db: AsyncSession, server_id: uuid.UUID) -> list[DNSRecordOp]:
+    return list(
+        (await db.execute(select(DNSRecordOp).where(DNSRecordOp.server_id == server_id)))
+        .scalars()
+        .all()
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_is_one_soft_delete_batch_with_wire_retraction(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _user(db_session, superadmin=False)
+    server, zone = await _agent_zone(db_session)
+    server_id = server.id
+    ids = await _records(db_session, zone, 3)
+    await db_session.commit()
+
+    resp = await client.post(
+        _url(zone), headers=headers, json={"record_ids": [str(i) for i in ids]}
+    )
+    assert resp.status_code == 200, resp.text
+    body: dict[str, Any] = resp.json()
+    assert body["deleted"] == 3 and body["skipped"] == [], body
+    batch_id = body["deletion_batch_id"]
+    assert batch_id is not None
+
+    rows = await _rows_including_deleted(db_session, ids)
+    assert len(rows) == 3, "soft delete must keep the rows"
+    assert all(r.deleted_at is not None for r in rows)
+    # ONE batch id across the selection — that is what makes "undo that bulk
+    # delete" a single restore from /admin/trash.
+    assert {str(r.deletion_batch_id) for r in rows} == {batch_id}
+    # Hidden from the default read, like every other soft-deleted row.
+    db_session.expire_all()
+    visible = (await db_session.execute(select(DNSRecord).where(DNSRecord.id.in_(ids)))).scalars()
+    assert list(visible) == []
+
+    # The retraction still reaches the agent (#632): one queued delete per record.
+    ops = await _ops(db_session, server_id)
+    assert sorted(o.op for o in ops) == ["delete"] * 3
+    assert {o.state for o in ops} == {"pending"}
+
+    audits = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(
+                    AuditLog.resource_type == "dns_record",
+                    AuditLog.resource_id.in_([str(i) for i in ids]),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {a.action for a in audits} == {"soft_delete"}
+    assert {a.old_value["deletion_batch_id"] for a in audits} == {batch_id}
+
+
+@pytest.mark.asyncio
+async def test_permanent_requires_superadmin_and_queues_nothing_on_refusal(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _user(db_session, superadmin=False)
+    server, zone = await _agent_zone(db_session)
+    server_id = server.id
+    ids = await _records(db_session, zone, 2)
+    await db_session.commit()
+
+    resp = await client.post(
+        _url(zone, permanent=True), headers=headers, json={"record_ids": [str(i) for i in ids]}
+    )
+    assert resp.status_code == 403, resp.text
+    rows = await _rows_including_deleted(db_session, ids)
+    assert len(rows) == 2 and all(r.deleted_at is None for r in rows)
+    # The gate ran before dispatch: nothing sits in the agent's queue.
+    assert await _ops(db_session, server_id) == []
+
+
+@pytest.mark.asyncio
+async def test_permanent_as_superadmin_hard_deletes(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _user(db_session, superadmin=True)
+    server, zone = await _agent_zone(db_session)
+    server_id = server.id
+    ids = await _records(db_session, zone, 2)
+    await db_session.commit()
+
+    resp = await client.post(
+        _url(zone, permanent=True), headers=headers, json={"record_ids": [str(i) for i in ids]}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["deleted"] == 2 and body["deletion_batch_id"] is None, body
+    assert await _rows_including_deleted(db_session, ids) == []
+    ops = await _ops(db_session, server_id)
+    assert sorted(o.op for o in ops) == ["delete"] * 2
+
+
+@pytest.mark.asyncio
+async def test_failed_wire_delete_keeps_the_row_on_the_soft_path(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A server that REJECTED the delete still serves the record; trashing the
+    row would tell the operator it is gone. Same rule as #951's permanent path."""
+    import app.api.v1.dns.router as dns_router
+
+    headers = await _user(db_session, superadmin=False)
+    _server, zone = await _agent_zone(db_session)
+    ids = await _records(db_session, zone, 2)
+    await db_session.commit()
+
+    real = dns_router.enqueue_record_ops_batch
+
+    async def _first_fails(db: AsyncSession, z: DNSZone, ops: list[dict[str, Any]]) -> list[Any]:
+        rows = await real(db, z, ops)
+        rows[0].state = "failed"
+        rows[0].last_error = "REFUSED"
+        return rows
+
+    monkeypatch.setattr(dns_router, "enqueue_record_ops_batch", _first_fails)
+    resp = await client.post(
+        _url(zone), headers=headers, json={"record_ids": [str(i) for i in ids]}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["deleted"] == 1, body
+    assert [s["reason"] for s in body["skipped"]] == ["wire delete failed: REFUSED"]
+    rows = {r.id: r for r in await _rows_including_deleted(db_session, ids)}
+    assert rows[ids[0]].deleted_at is None
+    assert rows[ids[1]].deleted_at is not None

--- a/backend/tests/test_dns_record_ops_sweep.py
+++ b/backend/tests/test_dns_record_ops_sweep.py
@@ -1,0 +1,165 @@
+"""#964 — the zone-scoped ``DNSRecordOp`` sweep lives in ONE helper, and its
+name-scoping under split-horizon is a documented decision, not an accident.
+
+``DNSRecordOp`` carries ``(server_id, zone_name)`` and no view discriminator,
+while ``DNSZone`` is unique on ``(group_id, view_id, name)`` — so two zones
+of the same name in sibling views share a queue. ``queued_zone_ops_where``
+records why that is accepted (the op payload carries no view either, and the
+ConfigBundle re-render converges both views). These tests pin:
+
+  * the helper's behaviour — queued states swept, history kept, other
+    servers untouched, the count agrees with the sweep;
+  * the documented over-sweep, so a future change to it is deliberate;
+  * that the three call sites use the helper and carry no copy of the
+    predicate — the shape #951 copied verbatim from zone_move.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dns import DNSRecordOp, DNSServer, DNSServerGroup, DNSView, DNSZone
+from app.services.dns.record_ops import (
+    QUEUED_OP_STATES,
+    count_queued_zone_ops,
+    sweep_zone_ops,
+)
+
+_APP = Path(__file__).resolve().parents[1] / "app"
+_CALL_SITES = (
+    _APP / "services" / "dns" / "zone_move.py",
+    _APP / "services" / "ai" / "operations_risky.py",
+)
+
+
+async def _group_with_servers(db: AsyncSession, n: int) -> tuple[DNSServerGroup, list[DNSServer]]:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    servers = [
+        DNSServer(
+            group_id=grp.id,
+            driver="bind9",
+            host=f"10.0.0.{i + 1}",
+            name=f"srv{i}-{uuid.uuid4().hex[:4]}",
+            is_primary=(i == 0),
+            is_enabled=True,
+        )
+        for i in range(n)
+    ]
+    db.add_all(servers)
+    await db.flush()
+    return grp, servers
+
+
+async def _zone(
+    db: AsyncSession, grp: DNSServerGroup, name: str, view_id: uuid.UUID | None = None
+) -> DNSZone:
+    zone = DNSZone(
+        group_id=grp.id,
+        view_id=view_id,
+        name=name,
+        zone_type="primary",
+        kind="forward",
+        primary_ns=f"ns1.{name}",
+        admin_email=f"admin.{name}",
+    )
+    db.add(zone)
+    await db.flush()
+    return zone
+
+
+def _op(server: DNSServer, zone_name: str, state: str) -> DNSRecordOp:
+    return DNSRecordOp(
+        server_id=server.id,
+        zone_name=zone_name,
+        op="create",
+        record={"name": "www", "type": "A", "value": "10.0.0.1"},
+        state=state,
+    )
+
+
+async def _states(db: AsyncSession, server: DNSServer) -> list[str]:
+    rows = (
+        (
+            await db.execute(
+                select(DNSRecordOp)
+                .where(DNSRecordOp.server_id == server.id)
+                .order_by(DNSRecordOp.state)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return sorted(o.state for o in rows)
+
+
+@pytest.mark.asyncio
+async def test_sweep_discards_queued_keeps_history_and_other_servers(
+    db_session: AsyncSession,
+) -> None:
+    grp, (a, b) = await _group_with_servers(db_session, 2)
+    zone = await _zone(db_session, grp, f"z{uuid.uuid4().hex[:6]}.example.")
+    other = await _zone(db_session, grp, f"o{uuid.uuid4().hex[:6]}.example.")
+    for state in ("pending", "in_flight", "applied", "failed"):
+        db_session.add(_op(a, zone.name, state))
+    db_session.add(_op(a, other.name, "pending"))  # a different zone, same server
+    db_session.add(_op(b, zone.name, "pending"))  # same zone, server NOT in scope
+    await db_session.flush()
+
+    assert set(QUEUED_OP_STATES) == {"pending", "in_flight"}
+    assert await count_queued_zone_ops(db_session, zone, [a.id]) == 2
+    assert await sweep_zone_ops(db_session, zone, [a.id]) == 2
+
+    assert await _states(db_session, a) == ["applied", "failed", "pending"]  # other zone's
+    assert await _states(db_session, b) == ["pending"]
+    # An empty server list is a no-op, never an unscoped sweep.
+    assert await count_queued_zone_ops(db_session, zone, []) == 0
+    assert await sweep_zone_ops(db_session, zone, []) == 0
+    assert await _states(db_session, b) == ["pending"]
+
+
+@pytest.mark.asyncio
+async def test_sweep_is_name_scoped_across_sibling_views_by_decision(
+    db_session: AsyncSession,
+) -> None:
+    """The documented over-sweep (#964). Under split-horizon the same name
+    exists once per view; the op queue cannot tell them apart, and neither can
+    the agent applying the op, so a sweep for one view's zone also discards
+    its sibling's queued ops. The bundle re-render converges both. If this
+    test starts failing because the sweep became view-exact, update the
+    decision in ``queued_zone_ops_where`` in the same change."""
+    grp, (a,) = await _group_with_servers(db_session, 1)
+    internal = DNSView(group_id=grp.id, name="internal", order=0)
+    external = DNSView(group_id=grp.id, name="external", order=1)
+    db_session.add_all([internal, external])
+    await db_session.flush()
+    name = f"split{uuid.uuid4().hex[:6]}.example."
+    z_int = await _zone(db_session, grp, name, view_id=internal.id)
+    z_ext = await _zone(db_session, grp, name, view_id=external.id)
+    assert z_int.id != z_ext.id and z_int.name == z_ext.name
+    db_session.add(_op(a, name, "pending"))
+    db_session.add(_op(a, name, "in_flight"))
+    await db_session.flush()
+
+    assert await count_queued_zone_ops(db_session, z_int, [a.id]) == 2
+    assert await sweep_zone_ops(db_session, z_int, [a.id]) == 2
+    assert await count_queued_zone_ops(db_session, z_ext, [a.id]) == 0
+
+
+def test_call_sites_use_the_helper_and_carry_no_copy_of_the_predicate() -> None:
+    """Three sites carried the same three-clause predicate verbatim (#951
+    copied it from zone_move). It lives in ``record_ops`` now; a re-inlined
+    copy would silently fork the #964 decision."""
+    pattern = re.compile(r"DNSRecordOp\.zone_name\s*==|sa_delete\(DNSRecordOp\)")
+    for path in _CALL_SITES:
+        src = path.read_text(encoding="utf-8")
+        assert "sweep_zone_ops" in src, f"{path.name} no longer routes through sweep_zone_ops"
+        hits = [m.group(0) for m in pattern.finditer(src)]
+        assert hits == [], f"{path.name} carries its own copy of the sweep predicate: {hits}"

--- a/backend/tests/test_dns_record_ops_sweep.py
+++ b/backend/tests/test_dns_record_ops_sweep.py
@@ -4,14 +4,18 @@ name-scoping under split-horizon is a documented decision, not an accident.
 ``DNSRecordOp`` carries ``(server_id, zone_name)`` and no view discriminator,
 while ``DNSZone`` is unique on ``(group_id, view_id, name)`` — so two zones
 of the same name in sibling views share a queue. ``queued_zone_ops_where``
-records why that is accepted (the op payload carries no view either, and the
-ConfigBundle re-render converges both views). These tests pin:
+records why that is accepted: with views present the bundle build ships no
+ops at all (records ride the structural fingerprint and every queued op is
+retired as ``applied``), so a sibling's op the sweep discards was never going
+to reach the agent. These tests pin:
 
   * the helper's behaviour — queued states swept, history kept, other
-    servers untouched, the count agrees with the sweep;
+    groups untouched, the count agrees with the sweep;
   * the documented over-sweep, so a future change to it is deliberate;
-  * that the three call sites use the helper and carry no copy of the
-    predicate — the shape #951 copied verbatim from zone_move.
+  * that the mechanism the decision rests on still holds — a group with
+    views dispatches no ops and retires the queue;
+  * that no module outside ``record_ops`` carries a copy of the predicate
+    or spells the queued-state tuple by hand.
 """
 
 from __future__ import annotations
@@ -21,10 +25,14 @@ import uuid
 from pathlib import Path
 
 import pytest
+from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.dns import DNSRecordOp, DNSServer, DNSServerGroup, DNSView, DNSZone
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dns import DNSRecord, DNSRecordOp, DNSServer, DNSServerGroup, DNSView, DNSZone
+from app.services.dns.agent_config import build_config_bundle
 from app.services.dns.record_ops import (
     QUEUED_OP_STATES,
     count_queued_zone_ops,
@@ -32,10 +40,8 @@ from app.services.dns.record_ops import (
 )
 
 _APP = Path(__file__).resolve().parents[1] / "app"
-_CALL_SITES = (
-    _APP / "services" / "dns" / "zone_move.py",
-    _APP / "services" / "ai" / "operations_risky.py",
-)
+# The one module allowed to spell the predicate / the state tuple.
+_OWNER = _APP / "services" / "dns" / "record_ops.py"
 
 
 async def _group_with_servers(db: AsyncSession, n: int) -> tuple[DNSServerGroup, list[DNSServer]]:
@@ -101,28 +107,30 @@ async def _states(db: AsyncSession, server: DNSServer) -> list[str]:
 
 
 @pytest.mark.asyncio
-async def test_sweep_discards_queued_keeps_history_and_other_servers(
+async def test_sweep_discards_queued_keeps_history_and_other_groups(
     db_session: AsyncSession,
 ) -> None:
     grp, (a, b) = await _group_with_servers(db_session, 2)
+    other_grp, (c,) = await _group_with_servers(db_session, 1)
     zone = await _zone(db_session, grp, f"z{uuid.uuid4().hex[:6]}.example.")
     other = await _zone(db_session, grp, f"o{uuid.uuid4().hex[:6]}.example.")
     for state in ("pending", "in_flight", "applied", "failed"):
         db_session.add(_op(a, zone.name, state))
+    db_session.add(_op(b, zone.name, "pending"))  # second server, SAME group
     db_session.add(_op(a, other.name, "pending"))  # a different zone, same server
-    db_session.add(_op(b, zone.name, "pending"))  # same zone, server NOT in scope
+    db_session.add(_op(c, zone.name, "pending"))  # same zone name, ANOTHER group
     await db_session.flush()
 
     assert set(QUEUED_OP_STATES) == {"pending", "in_flight"}
-    assert await count_queued_zone_ops(db_session, zone, [a.id]) == 2
-    assert await sweep_zone_ops(db_session, zone, [a.id]) == 2
+    assert await count_queued_zone_ops(db_session, zone, grp.id) == 3
+    # Every server of the group — a sweep that reached only the primary would
+    # leave the secondaries' queues behind (the #934 fan-out bug).
+    assert await sweep_zone_ops(db_session, zone, grp.id) == 3
 
     assert await _states(db_session, a) == ["applied", "failed", "pending"]  # other zone's
-    assert await _states(db_session, b) == ["pending"]
-    # An empty server list is a no-op, never an unscoped sweep.
-    assert await count_queued_zone_ops(db_session, zone, []) == 0
-    assert await sweep_zone_ops(db_session, zone, []) == 0
-    assert await _states(db_session, b) == ["pending"]
+    assert await _states(db_session, b) == []
+    assert await _states(db_session, c) == ["pending"]
+    assert await count_queued_zone_ops(db_session, zone, other_grp.id) == 1
 
 
 @pytest.mark.asyncio
@@ -130,11 +138,10 @@ async def test_sweep_is_name_scoped_across_sibling_views_by_decision(
     db_session: AsyncSession,
 ) -> None:
     """The documented over-sweep (#964). Under split-horizon the same name
-    exists once per view; the op queue cannot tell them apart, and neither can
-    the agent applying the op, so a sweep for one view's zone also discards
-    its sibling's queued ops. The bundle re-render converges both. If this
-    test starts failing because the sweep became view-exact, update the
-    decision in ``queued_zone_ops_where`` in the same change."""
+    exists once per view and the op queue cannot tell them apart — and does
+    not need to, because a group with views ships no ops (next test). If this
+    starts failing because the sweep became view-exact, update the decision in
+    ``queued_zone_ops_where`` in the same change."""
     grp, (a,) = await _group_with_servers(db_session, 1)
     internal = DNSView(group_id=grp.id, name="internal", order=0)
     external = DNSView(group_id=grp.id, name="external", order=1)
@@ -148,18 +155,110 @@ async def test_sweep_is_name_scoped_across_sibling_views_by_decision(
     db_session.add(_op(a, name, "in_flight"))
     await db_session.flush()
 
-    assert await count_queued_zone_ops(db_session, z_int, [a.id]) == 2
-    assert await sweep_zone_ops(db_session, z_int, [a.id]) == 2
-    assert await count_queued_zone_ops(db_session, z_ext, [a.id]) == 0
+    assert await count_queued_zone_ops(db_session, z_int, grp.id) == 2
+    assert await sweep_zone_ops(db_session, z_int, grp.id) == 2
+    assert await count_queued_zone_ops(db_session, z_ext, grp.id) == 0
 
 
-def test_call_sites_use_the_helper_and_carry_no_copy_of_the_predicate() -> None:
-    """Three sites carried the same three-clause predicate verbatim (#951
-    copied it from zone_move). It lives in ``record_ops`` now; a re-inlined
-    copy would silently fork the #964 decision."""
-    pattern = re.compile(r"DNSRecordOp\.zone_name\s*==|sa_delete\(DNSRecordOp\)")
-    for path in _CALL_SITES:
+@pytest.mark.asyncio
+async def test_a_group_with_views_ships_no_ops_and_retires_its_queue(
+    db_session: AsyncSession,
+) -> None:
+    """The invariant the #964 decision rests on. If a future change makes ops
+    view-aware and starts dispatching them under split-horizon, this fails and
+    the sweep's name-scoping must be revisited in the same change."""
+    grp, (a,) = await _group_with_servers(db_session, 1)
+    view = DNSView(group_id=grp.id, name="internal", order=0)
+    db_session.add(view)
+    await db_session.flush()
+    zone = await _zone(db_session, grp, f"v{uuid.uuid4().hex[:6]}.example.", view_id=view.id)
+    db_session.add(
+        DNSRecord(
+            zone_id=zone.id, name="www", fqdn=f"www.{zone.name}", record_type="A", value="10.0.0.1"
+        )
+    )
+    db_session.add(_op(a, zone.name, "pending"))
+    db_session.add(_op(a, zone.name, "in_flight"))
+    await db_session.flush()
+
+    bundle = await build_config_bundle(db_session, a)
+    assert bundle["pending_record_ops"] == []
+    assert await _states(db_session, a) == ["applied", "applied"]
+
+
+def test_no_module_outside_record_ops_spells_the_sweep_or_the_state_tuple() -> None:
+    """Three sites in two files carried the same three-clause predicate
+    verbatim (#951 copied it from zone_move), and two more hand-spelled the
+    queued-state tuple. Both now live in ``record_ops``; a re-inlined copy
+    anywhere under ``app/`` — not just the files that had one — would fork the
+    #964 decision silently."""
+    sweep = re.compile(r"sa_delete\(DNSRecordOp\)")
+    # A zone-name match on its own is a read (acme dns01 polls its TXT op by
+    # zone + serial); it is the queued-STATE clause beside it that makes a
+    # sweep or count predicate.
+    queued_predicate = re.compile(
+        r"DNSRecordOp\.zone_name\s*==[\s\S]{0,200}DNSRecordOp\.state\.in_"
+    )
+    state_tuple = re.compile(r"""\(\s*["']pending["']\s*,\s*["']in_flight["']\s*\)""")
+    offenders: list[str] = []
+    for path in sorted(_APP.rglob("*.py")):
+        if path == _OWNER:
+            continue
         src = path.read_text(encoding="utf-8")
-        assert "sweep_zone_ops" in src, f"{path.name} no longer routes through sweep_zone_ops"
-        hits = [m.group(0) for m in pattern.finditer(src)]
-        assert hits == [], f"{path.name} carries its own copy of the sweep predicate: {hits}"
+        rel = path.relative_to(_APP).as_posix()
+        # server_move sweeps by SERVER, deliberately (a server leaving a group
+        # takes its whole queue with it) — the one allowed delete outside the
+        # owner, and it must stay zone-blind.
+        if sweep.search(src) and rel != "services/dns/server_move.py":
+            offenders.append(f"{rel}: sa_delete(DNSRecordOp) outside record_ops")
+        if queued_predicate.search(src):
+            offenders.append(f"{rel}: zone-scoped queued-ops predicate (use record_ops)")
+        if state_tuple.search(src):
+            offenders.append(f"{rel}: hand-spelled queued-state tuple (use QUEUED_OP_STATES)")
+    assert offenders == [], offenders
+    for rel in ("services/dns/zone_move.py", "services/ai/operations_risky.py"):
+        assert "sweep_zone_ops" in (_APP / rel).read_text(encoding="utf-8"), rel
+
+
+@pytest.mark.asyncio
+async def test_soft_deleting_a_zone_sweeps_its_queued_ops(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The default (soft) zone delete is the moment the zone leaves the bundle,
+    so its queued ops become unapplyable then — not only on ``?permanent``.
+    Left behind, each op was shipped up to five times against a zone the agent
+    no longer serves and then parked as ``failed`` forever (review of #964)."""
+    user = User(
+        username=f"sw-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="Sweep Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    headers = {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+    grp, (a,) = await _group_with_servers(db_session, 1)
+    zone = await _zone(db_session, grp, f"sd{uuid.uuid4().hex[:6]}.example.")
+    db_session.add(_op(a, zone.name, "pending"))
+    db_session.add(_op(a, zone.name, "in_flight"))
+    db_session.add(_op(a, zone.name, "applied"))
+    await db_session.commit()
+    server_id, zone_id, group_id = a.id, zone.id, grp.id
+
+    resp = await client.delete(f"/api/v1/dns/groups/{group_id}/zones/{zone_id}", headers=headers)
+    assert resp.status_code == 204, resp.text
+
+    db_session.expire_all()
+    rows = (
+        (await db_session.execute(select(DNSRecordOp).where(DNSRecordOp.server_id == server_id)))
+        .scalars()
+        .all()
+    )
+    assert sorted(o.state for o in rows) == ["applied"]
+    trashed = (
+        await db_session.execute(
+            select(DNSZone).where(DNSZone.id == zone_id).execution_options(include_deleted=True)
+        )
+    ).scalar_one()
+    assert trashed.deleted_at is not None

--- a/backend/tests/test_dns_sync_no_primary_stale_delete.py
+++ b/backend/tests/test_dns_sync_no_primary_stale_delete.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import create_access_token, hash_password
 from app.models.auth import User
-from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
+from app.models.dns import DNSRecord, DNSRecordOp, DNSServer, DNSServerGroup, DNSZone
 from app.models.ipam import IPBlock, IPSpace, Subnet
 
 
@@ -107,3 +107,146 @@ async def test_no_primary_stale_record_is_deletable(
     assert (
         await db_session.execute(select(DNSRecord).where(DNSRecord.id == rec_id))
     ).scalar_one_or_none() is None
+
+
+# ── #962 — agent-based zones: pending is dispatched, only failed blocks ───────
+#
+# Same defect #950 fixed in the DNS bulk-delete route, in this file's commit
+# path. Agent-based servers never answer inline — ``enqueue_record_ops_batch``
+# queues ``pending`` rows for the agent's next long-poll — and the old
+# ``!= "applied"`` gate reported every one of them as "wire delete failed —
+# unknown", keeping the row while the agent still removed the record from the
+# served zone. The next drift report then listed it as missing-on-server.
+
+
+async def _agent_zone_subnet(db: AsyncSession) -> tuple[DNSServer, DNSZone, Subnet]:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    server = DNSServer(
+        group_id=grp.id,
+        driver="bind9",
+        host="10.0.0.1",
+        name=f"srv-{uuid.uuid4().hex[:6]}",
+        is_primary=True,
+        is_enabled=True,
+    )
+    db.add(server)
+    await db.flush()
+    zone = DNSZone(
+        group_id=grp.id,
+        name=f"ab{uuid.uuid4().hex[:6]}.example.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.example.",
+        admin_email="admin.example.",
+    )
+    db.add(zone)
+    await db.flush()
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.71.0.0/16", name="blk")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(
+        space_id=space.id,
+        block_id=block.id,
+        network="10.71.0.0/24",
+        name="sn",
+        dns_zone_id=str(zone.id),
+        dns_inherit_settings=False,
+    )
+    db.add(subnet)
+    await db.flush()
+    return server, zone, subnet
+
+
+async def _stale_records(db: AsyncSession, zone: DNSZone, n: int) -> list[uuid.UUID]:
+    rows = [
+        DNSRecord(
+            zone_id=zone.id,
+            name=f"stale{i}",
+            fqdn=f"stale{i}.{zone.name}",
+            record_type="A",
+            value=f"10.71.0.{i + 10}",
+            auto_generated=True,
+            ip_address_id=None,
+        )
+        for i in range(n)
+    ]
+    db.add_all(rows)
+    await db.flush()
+    return [r.id for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_agent_based_stale_delete_removes_the_row_while_the_op_queues(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _admin_headers(db_session)
+    server, zone, subnet = await _agent_zone_subnet(db_session)
+    server_id = server.id
+    ids = await _stale_records(db_session, zone, 2)
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/v1/ipam/subnets/{subnet.id}/dns-sync/commit",
+        headers=headers,
+        json={"delete_stale_record_ids": [str(i) for i in ids]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["deleted"] == 2, body
+    assert body["errors"] == [], body
+
+    db_session.expire_all()
+    left = (await db_session.execute(select(DNSRecord).where(DNSRecord.id.in_(ids)))).scalars()
+    assert list(left) == []
+    # The wire delete is queued for the agent, not lost: one pending op each.
+    ops = (
+        (await db_session.execute(select(DNSRecordOp).where(DNSRecordOp.server_id == server_id)))
+        .scalars()
+        .all()
+    )
+    assert sorted(o.op for o in ops) == ["delete", "delete"]
+    assert {o.state for o in ops} == {"pending"}
+
+
+@pytest.mark.asyncio
+async def test_agent_based_stale_delete_keeps_the_row_only_when_the_op_failed(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``failed`` is the one state that means a server still serves the record."""
+    import app.services.dns.record_ops as record_ops
+
+    headers = await _admin_headers(db_session)
+    _server, zone, subnet = await _agent_zone_subnet(db_session)
+    ids = await _stale_records(db_session, zone, 2)
+    await db_session.commit()
+
+    real = record_ops.enqueue_record_ops_batch
+
+    async def _first_fails(db, z, ops):  # noqa: ANN001
+        rows = await real(db, z, ops)
+        rows[0].state = "failed"
+        rows[0].last_error = "REFUSED"
+        return rows
+
+    # ``_apply_dns_sync`` imports the name locally at call time, so the module
+    # attribute is the seam.
+    monkeypatch.setattr(record_ops, "enqueue_record_ops_batch", _first_fails)
+
+    resp = await client.post(
+        f"/api/v1/ipam/subnets/{subnet.id}/dns-sync/commit",
+        headers=headers,
+        json={"delete_stale_record_ids": [str(i) for i in ids]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["deleted"] == 1, body
+    assert len(body["errors"]) == 1 and "REFUSED" in body["errors"][0], body
+
+    db_session.expire_all()
+    left = (await db_session.execute(select(DNSRecord).where(DNSRecord.id.in_(ids)))).scalars()
+    assert [r.id for r in left] == [ids[0]]

--- a/backend/tests/test_dns_zone_lifecycle_at_scale.py
+++ b/backend/tests/test_dns_zone_lifecycle_at_scale.py
@@ -7,7 +7,9 @@
    servers never answer inline: the batch enqueue queues their ops as
    ``pending`` for the agent's next long-poll, and the route's gate treated
    anything but ``applied`` as a failure. Only a ``failed`` wire delete may
-   keep the DB row.
+   keep the DB row live. (Since #963 the route soft-deletes by default —
+   the rows go to the trash under one shared batch id rather than away —
+   so "deleted" below means trashed; ``?permanent=true`` is superadmin-only.)
 
 2. ``DELETE .../zones/{id}?permanent=true`` cascaded through the ORM — every
    record row loaded and deleted one by one in the request — so a large zone
@@ -113,14 +115,34 @@ async def _ops(db: AsyncSession, zone_name: str) -> list[DNSRecordOp]:
 # ── 1. bulk delete on an agent-based zone ────────────────────────────────────
 
 
+async def _live_and_trashed(db: AsyncSession, zone_id: uuid.UUID) -> tuple[int, int]:
+    """(rows not soft-deleted, rows soft-deleted) — ``_record_count`` is a
+    bare aggregate the soft-delete filter does not touch, so it cannot tell."""
+    db.expire_all()
+    rows = (
+        (
+            await db.execute(
+                select(DNSRecord)
+                .where(DNSRecord.zone_id == zone_id)
+                .execution_options(include_deleted=True)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    trashed = sum(1 for r in rows if r.deleted_at is not None)
+    return len(rows) - trashed, trashed
+
+
 @pytest.mark.asyncio
-async def test_bulk_delete_on_an_agent_zone_deletes_the_rows_and_queues_the_ops(
+async def test_bulk_delete_on_an_agent_zone_trashes_the_rows_and_queues_the_ops(
     client: AsyncClient, db_session: AsyncSession
 ) -> None:
     headers = await _admin_headers(db_session)
     _grp, _server, zone = await _agent_group_and_zone(db_session)
     rows = await _add_records(db_session, zone, 5)
     await db_session.commit()
+    zone_id, zone_name = zone.id, zone.name
 
     resp = await client.post(
         f"{_zone_url(zone)}/records/bulk-delete",
@@ -131,11 +153,13 @@ async def test_bulk_delete_on_an_agent_zone_deletes_the_rows_and_queues_the_ops(
     body = resp.json()
     # The wire ops are PENDING on an agent-based server (the agent applies
     # them on its next long-poll); that is a dispatched delete, not a failed
-    # one, and the DB rows must go.
+    # one, and the DB rows must go — to the trash, since #963 (one shared
+    # batch id, restorable together), not to /dev/null.
     assert body["deleted"] == 3, body
     assert body["skipped"] == [], body
-    assert await _record_count(db_session, zone.id) == 2
-    ops = [o for o in await _ops(db_session, zone.name) if o.op == "delete"]
+    assert body["deletion_batch_id"] is not None, body
+    assert await _live_and_trashed(db_session, zone_id) == (2, 3)
+    ops = [o for o in await _ops(db_session, zone_name) if o.op == "delete"]
     assert len(ops) == 3
     assert {o.state for o in ops} == {"pending"}
 
@@ -172,8 +196,9 @@ async def test_bulk_delete_keeps_the_row_only_when_the_wire_delete_failed(
     assert len(body["skipped"]) == 1
     assert body["skipped"][0]["record_id"] == str(rows[0].id)
     assert "primary refused" in body["skipped"][0]["reason"]
-    # The failed one is still published, so it is still in the database.
-    assert await _record_count(db_session, zone.id) == 1
+    # The failed one is still published, so it stays live; the other two are
+    # in the trash.
+    assert await _live_and_trashed(db_session, zone.id) == (1, 2)
 
 
 # ── 2. permanent zone delete at scale ────────────────────────────────────────

--- a/charts/spatiumddi-appliance/templates/_helpers.tpl
+++ b/charts/spatiumddi-appliance/templates/_helpers.tpl
@@ -18,6 +18,17 @@
 
 {{- define "spatiumddi-appliance.labels" -}}
 app.kubernetes.io/name: {{ include "spatiumddi-appliance.name" . }}
+{{ include "spatiumddi-appliance.podLabels" . }}
+{{- end -}}
+
+{{/* Pod-template labels: everything in .labels EXCEPT app.kubernetes.io/name,
+     which every pod template sets to its own workload name (dns-bind9,
+     dhcp-kea, ...) so the selector matches. Including .labels there too
+     emitted the key twice in one map — YAML that yaml.v2 resolves last-wins
+     (which is why the live pods were always labelled correctly) but that a
+     strict decoder rejects outright: kubeconform, and kubectl's
+     --validate=strict. Found by the #966 render gate on the first run. */}}
+{{- define "spatiumddi-appliance.podLabels" -}}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: spatiumddi

--- a/charts/spatiumddi-appliance/templates/agent-landing.yaml
+++ b/charts/spatiumddi-appliance/templates/agent-landing.yaml
@@ -33,7 +33,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "spatiumddi-appliance.labels" . | nindent 8 }}
+        {{- include "spatiumddi-appliance.podLabels" . | nindent 8 }}
         app.kubernetes.io/name: agent-landing
         app.kubernetes.io/component: agent-landing
     spec:
@@ -45,6 +45,12 @@ spec:
         - name: nginx
           image: "{{ .Values.agentLanding.image.repository }}:{{ .Values.agentLanding.image.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          # #965 — token request so the audit of this chart has no BestEffort
+          # pod left; nginx serving a static page needs nothing more.
+          {{- with .Values.agentLanding.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/spatiumddi-appliance/templates/dhcp-kea.yaml
+++ b/charts/spatiumddi-appliance/templates/dhcp-kea.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "spatiumddi-appliance.labels" . | nindent 8 }}
+        {{- include "spatiumddi-appliance.podLabels" . | nindent 8 }}
         app.kubernetes.io/name: dhcp-kea
         app.kubernetes.io/component: dhcp-kea
     spec:

--- a/charts/spatiumddi-appliance/templates/dns-bind9.yaml
+++ b/charts/spatiumddi-appliance/templates/dns-bind9.yaml
@@ -43,7 +43,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "spatiumddi-appliance.labels" . | nindent 8 }}
+        {{- include "spatiumddi-appliance.podLabels" . | nindent 8 }}
         app.kubernetes.io/name: dns-bind9
         app.kubernetes.io/component: dns-bind9
     spec:

--- a/charts/spatiumddi-appliance/templates/dns-powerdns.yaml
+++ b/charts/spatiumddi-appliance/templates/dns-powerdns.yaml
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "spatiumddi-appliance.labels" . | nindent 8 }}
+        {{- include "spatiumddi-appliance.podLabels" . | nindent 8 }}
         app.kubernetes.io/name: dns-powerdns
         app.kubernetes.io/component: dns-powerdns
     spec:

--- a/charts/spatiumddi-appliance/templates/dns-technitium.yaml
+++ b/charts/spatiumddi-appliance/templates/dns-technitium.yaml
@@ -31,7 +31,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "spatiumddi-appliance.labels" . | nindent 8 }}
+        {{- include "spatiumddi-appliance.podLabels" . | nindent 8 }}
         app.kubernetes.io/name: dns-technitium
         app.kubernetes.io/component: dns-technitium
     spec:

--- a/charts/spatiumddi-appliance/templates/looking-glass.yaml
+++ b/charts/spatiumddi-appliance/templates/looking-glass.yaml
@@ -41,7 +41,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "spatiumddi-appliance.labels" . | nindent 8 }}
+        {{- include "spatiumddi-appliance.podLabels" . | nindent 8 }}
         app.kubernetes.io/name: looking-glass
         app.kubernetes.io/component: looking-glass
     spec:
@@ -66,6 +66,13 @@ spec:
         - name: looking-glass
           image: {{ include "spatiumddi-appliance.imageRef" (dict "global" .Values.global "repository" .Values.lookingGlass.image.repository) }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          # #965 — keep the collector out of BestEffort: a starved gobgpd
+          # misses keepalives and the operator's routers drop the session on
+          # hold-timer expiry. Requests only; see values.yaml.
+          {{- with .Values.lookingGlass.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           # gobgpd binds the privileged BGP port :179 as the non-root
           # ``spatium`` user via a file capability (``setcap
           # cap_net_bind_service`` on the binary). Under k8s that file cap is

--- a/charts/spatiumddi-appliance/templates/observability-kube-state-metrics.yaml
+++ b/charts/spatiumddi-appliance/templates/observability-kube-state-metrics.yaml
@@ -96,7 +96,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "spatiumddi-appliance.labels" . | nindent 8 }}
+        {{- include "spatiumddi-appliance.podLabels" . | nindent 8 }}
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/component: kube-state-metrics
     spec:

--- a/charts/spatiumddi-appliance/templates/observability-node-exporter.yaml
+++ b/charts/spatiumddi-appliance/templates/observability-node-exporter.yaml
@@ -37,7 +37,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "spatiumddi-appliance.labels" . | nindent 8 }}
+        {{- include "spatiumddi-appliance.podLabels" . | nindent 8 }}
         app.kubernetes.io/name: node-exporter
         app.kubernetes.io/component: node-exporter
       annotations:

--- a/charts/spatiumddi-appliance/templates/supervisor.yaml
+++ b/charts/spatiumddi-appliance/templates/supervisor.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "spatiumddi-appliance.labels" . | nindent 8 }}
+        {{- include "spatiumddi-appliance.podLabels" . | nindent 8 }}
         app.kubernetes.io/name: spatium-supervisor
         app.kubernetes.io/component: supervisor
     spec:
@@ -57,6 +57,14 @@ spec:
         - name: spatium-supervisor
           image: {{ include "spatiumddi-appliance.imageRef" (dict "global" .Values.global "repository" .Values.supervisor.image.repository) }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          # #965 — a CPU request lifts the supervisor out of BestEffort QoS. It
+          # is the thing that REPAIRS the node (watchdog auto-heal, firewall
+          # drift re-apply), and BestEffort starves it in exactly the window
+          # those exist for. Requests only; see values.yaml.
+          {{- with .Values.supervisor.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           # Privileged because the supervisor writes host-side
           # trigger files + reads /run/udev. Phase 3 narrows this
           # down once the controller pattern lands.

--- a/charts/spatiumddi-appliance/values.yaml
+++ b/charts/spatiumddi-appliance/values.yaml
@@ -175,9 +175,17 @@ dhcpKea:
   # DORA ramp: as a BestEffort pod Kea was given 7.5 % of a CPU while the
   # api ran at 110 %, its socket queue overflowed and only 37 % of the
   # DISCOVERs on the wire were answered. Requests only, no limits.
+  #
+  # 500m is the value every measured cell used (#967): what does the work
+  # under contention is the cgroup weight the request derives to, and
+  # 500m (weight 20) holds ~48 % of the CPU against the api + worker where
+  # the 250m #953 first shipped (weight 10) holds ~31 %. Kea's own use was
+  # under 100m once scheduled, so this is headroom for the api's bursts,
+  # not Kea's need; the DNS roles held 99.5–100 % at 250m in every cell
+  # and keep that floor.
   resources:
     requests:
-      cpu: 250m
+      cpu: 500m
       memory: 64Mi
   controlPlaneUrl: ""
   inClusterApiUrl: ""  # #292 — see dnsBind9.inClusterApiUrl
@@ -212,6 +220,15 @@ lookingGlass:
   enabled: false
   image:
     repository: ghcr.io/spatiumddi/looking-glass
+  # #965 — a floor, not a measurement. gobgpd holds real BGP sessions with
+  # operator routers (#566); as a BestEffort pod it had the lowest CFS
+  # weight on the node, and a starved collector misses keepalives until
+  # the peer's hold timer expires and the session flaps — louder than a
+  # dropped query. Requests only, no limits, same shape as dnsBind9.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
   # Same precedence + rationale as dnsBind9.controlPlaneUrl /
   # inClusterApiUrl above: external operator-facing URL (Application
   # appliance, self-signed) takes priority over the in-cluster Service
@@ -295,6 +312,17 @@ supervisor:
   enabled: false
   image:
     repository: ghcr.io/spatiumddi/spatium-supervisor
+  # #965 — a floor, not a measurement. The supervisor is not a data-plane
+  # server, it is what repairs the node: the Wave-E watchdog re-fires
+  # apply_role_assignment for a missing service and re-applies a drifted
+  # nftables ruleset, both from inside the heartbeat loop. As a BestEffort
+  # pod it was starved at exactly the moment the data plane degraded, and
+  # the external bash watchdog then restarted a supervisor that was merely
+  # slow — burning its 3-per-30-min budget for nothing. Requests only.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
   # Host mounts the supervisor needs — same set as today's compose
   # entry (release-state writes the trigger files, etc).
   hostMounts:
@@ -337,6 +365,12 @@ agentLanding:
   image:
     repository: nginx
     tag: 1.30.3-alpine
+  # #965 — token request so no pod in this chart is BestEffort (the CI
+  # render check refuses one). A static nginx page needs nothing more.
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
   hostMounts:
     htmlDir: /var/lib/spatiumddi/agent-landing
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -242,10 +242,14 @@ triggered on push to `main` and on every pull request:
 | **Backend — Tests** (`backend-test`) | A required-check aggregator over **eight** parallel `backend-test-shard` jobs. Each shard spins up `postgres:16-alpine` + `redis:8.8-alpine` services, runs `alembic upgrade head`, then `pytest -n auto --splits 8 --group N` (pytest-split selects the shard's slice; `-n auto` parallelizes it across the runner's vCPUs, each xdist worker on its own `spatiumddi_test_gw<N>` DB). The aggregator passes only if all eight shards pass. |
 | **Frontend — Lint & Type Check** (`frontend-lint`) | Node 22, `npm install`, then `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test`. |
 | **Frontend — Build** (`frontend-build`) | Node 22, `npm install`, `npm run build`. |
+| **Charts — Lint & Template** (`charts-lint`) | Helm 3.20 + a checksum-pinned kubeconform. `helm lint --strict` both charts at defaults and with every role / feature toggle on, `helm template` five value sets (umbrella: defaults, all-on, external DB + Redis; appliance: defaults, all-on, the single-node full-stack shape), `kubeconform -strict` against the Kubernetes 1.31 + CRD-catalog schemas, and `.github/scripts/chart-no-besteffort.py` on the appliance renders (#965 — no container may lack CPU + memory requests). Rendered manifests are uploaded as the `rendered-charts` artifact. Until #966 nothing on a PR parsed the appliance chart at all; it was first read by helm during the release. `make charts-lint` runs the same script in a helm container. |
+| **Perf — Tests** (`perf-test`) | Python 3.12 + pytest, `python -m pytest perf`. Hermetic (fake sockets, no network, no appliance). Tests only — `perf/` is outside the Backend Lint scope and carries pre-existing ruff/black drift (#968). `make perf-test` reproduces it. |
 
 Branch protection on `main` gates on these checks. `make ci` reproduces
 the two lint jobs and the frontend build locally; `make test` reproduces
-the backend test job (single-runner rather than sharded).
+the backend test job (single-runner rather than sharded); `make charts-lint`
+and `make perf-test` reproduce the two jobs above (both via Docker, so
+neither helm nor kubeconform needs to be on the host).
 
 ### What runs when — the trigger policy
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -219,13 +219,15 @@ every push and pull request. Run it locally before pushing.
 make ci
 ```
 
-It chains three targets:
+It chains five targets:
 
 | `make` target | What it runs |
 |---|---|
 | `ci-backend-lint` | `ruff check app tests`, `black --check app tests`, `mypy app` (inside the api container; installs ruff/black/mypy on first run if missing) |
 | `ci-frontend-lint` | `npm run lint && npm run format:check && npm run typecheck` (CI's `frontend-lint` job also runs `npm test`) |
 | `ci-frontend-build` | `npm run build` |
+| `charts-lint` | The `Charts — Lint & Template` gate, in a helm container (see the job table below) |
+| `perf-test` | `python -m pytest perf` in a python container |
 
 `make ci` requires the dev stack to be running (the backend checks
 execute inside the api container) and Node 20+ on the host. It does **not**
@@ -242,14 +244,14 @@ triggered on push to `main` and on every pull request:
 | **Backend — Tests** (`backend-test`) | A required-check aggregator over **eight** parallel `backend-test-shard` jobs. Each shard spins up `postgres:16-alpine` + `redis:8.8-alpine` services, runs `alembic upgrade head`, then `pytest -n auto --splits 8 --group N` (pytest-split selects the shard's slice; `-n auto` parallelizes it across the runner's vCPUs, each xdist worker on its own `spatiumddi_test_gw<N>` DB). The aggregator passes only if all eight shards pass. |
 | **Frontend — Lint & Type Check** (`frontend-lint`) | Node 22, `npm install`, then `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test`. |
 | **Frontend — Build** (`frontend-build`) | Node 22, `npm install`, `npm run build`. |
-| **Charts — Lint & Template** (`charts-lint`) | Helm 3.20 + a checksum-pinned kubeconform. `helm lint --strict` both charts at defaults and with every role / feature toggle on, `helm template` five value sets (umbrella: defaults, all-on, external DB + Redis; appliance: defaults, all-on, the single-node full-stack shape), `kubeconform -strict` against the Kubernetes 1.31 + CRD-catalog schemas, and `.github/scripts/chart-no-besteffort.py` on the appliance renders (#965 — no container may lack CPU + memory requests). Rendered manifests are uploaded as the `rendered-charts` artifact. Until #966 nothing on a PR parsed the appliance chart at all; it was first read by helm during the release. `make charts-lint` runs the same script in a helm container. |
+| **Charts — Lint & Template** (`charts-lint`) | Helm 3.20 + a checksum-pinned kubeconform. `helm lint --strict` both charts at defaults and with every role / feature toggle on, `helm template` six value sets (umbrella: defaults, all-on, external DB + Redis, the CNPG + Sentinel HA shape; appliance: defaults, all-on, the single-node full-stack shape), `kubeconform -strict` against the Kubernetes 1.31 + CRD-catalog schemas, and `.github/scripts/chart-no-besteffort.py` on every render (#965 — no serving container may lack CPU + memory requests or limits; init containers are exempt, they finish before the pod serves) plus `chart-toggle-coverage.py`, which fails if a template is gated on a values key none of the value sets flips. Rendered manifests are uploaded as the `rendered-charts` artifact. Until #966 nothing on a PR parsed the appliance chart at all; it was first read by helm during the release. `make charts-lint` runs the same script in a helm container. |
 | **Perf — Tests** (`perf-test`) | Python 3.12 + pytest, `python -m pytest perf`. Hermetic (fake sockets, no network, no appliance). Tests only — `perf/` is outside the Backend Lint scope and carries pre-existing ruff/black drift (#968). `make perf-test` reproduces it. |
 
 Branch protection on `main` gates on these checks. `make ci` reproduces
-the two lint jobs and the frontend build locally; `make test` reproduces
-the backend test job (single-runner rather than sharded); `make charts-lint`
-and `make perf-test` reproduce the two jobs above (both via Docker, so
-neither helm nor kubeconform needs to be on the host).
+the two lint jobs, the frontend build, the chart gate and the perf tests
+locally (the last two via Docker, so neither helm nor kubeconform needs to
+be on the host); `make test` reproduces the backend test job
+(single-runner rather than sharded).
 
 ### What runs when — the trigger policy
 

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -105,13 +105,13 @@ not the operator's:
   of a CPU and answered 37 % of the DISCOVERs on the wire (55 % handshake
   success) while it answered 100 % of what reached it. The same cell with a
   CPU request on `dhcp-kea` and `dns-bind9` reached 95.6 % with 0 restarts.
-  That measurement used a **500m** request (cgroup weight 20 against the
-  api's 4); the chart default since spatiumddi#953 is **250m** (weight 10),
-  which lifts the pods out of BestEffort — the defect — but has not itself
-  been run against this load. Sizing a node at the knee, prefer the measured
-  500m. See spatiumddi#967. That is why the 4 vCPU rows pass — a fourth CPU
-  happens to be free for Kea — and why 3 vCPU sits at the knee. A larger
-  socket receive buffer does not help: with 8 MiB of buffer the drops
+  That measurement used a **500m** request on Kea (cgroup weight 20 against
+  the api's 4), which is what the chart ships since spatiumddi#967
+  (spatiumddi#953 first landed 250m — weight 10, enough to leave BestEffort,
+  but never itself run against this load). The DNS roles keep 250m: they
+  held 99.5–100 % in every cell. That is why the 4 vCPU rows pass — a
+  fourth CPU happens to be free for Kea — and why 3 vCPU sits at the knee.
+  A larger socket receive buffer does not help: with 8 MiB of buffer the drops
   vanish but a DORA takes 34 s instead of 1.5 s, because Kea then answers
   stale requests whole retransmit rounds late.
 

--- a/docs/drivers/DHCP_DRIVERS.md
+++ b/docs/drivers/DHCP_DRIVERS.md
@@ -295,7 +295,7 @@ Default ABC impls call the singular method in a loop — Kea inherits the plural
 
 **Windows batch size — 30 ops per chunk.** `pywinrm.run_ps` ships the script as a single CMD.EXE command line (8191-char cap, see [DNS_DRIVERS.md §3.7](DNS_DRIVERS.md#37-batched-winrm-dispatch) for the full math). DHCP payloads are leaner than DNS — each reservation / exclusion op is ~60 raw chars of JSON vs. DNS's ~160 — so the cmdline limit is farther away, but capped at 30 to stay comfortably inside it. Documented in `_WINRM_BATCH_SIZE` in [`drivers/dhcp/windows.py`](../../backend/app/drivers/dhcp/windows.py).
 
-**Dispatcher.** `push_statics_bulk_delete` groups by `(server, scope)` so the IPAM purge-orphans path went from N×M WinRM calls to one per server. Same state-aware commit pattern as DNS — only state=`applied` ops delete the DB row.
+**Dispatcher.** `push_statics_bulk_delete` groups by `(server, scope)` so the IPAM purge-orphans path went from N×M WinRM calls to one per server. Unlike the DNS side there is no state-aware commit here: the dispatcher returns nothing and the caller deletes the `DHCPStaticAssignment` rows regardless — the push is best-effort, and the next lease poll / config bundle reconciles the server.
 
 ---
 

--- a/docs/drivers/DNS_DRIVERS.md
+++ b/docs/drivers/DNS_DRIVERS.md
@@ -459,7 +459,7 @@ $r | ConvertTo-Json -Compress -Depth 3
 
 **RFC 2136 path — `asyncio.gather`.** The 2136 write path is cheap per-op but was still serial. Record ops now run in parallel via `asyncio.gather`; no batching needed because the dnspython update framing is already compact.
 
-**Dispatch.** `enqueue_record_ops_batch(db, zone, ops)` in [`services/dns/record_ops.py`](../../backend/app/services/dns/record_ops.py) groups pending ops by zone and calls `apply_record_changes` once per group. Zone serial bumps once per batch instead of N times. **State-aware commit**: the caller zips through the returned op rows and only deletes (or confirms success) when `state == "applied"`. A failed wire op never causes a DB delete — previous behaviour would report "deleted" to the UI while the record was still published on Windows.
+**Dispatch.** `enqueue_record_ops_batch(db, zone, ops)` in [`services/dns/record_ops.py`](../../backend/app/services/dns/record_ops.py) groups pending ops by zone and calls `apply_record_changes` once per group. Zone serial bumps once per batch instead of N times. **State-aware commit**: the caller zips through the returned op rows and keeps the DB row only when the op came back `state == "failed"` — a server rejected the delete, so the record is still published and reporting "deleted" would leave a zombie the next "Sync with server" pulls back. Every other outcome deletes locally: `applied` (agentless, inline), `pending` (agent-based — the agent applies it on its next long-poll; gating on `applied` here was the #950 / #962 defect, which reported every agent-side delete as failed) and `None` (no primary to push to — DB-only cruft, #623).
 
 **Results.**
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6156,14 +6156,25 @@ export const dnsApi = {
   deleteRecord: (groupId: string, zoneId: string, recordId: string) =>
     api.delete(`/dns/groups/${groupId}/zones/${zoneId}/records/${recordId}`),
 
-  bulkDeleteRecords: (groupId: string, zoneId: string, recordIds: string[]) =>
+  // Soft-deletes by default (#963) — the whole selection shares one
+  // deletion_batch_id, so it restores from Admin → Trash in one action.
+  // ``permanent`` is superadmin-only server-side, same as deleteRecord.
+  bulkDeleteRecords: (
+    groupId: string,
+    zoneId: string,
+    recordIds: string[],
+    opts?: { permanent?: boolean },
+  ) =>
     api
       .post<{
         deleted: number;
         skipped: { record_id: string; reason: string }[];
-      }>(`/dns/groups/${groupId}/zones/${zoneId}/records/bulk-delete`, {
-        record_ids: recordIds,
-      })
+        deletion_batch_id: string | null;
+      }>(
+        `/dns/groups/${groupId}/zones/${zoneId}/records/bulk-delete`,
+        { record_ids: recordIds },
+        { params: opts?.permanent ? { permanent: true } : undefined },
+      )
       .then((r) => r.data),
 
   // Bulk zone file import / export

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -14191,6 +14191,7 @@ export interface TrashListResponse {
 export interface TrashRestoreResponse {
   batch_id: string;
   restored: number;
+  skipped: { type: string; id: string; display: string; reason: string }[];
 }
 
 export const trashApi = {
@@ -14205,9 +14206,21 @@ export const trashApi = {
     } = {},
   ) =>
     api.get<TrashListResponse>("/admin/trash", { params }).then((r) => r.data),
-  restore: (type: TrashEntryType, id: string) =>
+  // ``skipConflicts`` restores every sibling that does not clash with a live
+  // row and reports the rest in ``skipped`` (#963 — one hand-recreated record
+  // must not pin a whole bulk-delete batch in the trash). Without it a
+  // conflict is a 409 for the whole batch, as for cascade batches.
+  restore: (
+    type: TrashEntryType,
+    id: string,
+    opts?: { skipConflicts?: boolean },
+  ) =>
     api
-      .post<TrashRestoreResponse>(`/admin/trash/${type}/${id}/restore`)
+      .post<TrashRestoreResponse>(
+        `/admin/trash/${type}/${id}/restore`,
+        undefined,
+        { params: opts?.skipConflicts ? { skip_conflicts: true } : undefined },
+      )
       .then((r) => r.data),
   permanentDelete: (type: TrashEntryType, id: string) =>
     api.delete(`/admin/trash/${type}/${id}`),

--- a/frontend/src/pages/admin/TrashPage.tsx
+++ b/frontend/src/pages/admin/TrashPage.tsx
@@ -40,8 +40,12 @@ function ConfirmRestoreModal({
 }) {
   const qc = useQueryClient();
   const [error, setError] = useState<string | null>(null);
+  // Set after a 409: the batch holds rows that clash with live ones. The
+  // operator can then restore the others and leave the clashing rows behind.
+  const [canSkipConflicts, setCanSkipConflicts] = useState(false);
   const mut = useMutation({
-    mutationFn: () => trashApi.restore(entry.type, entry.id),
+    mutationFn: (skipConflicts: boolean) =>
+      trashApi.restore(entry.type, entry.id, { skipConflicts }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["trash"] });
       qc.invalidateQueries({ queryKey: ["ipam"] });
@@ -61,6 +65,7 @@ function ConfirmRestoreModal({
             .map((c) => `${c.display} — ${c.reason}`)
             .join("; ")}`,
         );
+        setCanSkipConflicts(entry.batch_size > conflicts.length);
       } else if (typeof detail === "string") {
         setError(detail);
       } else {
@@ -77,7 +82,7 @@ function ConfirmRestoreModal({
           <span className="font-mono font-medium">{entry.name_or_cidr}</span> (
           {TYPE_LABELS[entry.type]})
           {entry.batch_size > 1
-            ? ` and ${entry.batch_size - 1} cascaded child row${entry.batch_size - 1 === 1 ? "" : "s"}`
+            ? ` and the ${entry.batch_size - 1} other row${entry.batch_size - 1 === 1 ? "" : "s"} deleted with it`
             : ""}
           ?
         </p>
@@ -93,10 +98,23 @@ function ConfirmRestoreModal({
           >
             Cancel
           </button>
+          {canSkipConflicts && (
+            <button
+              onClick={() => {
+                setError(null);
+                mut.mutate(true);
+              }}
+              disabled={mut.isPending}
+              className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+              title="Restore every row in the batch except the ones that clash with a live row"
+            >
+              Restore the others
+            </button>
+          )}
           <button
             onClick={() => {
               setError(null);
-              mut.mutate();
+              mut.mutate(false);
             }}
             disabled={mut.isPending}
             className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"

--- a/frontend/src/pages/admin/TrashPage.tsx
+++ b/frontend/src/pages/admin/TrashPage.tsx
@@ -42,6 +42,13 @@ function ConfirmRestoreModal({
   const [error, setError] = useState<string | null>(null);
   // Set after a 409: the batch holds rows that clash with live ones. The
   // operator can then restore the others and leave the clashing rows behind.
+  //
+  // Only offered for a dns_record batch — a bulk record delete (#963) stamps
+  // N independent siblings under one id, so leaving one behind is sound. Every
+  // other batch is a cascade (a zone AND its records, a scope AND its pools)
+  // where a partial restore can bring a child back without its parent; the
+  // server refuses those with a 422, and this keeps the button off the screen
+  // rather than showing one that always errors.
   const [canSkipConflicts, setCanSkipConflicts] = useState(false);
   const mut = useMutation({
     mutationFn: (skipConflicts: boolean) =>
@@ -65,7 +72,9 @@ function ConfirmRestoreModal({
             .map((c) => `${c.display} — ${c.reason}`)
             .join("; ")}`,
         );
-        setCanSkipConflicts(entry.batch_size > conflicts.length);
+        setCanSkipConflicts(
+          entry.type === "dns_record" && entry.batch_size > conflicts.length,
+        );
       } else if (typeof detail === "string") {
         setError(detail);
       } else {

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -4380,9 +4380,10 @@ function ZoneDetailView({
           title={`Delete ${selectedRecords.size} records`}
           description={
             <>
-              Delete the{" "}
+              Move the{" "}
               <span className="font-medium">{selectedRecords.size}</span>{" "}
-              selected records? IPAM-managed records are excluded automatically.
+              selected records to the trash? They can be restored together from
+              Admin → Trash. IPAM-managed records are excluded automatically.
             </>
           }
           isPending={bulkDeleteRecords.isPending}

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -3310,6 +3310,10 @@ function MoveZoneModal({
 // (``records`` is the default and is left out of the URL entirely).
 type ZoneSubtab = "records" | "pools" | "certs" | "drift";
 
+// Matches BULK_DELETE_RECORDS_MAX server-side. A selection larger than this
+// is split, and each call is its own trash batch — the confirm copy says so.
+const BULK_DELETE_CHUNK = 2000;
+
 function ZoneDetailView({
   group,
   zone,
@@ -3489,32 +3493,43 @@ function ZoneDetailView({
   const bulkDeleteRecords = useMutation({
     // Server-side bulk endpoint: one WinRM round trip for agentless
     // drivers + a single zone-serial bump instead of N. Replaces the
-    // old Promise.allSettled fan-out. The server caps a call at 2000 ids
-    // and the selection can exceed that across pages, so chunk.
+    // old Promise.allSettled fan-out. The server caps a call at
+    // BULK_DELETE_CHUNK ids and the selection can exceed that across
+    // pages, so chunk — and each chunk is its own trash batch, which the
+    // confirm copy says rather than promising one restore.
     mutationFn: async (ids: string[]) => {
-      const CHUNK = 2000;
       let deleted = 0;
       const skipped: { record_id: string; reason: string }[] = [];
-      for (let i = 0; i < ids.length; i += CHUNK) {
+      const batches: string[] = [];
+      for (let i = 0; i < ids.length; i += BULK_DELETE_CHUNK) {
         const res = await dnsApi.bulkDeleteRecords(
           group.id,
           zone.id,
-          ids.slice(i, i + CHUNK),
+          ids.slice(i, i + BULK_DELETE_CHUNK),
           { permanent: bulkPermanent },
         );
         deleted += res.deleted;
         skipped.push(...res.skipped);
+        if (res.deletion_batch_id) batches.push(res.deletion_batch_id);
       }
-      return { deleted, skipped };
+      return { deleted, skipped, batches };
     },
-    onSuccess: ({ deleted, skipped }) => {
+    onSuccess: ({ deleted, skipped, batches }) => {
       qc.invalidateQueries({ queryKey: ["dns-records", zone.id] });
       setSelectedRecords(new Set());
       setConfirmBulkDelete(false);
+      const spread =
+        batches.length > 1
+          ? ` across ${batches.length} trash batches, each restored separately`
+          : "";
       if (skipped.length > 0) {
         const reasons = Array.from(new Set(skipped.map((s) => s.reason)));
         setBulkDeleteNotice(
-          `${deleted} record${deleted === 1 ? "" : "s"} ${bulkPermanent ? "deleted" : "moved to the trash"}; ${skipped.length} skipped — ${reasons.join("; ")}`,
+          `${deleted} record${deleted === 1 ? "" : "s"} ${bulkPermanent ? "deleted" : "moved to the trash"}${spread}; ${skipped.length} skipped — ${reasons.join("; ")}`,
+        );
+      } else if (spread) {
+        setBulkDeleteNotice(
+          `${deleted} record${deleted === 1 ? "" : "s"} ${bulkPermanent ? "deleted" : "moved to the trash"}${spread}.`,
         );
       } else {
         setBulkDeleteNotice(null);
@@ -4438,7 +4453,9 @@ function ZoneDetailView({
                 selected records
                 {bulkPermanent
                   ? "? This cannot be undone."
-                  : " to the trash? They can be restored together from Admin → Trash."}{" "}
+                  : selectedRecords.size > BULK_DELETE_CHUNK
+                    ? ` to the trash? They are split into ${Math.ceil(selectedRecords.size / BULK_DELETE_CHUNK)} batches in Admin → Trash, each restored separately.`
+                    : " to the trash? They can be restored together from Admin → Trash."}{" "}
                 IPAM-managed records are excluded automatically.
               </p>
               {isSuperadmin && (

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -58,6 +58,7 @@ import {
   TLSStatePill,
 } from "@/pages/network/CertificatesPage";
 import { useFeatureModules } from "@/hooks/useFeatureModules";
+import { usePermissions } from "@/hooks/usePermissions";
 import { Modal } from "@/components/ui/modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { HeaderButton } from "@/components/ui/header-button";
@@ -3474,16 +3475,51 @@ function ZoneDetailView({
     new Set(),
   );
   const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
+  // Superadmin-only permanent bulk delete (#963): the default moves the
+  // selection to the trash under one batch id; before #963 the grid could
+  // only hard-delete, so the option stays reachable for the one role that
+  // may use it.
+  const { isSuperadmin } = usePermissions();
+  const [bulkPermanent, setBulkPermanent] = useState(false);
+  // Outcome of the last bulk delete when some rows were skipped — the
+  // selection persists across pages, so the count in the modal can differ
+  // from what the server did (pool-managed or synthesised rows, wire
+  // failures). Shown above the records table until dismissed.
+  const [bulkDeleteNotice, setBulkDeleteNotice] = useState<string | null>(null);
   const bulkDeleteRecords = useMutation({
     // Server-side bulk endpoint: one WinRM round trip for agentless
     // drivers + a single zone-serial bump instead of N. Replaces the
-    // old Promise.allSettled fan-out.
-    mutationFn: (ids: string[]) =>
-      dnsApi.bulkDeleteRecords(group.id, zone.id, ids),
-    onSuccess: () => {
+    // old Promise.allSettled fan-out. The server caps a call at 2000 ids
+    // and the selection can exceed that across pages, so chunk.
+    mutationFn: async (ids: string[]) => {
+      const CHUNK = 2000;
+      let deleted = 0;
+      const skipped: { record_id: string; reason: string }[] = [];
+      for (let i = 0; i < ids.length; i += CHUNK) {
+        const res = await dnsApi.bulkDeleteRecords(
+          group.id,
+          zone.id,
+          ids.slice(i, i + CHUNK),
+          { permanent: bulkPermanent },
+        );
+        deleted += res.deleted;
+        skipped.push(...res.skipped);
+      }
+      return { deleted, skipped };
+    },
+    onSuccess: ({ deleted, skipped }) => {
       qc.invalidateQueries({ queryKey: ["dns-records", zone.id] });
       setSelectedRecords(new Set());
       setConfirmBulkDelete(false);
+      if (skipped.length > 0) {
+        const reasons = Array.from(new Set(skipped.map((s) => s.reason)));
+        setBulkDeleteNotice(
+          `${deleted} record${deleted === 1 ? "" : "s"} ${bulkPermanent ? "deleted" : "moved to the trash"}; ${skipped.length} skipped — ${reasons.join("; ")}`,
+        );
+      } else {
+        setBulkDeleteNotice(null);
+      }
+      setBulkPermanent(false);
     },
   });
 
@@ -3914,6 +3950,18 @@ function ZoneDetailView({
               />
             </>
           )}
+        </div>
+      )}
+
+      {bulkDeleteNotice && (
+        <div className="flex items-center justify-between border-b bg-amber-50 px-5 py-1.5 text-xs dark:bg-amber-900/10">
+          <span>{bulkDeleteNotice}</span>
+          <button
+            onClick={() => setBulkDeleteNotice(null)}
+            className="rounded-md border px-2 py-1 hover:bg-muted"
+          >
+            Dismiss
+          </button>
         </div>
       )}
 
@@ -4377,20 +4425,43 @@ function ZoneDetailView({
       )}
       {confirmBulkDelete && (
         <ConfirmSingleModal
-          title={`Delete ${selectedRecords.size} records`}
-          description={
-            <>
-              Move the{" "}
-              <span className="font-medium">{selectedRecords.size}</span>{" "}
-              selected records to the trash? They can be restored together from
-              Admin → Trash. IPAM-managed records are excluded automatically.
-            </>
+          title={
+            bulkPermanent
+              ? `Permanently delete ${selectedRecords.size} records`
+              : `Move ${selectedRecords.size} records to the trash`
           }
+          description={
+            <div className="space-y-2">
+              <p>
+                {bulkPermanent ? "Permanently delete the " : "Move the "}
+                <span className="font-medium">{selectedRecords.size}</span>{" "}
+                selected records
+                {bulkPermanent
+                  ? "? This cannot be undone."
+                  : " to the trash? They can be restored together from Admin → Trash."}{" "}
+                IPAM-managed records are excluded automatically.
+              </p>
+              {isSuperadmin && (
+                <label className="flex items-center gap-2 text-xs">
+                  <input
+                    type="checkbox"
+                    checked={bulkPermanent}
+                    onChange={(e) => setBulkPermanent(e.target.checked)}
+                  />
+                  Delete permanently (skip the trash)
+                </label>
+              )}
+            </div>
+          }
+          confirmLabel={bulkPermanent ? "Delete permanently" : "Move to trash"}
           isPending={bulkDeleteRecords.isPending}
           onConfirm={() =>
             bulkDeleteRecords.mutate(Array.from(selectedRecords))
           }
-          onClose={() => setConfirmBulkDelete(false)}
+          onClose={() => {
+            setConfirmBulkDelete(false);
+            setBulkPermanent(false);
+          }}
         />
       )}
       {showMoveZone && (


### PR DESCRIPTION
One PR for the seven issues filed while validating #951 / #953 / #955 / #956 / #961, plus the `/code-review` round on top. Five commits, grouped by area so each reads on its own.

## Backend DNS (#962, #963, #964)

- **#962** — `_apply_dns_sync` gated the DB delete on the wire op coming back `applied`, the same defect #950 fixed in bulk-delete. Agent-based servers queue `pending`, so every stale record was reported as failed and kept while the agent still removed it. Only `failed` blocks now.
- **#963** — `POST …/records/bulk-delete` hard-deleted under a plain `CurrentUser` while the singular route soft-deletes and needs superadmin for `permanent`. Now: soft-delete by default under **one shared `deletion_batch_id`** (returned, so the whole selection restores together), `?permanent=true` superadmin-only and checked **before** any wire op is enqueued, the singular route's synthesised/pool-member gate reused, duplicate ids counted once, 2000-id cap like bulk-create. UI: superadmin permanent checkbox, chunking above the cap, skipped rows surfaced.
- **#964** — the three verbatim copies of the zone-op sweep predicate are one helper, group-scoped by subquery. The name-scoping under split-horizon is a written decision — and the review corrected its mechanism: with views present the bundle ships **no** ops and retires the queue as `applied`, so the over-sweep costs nothing (pinned by a test against `build_config_bundle`). The soft zone-delete path and trash purge never swept at all; both do now.

## Appliance chart (#965, #967)

- **#965** — supervisor / looking-glass / agent-landing carry requests (50m/128Mi, 50m/64Mi, 10m/16Mi). Floors, not measurements.
- **#967** — `dhcpKea` raised to the measured **500m**; the doc now says what the chart ships. Not run: a 250m cell on the rig — this picks the value with data behind it.
- Found by the new render gate on its first run: every pod template emitted `app.kubernetes.io/name` twice in one map (last-wins in helm, rejected by strict decoders). Fixed via a `podLabels` helper; before/after renders verified equivalent.

## CI (#966, #968)

- **#966** — `Charts — Lint & Template`: helm lint + template over seven value sets (incl. the CNPG + Sentinel HA shape) + `kubeconform -strict` + a no-BestEffort check on every render + a **toggle-coverage** script that fails the gate when a template is gated on a values key no render flips (it caught nine umbrella gates the first matrix missed). `make charts-lint` runs the same script in a helm container.
- **#968** — `perf/` denied by the backend path filter; new `Perf — Tests` job. Tests only: perf/ has 25 ruff findings and 39/42 files black would reformat — a formatting change of its own.

## Also fixed on the way (review round)

Trash restore was all-or-nothing, so one hand-recreated record pinned a whole bulk batch: `?skip_conflicts=true` + "Restore the others" in the UI, and the re-push now goes per zone in one batch. Batch enqueue paid two SELECTs and a flush per record; both entry points share one fan-out. `DNS_DRIVERS.md` / `DHCP_DRIVERS.md` stated the inverse of the #950/#962 gate. `make ci` now includes the two new gates.

**Verification**: 163 backend tests across every touched suite (serial), ruff/black/mypy, frontend lint/typecheck/build, the chart gate on all seven renders with all 29 template gates covered, perf tests.

**Explicit decisions**: no `propose_*` copilot tool for bulk delete (non-negotiable #13, broad blast radius); trash batch semantics stay all-or-nothing by default (right for cascade batches).

Closes #962
Closes #963
Closes #964
Closes #965
Closes #966
Closes #967
Closes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)
