### PR TITLE
ci(nightly): gate the DST twin crons on which cron fired, not the run-time clock

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,8 +55,12 @@ on:
     # so the nightly must run AFTER their late pushes, DST included. Cron
     # is UTC-only, so schedule both candidate UTC hours (06:23 = 02:23
     # EDT, 07:23 = 02:23 EST) and let the gate job keep exactly the one
-    # where the Eastern wall clock actually reads 02 — the other fires
-    # and immediately skips. Off-the-hour minute for the same reason
+    # whose SCHEDULED slot reads 02 on the Eastern clock — the other fires
+    # and immediately skips. The gate decides from the cron string GitHub
+    # hands it (github.event.schedule), never from the clock at run time:
+    # GitHub starts these runs 40 min to 13 h late (measured, every
+    # night), so the run-time wall clock says nothing about which slot a
+    # run belongs to. Off-the-hour minute for the same reason
     # prune-release-assets.yml uses one: the top-of-hour cron stampede
     # delays runner scheduling on GitHub's shared infrastructure.
     - cron: "23 6 * * *"
@@ -114,18 +118,49 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORCE: ${{ github.event.inputs.force || 'false' }}
           EVENT_NAME: ${{ github.event_name }}
+          # The cron string that fired ("23 6 * * *"); empty on dispatch.
+          SCHEDULE: ${{ github.event.schedule }}
         run: |
           set -euo pipefail
 
-          # ── Eastern-wall-clock gate ──────────────────────────────────
+          # ── Which twin fired? ────────────────────────────────────────
           # Two UTC crons cover 02:23 America/New_York across DST (see the
-          # trigger comment). Keep the firing where Eastern actually reads
-          # 02; the other is a no-op. Manual dispatch always proceeds.
-          ET_HOUR=$(TZ=America/New_York date +%H)
-          if [ "$EVENT_NAME" = "schedule" ] && [ "$ET_HOUR" != "02" ]; then
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
-            echo "→ $(TZ=America/New_York date '+%H:%M %Z') is not the 02:xx Eastern slot; skipping (DST twin cron)"
-            exit 0
+          # trigger comment). Keep the twin whose SCHEDULED slot reads 02
+          # on the Eastern clock; the other is a no-op. Manual dispatch
+          # always proceeds.
+          #
+          # The slot comes from the cron string that fired, NOT from the
+          # clock when this step runs. GitHub starts scheduled runs late —
+          # 40 min to 13 h on this repo, every night since the twin crons
+          # landed — and the previous form of this gate compared the
+          # run-time Eastern hour to 02, so both twins always woke outside
+          # 02:xx and both skipped: no scheduled nightly built between
+          # 2026-08-09 and this change (the only nightly in that window
+          # was a manual dispatch). The cron string is immune to the delay.
+          #
+          # DST nights: on the fall-back night the 06:23 twin reads 01:23
+          # EST and the 07:23 twin 02:23 EST — one build. On the
+          # spring-forward night no Eastern 02:xx exists (01:59 → 03:00),
+          # so neither twin builds; the next night covers it.
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            # "23 6 * * *" → "6:23", today's 06:23 UTC read on the Eastern
+            # clock. A missing or odd cron string is a hard failure, never
+            # a skip — a failed gate is what finalize turns into the
+            # tracking issue, whereas a quiet skip is exactly how the
+            # previous gate went unnoticed for four weeks.
+            CRON_UTC=$(printf '%s' "$SCHEDULE" | awk '{print $2 ":" $1}')
+            if [[ ! "$CRON_UTC" =~ ^[0-9]{1,2}:[0-9]{1,2}$ ]]; then
+              echo "::error::github.event.schedule is '${SCHEDULE}' — cannot tell which twin fired"
+              exit 1
+            fi
+            SLOT_ET=$(TZ=America/New_York \
+                      date -d "$(date -u +%F) ${CRON_UTC} UTC" '+%H:%M %Z')
+            if [ "${SLOT_ET%%:*}" != "02" ]; then
+              echo "should_build=false" >> "$GITHUB_OUTPUT"
+              echo "→ cron '${SCHEDULE}' is the ${SLOT_ET} slot, not 02:xx Eastern; skipping (DST twin cron)"
+              exit 0
+            fi
+            echo "→ cron '${SCHEDULE}' is the ${SLOT_ET} slot; run started $(TZ=America/New_York date '+%H:%M %Z')"
           fi
 
           # ONE source of truth for which images exist. Both the build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -143,9 +143,9 @@ jobs:
           # spring-forward night no Eastern 02:xx exists (01:59 → 03:00),
           # so neither twin builds; the next night covers it.
           if [ "$EVENT_NAME" = "schedule" ]; then
-            # "23 6 * * *" → "6:23", today's 06:23 UTC read on the Eastern
-            # clock. A missing or odd cron string is a hard failure, never
-            # a skip — a failed gate is what finalize turns into the
+            # "23 6 * * *" → "6:23", that cron's UTC instant read on the
+            # Eastern clock. A missing or odd cron string is a hard failure,
+            # never a skip — a failed gate is what finalize turns into the
             # tracking issue, whereas a quiet skip is exactly how the
             # previous gate went unnoticed for four weeks.
             CRON_UTC=$(printf '%s' "$SCHEDULE" | awk '{print $2 ":" $1}')
@@ -153,8 +153,23 @@ jobs:
               echo "::error::github.event.schedule is '${SCHEDULE}' — cannot tell which twin fired"
               exit 1
             fi
-            SLOT_ET=$(TZ=America/New_York \
-                      date -d "$(date -u +%F) ${CRON_UTC} UTC" '+%H:%M %Z')
+            # Which day's slot? The most recent occurrence at or before now,
+            # never today's unconditionally: GitHub starts a run late but
+            # never early, so a delay that crosses UTC midnight would read
+            # TOMORROW's slot. On a same-offset day both readings agree, so
+            # this is invisible 363 nights a year — but on a DST-change day
+            # they differ by an hour and that is the whole decision. Worked
+            # example: the 02:23 EDT twin of Sat 10-31, started 00:30 UTC on
+            # Sun 11-01, reads 11-01 06:23 UTC = 01:23 EST and skips, while
+            # the 03:23 EDT twin that must skip reads 02:23 EST and builds.
+            # With the on-time twin also skipping, that night builds nothing
+            # — the same silent miss this gate was rewritten to end, just
+            # twice a year instead of nightly.
+            SLOT_UTC=$(date -u -d "$(date -u +%F) ${CRON_UTC} UTC" +%s)
+            if [ "$SLOT_UTC" -gt "$(date -u +%s)" ]; then
+              SLOT_UTC=$((SLOT_UTC - 86400))
+            fi
+            SLOT_ET=$(TZ=America/New_York date -d "@$SLOT_UTC" '+%H:%M %Z')
             if [ "${SLOT_ET%%:*}" != "02" ]; then
               echo "should_build=false" >> "$GITHUB_OUTPUT"
               echo "→ cron '${SCHEDULE}' is the ${SLOT_ET} slot, not 02:xx Eastern; skipping (DST twin cron)"


### PR DESCRIPTION
## Summary

**No scheduled nightly has built since 2026-08-09.** Every `schedule` run of `nightly.yml` since then completes "success" in 10–18 s having done nothing; the only nightly in the window is the 08-08 manual dispatch (`nightly-2026.08.08`, built-from `08d81ad`), while `main` has moved 30+ commits. The `Decide` gate tests the Eastern wall clock **when the job runs** (`TZ=America/New_York date +%H` must be `02`), but GitHub starts these crons late — every night, by a lot — so neither twin has ever woken inside 02:xx and both skip.

Measured start times of the twins (should be 02:23 EDT):

| night | 06:23 UTC twin started | 07:23 UTC twin started | late by |
|---|---|---|---|
| 08-09 | 03:26 EDT | 04:05 EDT | 1 h |
| 08-28 | 14:49 EDT | 15:29 EDT | 12–13 h |
| 09-01 | 07:46 EDT | 08:37 EDT | 5 h |
| 09-04 | 07:27 EDT | 08:10 EDT | 5 h |

(`gh run list --workflow nightly.yml`, 56 scheduled runs since 08-09, all 10–18 s, all skipped with `→ HH:MM EDT is not the 02:xx Eastern slot; skipping (DST twin cron)`.)

This PR keeps the twin-cron design and fixes the gate: decide from **which cron fired** (`github.event.schedule`, the cron string, immune to scheduler delay), reading that cron's scheduled UTC instant on the Eastern clock and keeping the twin whose slot is 02:xx. A missing or malformed cron string now fails the gate (so `finalize` opens the tracking issue) instead of quietly skipping — a quiet skip is exactly how this went unnoticed for four weeks. `workflow_dispatch` behaviour is unchanged.

Behaviour on the two DST nights, for the record: fall-back → the 07:23 twin reads 02:23 EST, one build; spring-forward → no Eastern 02:xx exists that night, neither twin builds, the next night covers it (same as the design's stated intent).

Considered and not taken: dropping the time gate and letting the second twin skip on "today's pre-release already exists". Delay-immune too, and it would even cover a dropped first twin, but it changes which slot builds in winter (01:23 EST) and re-runs a failed build an hour later; the one-line-in-spirit fix above preserves the 02:23-year-round intent exactly.

## Area

- [x] Deployment (Compose / K8s / Appliance) — CI, `nightly.yml` only

## Test plan

- [x] **faketime matrix of the exact gate block** (GNU date 9.4 + tzdata, the same coreutils as `ubuntu-latest`): 15 cases — both twins delayed 5 h and 13 h in EDT, on time in EDT and EST, delayed in EST, a delay past UTC midnight, the 2026-11-01 fall-back and 2027-03-14 spring-forward nights. All decide as documented above; the previous gate skips every delayed case. Plus: empty and garbage `github.event.schedule` exit 1 with a `::error`, and `workflow_dispatch` passes through.

  <details><summary>Matrix output on <code>ubuntu-latest</code> (spatiumddi-qa run 33902702507, all 15 match, empty schedule → exit 1, dispatch passes through)</summary>

  ```
  CASE                               SCHEDULE     NOW (UTC)            WANT   GOT
  EDT delayed 5h, twin1              23 6 * * *   2026-09-04 11:27:00  build  build
  EDT delayed 5h, twin2              23 7 * * *   2026-09-04 12:10:00  skip   skip
  EDT delayed 13h, twin1             23 6 * * *   2026-08-28 18:49:00  build  build
  EDT delayed 13h, twin2             23 7 * * *   2026-08-28 19:29:00  skip   skip
  EDT on time, twin1                 23 6 * * *   2026-09-04 06:23:30  build  build
  EDT on time, twin2                 23 7 * * *   2026-09-04 07:23:30  skip   skip
  EDT delayed past UTC midnight      23 6 * * *   2026-09-05 00:30:00  build  build
  EST delayed, twin1                 23 6 * * *   2026-12-04 07:00:00  skip   skip
  EST delayed, twin2                 23 7 * * *   2026-12-04 08:30:00  build  build
  EST on time, twin2                 23 7 * * *   2026-12-04 07:23:30  build  build
  spring-fwd 2027-03-14 twin1 early  23 6 * * *   2027-03-14 06:50:00  skip   skip
  spring-fwd 2027-03-14 twin1 late   23 6 * * *   2027-03-14 07:30:00  skip   skip
  spring-fwd 2027-03-14 twin2        23 7 * * *   2027-03-14 08:00:00  skip   skip
  fall-back 2026-11-01 twin1         23 6 * * *   2026-11-01 06:40:00  skip   skip
  fall-back 2026-11-01 twin2         23 7 * * *   2026-11-01 07:40:00  build  build
  ```
  The previous gate, evaluated at the same instants, builds only where the delayed start happens to land inside 02:xx (four rows: the two on-time slots, plus 02:00 EST and 02:40 EST by luck) and skips every other row — including every delayed EDT night, which is every night since 08-09.
  </details>

- [x] **Real `schedule` event** in the private `spatiumddi-qa` sandbox, on a probe workflow that runs the gate block extracted byte-for-byte from this PR's `nightly.yml`: the `23 18 * * *` cron was started by GitHub **2 h 26 min late** (20:48 UTC) and the gate still decided from the cron string — `is the 14:23 EDT slot … skipping` — see the comment below for the log. The real `23 6`/`23 7` twins run on the same probe tonight (expected build/skip) and will be posted as a comment.
- [x] `actionlint` on the changed file: no new findings (one pre-existing SC2129 style note on the original `$GITHUB_OUTPUT` echoes).
- [ ] The first real proof is tomorrow's 06:23 UTC twin on `main` after merge — it should log `→ cron '23 6 * * *' is the 02:23 EDT slot; run started HH:MM EDT` and go on to build.

Downstream context: ddi-pg's full-lane QA (cluster_gate/api_cluster/gate_load/ha/ha_upgrade) walks the nightly's ISO + slot image, so it has had nothing new to walk since 08-08; its wall raises a "nightly lane STALE" banner for exactly this.

## Related issues

Refs #849 (the twin-cron rewrite this fixes), #805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
