### PR TITLE
docs: privacy statement — no telemetry, and a CI guard that keeps it true

### DIFF
--- a/.github/scripts/ci-backend-must-run.txt
+++ b/.github/scripts/ci-backend-must-run.txt
@@ -30,6 +30,12 @@ agent/supervisor/spatium_supervisor/
 # that its output still goes through app.openapi()'s wrapper.
 scripts/export_openapi.py
 
+# test_outbound_hosts_documented.py (#976) asserts every hostname literal in
+# backend/app is documented in the privacy statement. docs/ is denied
+# wholesale, so without this carve-out a PR that quietly deletes a row from
+# PRIVACY.md would go green — the one edit that must run the guard.
+docs/PRIVACY.md
+
 # The gate machinery itself: the script, this manifest, and the tests that
 # pin them. Any edit here must run the suite that contains those tests.
 .github/scripts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Always read the relevant spec doc(s) before writing code for a feature area.
 | `docs/OBSERVABILITY.md` | Logging (centralized + UI viewer), metrics, health dashboard, alerting |
 | `docs/TROUBLESHOOTING.md` | Recovery recipes: accidentally deleted agent rows, password reset, subnet delete refused |
 | `docs/THIRD_PARTY.md` | Catalogue of every bundled/shipped third-party component — engine, library, OS package — with license, the artifact it ships in, and the rationale. Operator-facing companion to the root `NOTICE` (which stays authoritative for license text). **When you add a shipped component, update BOTH** |
+| `docs/PRIVACY.md` | The privacy statement — no telemetry, no analytics, no phone-home — plus the **normative table of every outbound connection** the backend can make, its default, and what it sends. `backend/tests/test_outbound_hosts_documented.py` fails CI when a hostname literal in `backend/app` is absent from it. **When you add an outbound call, update this page in the same PR** (see non-negotiable #17) |
 | `docs/features/IPAM.md` | IP Space/Block/Subnet/Address management, VLAN/VXLAN, custom fields, import/export, tree UI |
 | `docs/features/DHCP.md` | DHCP servers, scopes, pools, static assignments, DDNS, caching, Windows DHCP (Path A) |
 | `docs/features/DNS.md` | DNS servers, zones, records, views, server groups, blocking lists, DDNS, zone tree, Windows DNS (Path A + B), Technitium, encrypted transports (DoT / DoH / DoQ), DNS threat analytics, sync-with-servers reconciliation |
@@ -146,6 +147,8 @@ These rules apply to every file Claude Code generates. No exceptions.
 14. **Feature-module gating for new top-level surfaces**: When adding a new top-level resource family (sidebar section, REST router prefix, MCP tool cluster), evaluate whether it should be a togglable feature module. If yes: (a) add a `ModuleSpec` to `app.services.feature_modules.MODULES`, (b) seed a row in a migration alongside the model migration, (c) apply `dependencies=[Depends(require_module("…"))]` to the router include in `app/api/v1/router.py`, (d) tag MCP tools with `module="…"` in their `register_tool(...)` call, (e) carry `module: "…"` on the matching sidebar `NavItem` definition. Default-enabled, per #13's discovery argument — operators turn off what they don't use
 15. **New integrations show up on the Dashboard — both surfaces**: When adding an integration mirror (Kubernetes / Docker / Proxmox / Tailscale / UniFi shape — read-only pull reconciler with per-target rows), wire it into BOTH dashboard surfaces: (1) the `IntegrationsPanel` inside the IPAM tab on `frontend/src/pages/DashboardPage.tsx` — add the `useQuery` gated on the `integration_*_enabled` flag, thread `enabled` + row list through props, extend column-count + grid cn() case, add a panel block following the existing icon + name + count + view-all + per-row `IntegrationRow` pattern; (2) the dedicated **Integrations dashboard tab** at `backend/app/api/v1/dashboards/integrations.py` — append a target query, add a `_build_panel(...)` entry to the `panels` list, register the new resource_type string in `_INTEGRATION_RESOURCE_TYPES` so reconciler error-audit rows surface in the recent-errors list, and extend the frontend `IntegrationDashboardKind` union in `lib/api.ts`. Both surfaces are operator-facing health rollups; missing either one means a new integration is invisible somewhere it should be obvious
 16. **Per-role node-label gating for every new workload**: Every new top-level workload (Deployment / StatefulSet / DaemonSet) added to `charts/spatiumddi/` or `charts/spatiumddi-appliance/` gates scheduling on a per-role node label (`spatium.io/role-<service>=true`), not on chart-render `values.<svc>.enabled` toggles. The `nodeSelector` block merges `global.nodeSelector` (the umbrella `spatium.io/role=appliance` gate) AND a per-role label. Labels are stamped by two paths that already exist: install-time bake in `appliance/mkosi.extra/usr/local/bin/spatium-install`'s `config.yaml.d/spatium-roles.yaml` drop-in for `full-stack` / `control-only` variants; dynamic apply via the supervisor's `kubectl label` (`agent/supervisor/spatium_supervisor/k8s_api.py`) for `application` variants on role-assignment changes. `enabled: false` values stay as a global suppression knob; the per-role label is the source of truth for *which* node a workload lands on. Reference pattern: `charts/spatiumddi-appliance/templates/{dns-bind9,dhcp-kea}.yaml`. Without this, multi-node HA (#272) silently schedules control-plane workloads on DNS-only nodes — invisible misplacement that won't surface until the first node loss.
+
+17. **No telemetry.** SpatiumDDI has no phone-home, no usage analytics, no crash reporting, and no project-controlled endpoint — and there is never to be one. Never add an outbound connection that is not operator-configured and documented in [`docs/PRIVACY.md`](docs/PRIVACY.md) with its default and its payload; a hostname literal in `backend/app` that is absent from that page fails CI (`backend/tests/test_outbound_hosts_documented.py`). Anything **default-on** needs an issue and a decision, not a PR: today exactly one connection is enabled out of the box (the daily anonymous GitHub release check), the README / docs hero / Settings copy all say so in those words, and a second one makes all three false at once
 
 ---
 
@@ -1111,6 +1114,34 @@ suggestion, free-space treemap.
 - ✅ [**Account lockout after N failed logins**](https://github.com/spatiumddi/spatiumddi/issues/71) — shipped `2026.05.07-1`: windowed-counter lockout for local-auth users over `user.failed_login_count` / `failed_login_locked_until` / `last_failed_login_at`, reset on any success. Defaults to disabled (`threshold=0`). Migration `a7b3c8d92e14`.
 - ✅ [**Active session viewer + force-logout**](https://github.com/spatiumddi/spatiumddi/issues/72) — shipped `2026.05.07-1`: live JWT registry the operator can browse and revoke from — access tokens carry a `jti`, and `user_session` gains `auth_source` / `last_seen_at` / `revoked` + a `(revoked, expires_at)` index. Migration `c8e4f7a91d36`.
 - ✅ [**Internal cert + secret expiry monitoring**](https://github.com/spatiumddi/spatiumddi/issues/76) — shipped `2026.06.11-1`: one `secret_expiring` alert rule that fires per internal credential expiring within `threshold_days` — supervisor mTLS certs (`appliance.cert_expires_at`) + API tokens (`api_token.expires_at`). Extended in `2026.06.19-1` to cover the Let's Encrypt Web-UI cert (#438).
+- ✅ [**Privacy statement — no telemetry, no analytics, your data stays in your install**](https://github.com/spatiumddi/spatiumddi/issues/976)
+  — SpatiumDDI has been privacy-first by construction since the first commit
+  and said so **nowhere**, so an operator evaluating a platform that will hold
+  every hostname, lease and subnet they own had to infer it from the absence of
+  a settings page. Now [`docs/PRIVACY.md`](docs/PRIVACY.md) (short form in the
+  README, linked from the docs nav, footer and hero), written from a sweep of
+  every outbound connection in the tree rather than from a slogan.
+  **The release check stays default-on and is disclosed in the first
+  paragraph**, not a footnote — the issue's other option was flipping it to
+  opt-in so the headline sentence needed no exception. It is an unauthenticated
+  GET that carries *nothing* about the install, GitHub is the only party that
+  sees it, and an operator who misses a security fix is worse off than one
+  whose firewall logged a daily GET; the Settings → Application → Updates toggle that
+  closes it now says exactly that instead of being an unlabelled switch.
+  **The guard is the deliverable, not the prose.** A statement like this rots
+  the first time somebody adds a convenience fetch — it does not go vague, it
+  goes *false*. `backend/tests/test_outbound_hosts_documented.py` scans
+  `backend/app` for hostname literals and fails until each appears on the page,
+  and a second test pins §3.1 to **one** row, because the README, the docs hero
+  and the Settings copy all state there is exactly one default-on connection
+  and a second would falsify three surfaces at once. Both lists — connections
+  *and* non-connections — live in PRIVACY.md rather than in a test allowlist,
+  so filing a real endpoint under "not a connection" is a lie a human has to
+  type into the document readers actually read. `docs/PRIVACY.md` is a declared
+  carve-out in `.github/scripts/ci-backend-must-run.txt`, or deleting a row
+  from it would go green (docs/ is denied wholesale). The sweep found six
+  hostnames the hand-written issue table missed, which is the argument for the
+  guard in one line. See non-negotiable #17.
 - ⬜ [**FIPS 140-3 posture**](https://github.com/spatiumddi/spatiumddi/issues/880) — crypto audit plus a tiered
   roadmap for a FIPS-capable build (containers / Kubernetes /
   appliance). Gate for government deployments; the audit comes first

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 
 - [Why I built this](#why-i-built-this) — the story
 - [Why SpatiumDDI](#why-spatiumddi) — the elevator pitch
+- [Privacy: your data stays yours](#privacy-your-data-stays-yours) — no telemetry, no analytics, no phone-home
 - [Support the project](#support-the-project) — sponsors, tip jar, getting involved
 - [What's in the box](#whats-in-the-box) — quick capability tour
 - [Full feature detail](#full-feature-detail) — deep dive on every subsystem
@@ -98,6 +99,12 @@ SpatiumDDI is built on nights and weekends with no commercial backing — every 
 **Built for delegation.** Group-based RBAC with LDAP, OIDC, SAML, RADIUS, and TACACS+ (with backup-server failover). Hand a subnet or a zone to a department without handing over root.
 
 **API-first.** Every UI action is a REST call. Terraform, Ansible, and ad-hoc scripts all speak the same surface. If you can click it, you can automate it.
+
+## Privacy: your data stays yours
+
+SpatiumDDI collects **no telemetry, no usage analytics, no crash reports, and no account or registration data**. There is no phone-home, no license server, no sign-up, and no project-controlled endpoint the software talks to. Everything you put in it — zones, records, leases, subnets, credentials, query logs, audit history — lives in *your* PostgreSQL on *your* infrastructure, and the maintainers have no way to see it and do not want it. This README, the documentation site and the web UI use no analytics or tracking scripts.
+
+The software makes no outbound connection you did not configure, with one exception: a **daily anonymous check of GitHub for a newer release** (an unauthenticated GET; GitHub sees your IP address and nothing about your install — no version, no counts, no identifiers). Turn it off under **Settings → Application → Updates → Check for GitHub Releases**, or run fully air-gapped — every feature works with no internet access at all. Optional features that do reach third parties (Fingerbank device profiling, the Operator Copilot's LLM provider, Let's Encrypt, blocklist feeds, cloud DNS / integration mirrors, the whois and RBL tools) are off until you configure them, and [docs/PRIVACY.md](docs/PRIVACY.md) lists exactly what each one sends, to whom, and how to stop it.
 
 ## What's in the box
 

--- a/backend/tests/test_ci_backend_relevant.py
+++ b/backend/tests/test_ci_backend_relevant.py
@@ -48,6 +48,7 @@ _KNOWN_REPO_ROOT_READS: dict[str, str] = {
     ),
     "test_ci_backend_relevant.py": ".github/scripts/ci-backend-relevant.sh",
     "test_openapi_export.py": "scripts/export_openapi.py",
+    "test_outbound_hosts_documented.py": "docs/PRIVACY.md",
 }
 
 # ``parents[2]`` from backend/tests/x.py is the repo root; anything at that

--- a/backend/tests/test_outbound_hosts_documented.py
+++ b/backend/tests/test_outbound_hosts_documented.py
@@ -120,6 +120,17 @@ def test_exactly_one_connection_is_enabled_by_default() -> None:
     assert len(rows) == 2, (
         f"§3.1 has {len(rows) - 1} default-on connection(s), expected 1. Adding one "
         "is a product decision (CLAUDE.md non-negotiable #17), and the README, the "
-        "docs hero and Settings → Platform all state there is exactly one."
+        "docs hero and Settings → Application → Updates all state there is exactly one."
     )
-    assert "api.github.com" in rows[1], "the one default-on row should be the release check"
+    # Read the first cell's code span and compare it whole. A substring test
+    # would also pass on a row that merely mentions the host in prose — and
+    # CodeQL flags ``"api.github.com" in row`` as incomplete URL sanitization,
+    # correctly in general even though nothing is being sanitized here.
+    first_cell = re.match(r"\|\s*`([^`]+)`", rows[1])
+    assert (
+        first_cell is not None
+    ), f"§3.1's data row should name its host in a code span, got: {rows[1]!r}"
+    assert first_cell.group(1) == "api.github.com", (
+        f"the one default-on connection should be the release check, "
+        f"not {first_cell.group(1)!r}"
+    )

--- a/backend/tests/test_outbound_hosts_documented.py
+++ b/backend/tests/test_outbound_hosts_documented.py
@@ -1,0 +1,125 @@
+"""Every hostname in the backend is documented in docs/PRIVACY.md (#976).
+
+SpatiumDDI's privacy statement claims something specific and checkable:
+the software makes exactly one outbound connection nobody configured (a
+daily anonymous release check against GitHub), and every other host it
+can reach is listed with its default and its payload. A claim like that
+rots the first time somebody adds a convenience fetch — the statement
+does not become vague, it becomes *false*, which is worse than never
+having made it.
+
+So this is the guard, in the shape of ``lint_untyped_routes.py`` and
+``test_response_media_types.py``: scan ``backend/app`` for hostname
+literals and require each one to appear on the page. A new outbound host
+fails CI until somebody writes down what it sends and when.
+
+**Both lists live in PRIVACY.md, not here.** A host that is *not* a
+connection — a documentation link, a homepage shown in the UI, an
+``example.com`` placeholder — goes in that page's appendix rather than
+into an allowlist in this file. That costs a line of prose and buys the
+property that matters: filing a real endpoint under "not a connection"
+is a lie a human has to type into the document readers actually read,
+instead of a quiet entry in a test fixture.
+
+**What the guard cannot see**, stated in PRIVACY.md §8 as well:
+
+* hosts assembled at runtime from operator input (``https://{host}/…``)
+  — which is the point, those are the operator's own endpoints;
+* the feed catalogues under ``backend/app/data/*.json`` (blocklist
+  sources, resolver presets), which are covered as a category by the
+  blocklist row and are all opt-in downloads.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+# Spelled as an explicit repo-root escape (``parents[2]``) rather than
+# ``backend/``.parent, because test_ci_backend_relevant.py scans for exactly
+# that spelling to prove every cross-boundary read is declared in the CI
+# must-run manifest — reaching the repo root by a route its regex cannot see
+# would silently drop docs/PRIVACY.md out of the gate that runs this test.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_BACKEND = _REPO_ROOT / "backend"
+_APP = _BACKEND / "app"
+_PRIVACY = _REPO_ROOT / "docs" / "PRIVACY.md"
+
+# The dev container copies only ``backend/`` into the image, so this skips
+# there and runs for real in CI, which tests from a full checkout. Same
+# convention as test_spatium_console.py and test_openapi_export.py.
+pytestmark = pytest.mark.skipif(
+    not _PRIVACY.exists(),
+    reason="docs/PRIVACY.md not present in this checkout",
+)
+
+# The character class deliberately excludes ``{`` and ``$``, so an
+# interpolated ``https://{host}/api`` yields no match at all rather than a
+# bogus one.
+_URL_RE = re.compile(r"https?://([A-Za-z0-9._-]+)")
+
+# A match has to look like a real hostname before we demand it be
+# documented. This drops the debris of scanning source text: ``https://...``
+# in a docstring ellipsis, a bare ``https://localhost``, a loopback literal,
+# and the truncated fragments left by a URL hard-wrapped across two lines.
+_HOSTNAME_RE = re.compile(r"^(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z]{2,}$")
+
+
+def _hosts_in_source() -> dict[str, set[str]]:
+    """Map each hostname literal under ``backend/app`` to the files using it."""
+    found: dict[str, set[str]] = {}
+    for path in sorted(_APP.rglob("*.py")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for host in _URL_RE.findall(text):
+            host = host.lower().rstrip(".")
+            if not _HOSTNAME_RE.match(host):
+                continue
+            found.setdefault(host, set()).add(str(path.relative_to(_BACKEND)))
+    return found
+
+
+def test_every_backend_hostname_is_in_the_privacy_statement() -> None:
+    """A hostname the backend knows about is either a documented connection
+    or a documented non-connection. There is no third category."""
+    privacy = _PRIVACY.read_text(encoding="utf-8").lower()
+    undocumented = {
+        host: sorted(files) for host, files in _hosts_in_source().items() if host not in privacy
+    }
+    assert not undocumented, (
+        "hostname(s) in backend/app that docs/PRIVACY.md does not mention: "
+        + "; ".join(f"{h} ({', '.join(f)})" for h, f in sorted(undocumented.items()))
+        + ". If it is an outbound connection, add a row to the table in §3 with its "
+        "default and what it sends. If it is a documentation link or a placeholder, "
+        "add it to the appendix. Do not add an allowlist to this test."
+    )
+
+
+def test_exactly_one_connection_is_enabled_by_default() -> None:
+    """§3.1 stays a one-row table.
+
+    The headline sentence — "no outbound connection you did not configure,
+    with one exception" — is only true while this table has one row in it,
+    and the README, the docs hero and the Settings copy all repeat it. Per
+    CLAUDE.md non-negotiable #17 a second default-on connection needs an
+    issue and a decision; this makes adding one a deliberate act rather
+    than a table edit nobody noticed.
+    """
+    text = _PRIVACY.read_text(encoding="utf-8")
+    section = text.split("### 3.1 Enabled by default", 1)
+    assert len(section) == 2, "PRIVACY.md lost its '### 3.1 Enabled by default' heading"
+    body = section[1].split("###", 1)[0]
+
+    rows = [
+        line
+        for line in body.splitlines()
+        if line.startswith("|") and not re.fullmatch(r"[|\s:-]+", line)
+    ]
+    # Header row + the single data row.
+    assert len(rows) == 2, (
+        f"§3.1 has {len(rows) - 1} default-on connection(s), expected 1. Adding one "
+        "is a product decision (CLAUDE.md non-negotiable #17), and the README, the "
+        "docs hero and Settings → Platform all state there is exactly one."
+    )
+    assert "api.github.com" in rows[1], "the one default-on row should be the release check"

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,267 @@
+---
+layout: default
+title: Privacy
+description: SpatiumDDI collects no telemetry, no analytics and no account data — and this page lists every outbound connection the software can make, what each one sends, and how to turn it off.
+---
+
+# Privacy: your data stays yours
+
+SpatiumDDI collects **no telemetry, no usage analytics, no crash
+reports, and no account or registration data**. There is no
+phone-home, no license server, no sign-up, and no project-controlled
+endpoint the software talks to. Everything you put in it — zones,
+records, leases, subnets, credentials, query logs, audit history —
+lives in *your* PostgreSQL on *your* infrastructure, and the
+maintainers have no way to see it and do not want it. The
+documentation site and the web UI use no analytics or tracking
+scripts.
+
+The software makes no outbound connection you did not configure, with
+one exception: a **daily anonymous check of GitHub for a newer
+release** (an unauthenticated GET; GitHub sees your IP address and
+nothing about your install). Turn it off under **Settings →
+Application → Updates → Check for GitHub Releases**, or run fully
+air-gapped — every feature works with no internet access at all.
+Optional features that do reach third parties (Fingerbank device
+profiling, the Operator Copilot's LLM provider, Let's Encrypt,
+blocklist feeds, cloud DNS / integration mirrors, the whois and RBL
+tools) are off until you configure them,
+and the table below lists exactly what each one sends and to whom.
+
+There is no telemetry endpoint to opt out of, because there is no
+telemetry endpoint. That is a design constraint, not a current state:
+[CLAUDE.md](https://github.com/spatiumddi/spatiumddi/blob/main/CLAUDE.md)
+non-negotiable #17 forbids adding one, and a CI test
+(`backend/tests/test_outbound_hosts_documented.py`) fails the build
+when a hostname appears in the backend that is not documented on this
+page.
+
+---
+
+## 1. What is never collected
+
+| | |
+|---|---|
+| Usage analytics / product telemetry | None. No counters, no feature-usage pings, no "anonymous statistics" toggle, because there is nothing behind it. |
+| Crash / error reporting | None. Errors go to your structured logs and the in-app diagnostics table. No Sentry, no Bugsnag, no third-party error sink. |
+| Accounts / registration / licensing | None. SpatiumDDI has no account system of its own, no activation, no entitlement check, and no trial timer. Apache 2.0, run it. |
+| Your DDI data | Never leaves your PostgreSQL unless you configure something that sends it (an integration to your own controller, a backup target you own, an alert webhook you point somewhere). |
+| Web UI tracking | The frontend loads no external script, font, or CDN asset. `frontend/index.html` pulls exactly one file: the app bundle from your own server. |
+| Docs site tracking | `www.spatiumddi.com` is a static Jekyll site with no analytics tag, no tracker pixel, and no third-party font or CDN include. |
+
+## 2. The one connection that is on by default
+
+**Daily GitHub release check** — `GET https://api.github.com/repos/spatiumddi/spatiumddi/releases/latest`
+
+Fired once a day by Celery Beat
+(`backend/app/tasks/update_check.py`), so the UI can tell you a newer
+release exists. It is:
+
+* **unauthenticated** — no token, no identifier, no cookie;
+* **empty in the outbound direction** — the request carries no version
+  string, no install id, no counts, no hostnames. Nothing about your
+  deployment is in it;
+* **anonymous to us and visible only to GitHub** — GitHub sees the
+  source IP address and an HTTP client User-Agent, exactly as it would
+  if you loaded the releases page in a browser. SpatiumDDI's
+  maintainers operate no server in this path and receive nothing.
+
+It is on by default because it is genuinely empty and because an
+operator who does not know a security fix shipped is worse off than
+one whose firewall logged a daily GET to GitHub. If you would rather
+it did not happen, one toggle stops it:
+
+**Settings → Application → Updates → Check for GitHub Releases** (or
+`PlatformSettings.github_release_check_enabled = false`). With it off,
+the task returns immediately and opens no socket. Nothing else in the
+product degrades — you simply do not get the "update available" pill.
+
+## 3. Every outbound connection, in full
+
+This table is normative. A hostname that appears in `backend/app` and
+not here fails CI (see §8).
+
+### 3.1 Enabled by default
+
+| Connection | What is sent | Turn it off with |
+|---|---|---|
+| `api.github.com` — daily release check | Anonymous GET. GitHub sees your IP + User-Agent; nothing about the install. | Settings → Application → Updates → *Check for GitHub Releases* |
+
+That is the whole list.
+
+### 3.2 On demand — only when an operator clicks
+
+| Connection | Feature | What is sent |
+|---|---|---|
+| `api.github.com` | The Releases view / Appliance → Fleet → Slot images (`services/appliance/releases.py`) | Anonymous GET for the release list and appliance-image asset names. |
+| `data.iana.org`, `rdap.arin.net`, `rdap.db.ripe.net`, `rdap.apnic.net`, `rdap.lacnic.net`, `rdap.afrinic.net` | Domain + ASN registration lookup (#85), and the *Refresh now* button | The domain name or ASN being looked up. RDAP is a public registry query — by nature the registry learns what you asked about. |
+| `crt.sh` | TLS certificate → *Certificate Transparency* cross-reference | The hostname being checked. Explicitly on-demand, never run by the scheduled probe, and the matching copilot tool ships disabled. |
+| RBL / DNSBL zones (`zen.spamhaus.org`, `bl.spamcop.net`, …) | Tools → RBL check | A DNS query encoding the IP being checked, to the list operator's resolver. |
+| Public resolvers | Tools → DNS propagation check | The name being queried, to each resolver in the chosen set. |
+| Whois / RDAP servers | Tools → whois | The name or IP being looked up. |
+
+Everything in this section is a per-click action with a visible result;
+nothing here runs on a schedule.
+
+### 3.3 Off until you configure them
+
+| Connection | Feature | Default | What is sent |
+|---|---|---|---|
+| RBL / DNSBL zones | Scheduled DNSBL monitoring | off — `dnsbl_monitoring_enabled=false`, **and** every catalogue list ships disabled, so both a master switch and a per-list opt-in are required | A DNS query encoding each monitored IP, to the list operator's resolver. |
+| `standards-oui.ieee.org` | MAC vendor database refresh | `oui_lookup_enabled=false` | Nothing — a CSV download. |
+| `api.fingerbank.org` | DHCP device profiling | off; requires **your** Fingerbank API key | **Sends observed fingerprints**: DHCP option 55, option 60, and the client MAC address. The most identifying outbound call in the product — read `docs/features/DHCP.md` before enabling it. |
+| `api.openai.com`, `generativelanguage.googleapis.com`, Azure OpenAI (`<your-resource>.openai.azure.com`), Anthropic | Operator Copilot | off; no provider is configured out of the box | **Sends prompts and tool results** — which can include hostnames, subnets and record data — to whichever provider you point it at. Can be fully on-prem: Ollama, vLLM and LocalAI all work through the `openai_compat` driver, in which case nothing leaves your network. |
+| `acme-v02.api.letsencrypt.org`, `acme-staging-v02.api.letsencrypt.org`, or any ACME directory you name | Embedded ACME client (#438) | off | A standard ACME order: the domains you are requesting a certificate for. Those names end up in public Certificate Transparency logs — that is how public CAs work, not something SpatiumDDI adds. |
+| Blocklist feed hosts (Hagezi, OISD, AdGuard, urlhaus, phishing.army, … — the catalogue is `backend/app/data/dns_blocklist_catalog.json`) | RPZ blocking lists | off per list | Nothing — an HTTPS download of the list, once per refresh interval, per list you subscribed to. |
+| `api.cloudflare.com`, `dns.hetzner.com`, `api.linode.com`, `api.vultr.com`, `api.digitalocean.com`, plus the AWS / Azure / Google SDK endpoints | Agentless cloud DNS drivers | off; one server row per provider | Zone and record operations, with **your** credentials, to **your** tenant. |
+| `api.meraki.com`, `api.netbird.io`, `api.tailscale.com`, `login.tailscale.com`, `api.ui.com` | Vendor-hosted integration mirrors (Meraki, NetBird, Tailscale, UniFi cloud) | off; one target row each | Read-only API calls with your credentials to your own tenant. Self-hosted integrations (Proxmox, OPNsense, PAN-OS, FortiGate, Kubernetes, Docker, …) reach only the address you type. |
+| `stat.ripe.net`, `www.peeringdb.com`, `ris-live.ripe.net`, `rpki.cloudflare.com`, `rpki-validator.ripe.net` | BGP Looking Glass enrichment | off (`bgp.*` feature modules) | The ASN or prefix being enriched. |
+| Your alert / notification endpoints (Slack webhook, generic webhook, SMTP relay) | Alerting | off until a channel is configured | The alert payload, to the URL or relay you entered. |
+| Your audit-forward endpoint | Audit forwarding | off | Audit rows, to the URL you entered. |
+| Your backup destination (S3, Azure Blob, GCS, WebDAV, SMB, FTP, SCP) | Backup targets | off; local volume by default | The encrypted backup archive, to the destination you configured. |
+
+### 3.4 Appliance host (OS-level, not the application)
+
+The OS appliance is a Debian host, and a Debian host talks to the
+network the way Debian hosts do:
+
+| Connection | Default | Change it under |
+|---|---|---|
+| `pool.ntp.org` — time sync | on (cloud-init's default pool) | Appliance → Fleet → Services → NTP; point it at an internal server or a unicast peer |
+| Debian APT mirrors (`deb.debian.org`, `security.debian.org`) | host default | Appliance → Fleet → Services → APT sources — managed repositories, an internal mirror, or a proxy |
+| `ghcr.io` — container image pulls at slot upgrade | only during an upgrade | Not needed at all if you upgrade from an uploaded slot image; the ISO already carries every image it runs |
+
+None of this is SpatiumDDI-specific traffic and none of it carries
+your DDI data.
+
+## 4. Air-gapped operation
+
+Every feature works with all of the above blocked. That is not a
+claim about the happy path — it is non-negotiable #5 in the project's
+own build rules: **DNS and DHCP service containers cache their
+last-known-good config locally and keep serving when the control plane
+is unreachable**, and by the same logic nothing in the control plane
+requires an internet round-trip to function.
+
+Concretely, on an air-gapped install:
+
+* the appliance ISO ships every container image in its rootfs, so
+  install and first boot need no registry;
+* upgrades are an uploaded `.raw.xz` slot image, verified against its
+  SHA-256 sidecar;
+* the release check fails, logs a warning, and stamps
+  `latest_check_error` — it does not retry in a loop or block anything.
+  Turning it off removes even that;
+* blocklists, OUI data and device profiling are simply features you do
+  not enable.
+
+## 5. The support bundle
+
+`POST /system/support-bundle` (#875) produces the diagnostics archive
+you would attach to a bug report. It is **generated locally and
+uploaded nowhere** — the response is a download; SpatiumDDI has no
+endpoint to send it to.
+
+Because a bug report on a public repository is public, the bundle is
+scrubbed in two tiers:
+
+* **Secrets are hard-excluded in every mode**, including the
+  unscrubbed one — Fernet-encrypted values, bcrypt/argon2 hashes, PEM
+  blocks, JWTs, pre-shared keys and TSIG secrets, matched by field
+  name *and* by value shape.
+* **Identifiers are pseudonymised**, not deleted: IP addresses,
+  hostnames, MAC addresses and usernames are replaced with stable
+  synthetic values derived by HMAC from your install's `SECRET_KEY`.
+  Topology survives (the same /24 maps to the same synthetic /24, with
+  the host octet preserved) so the archive is still diagnosable, and
+  the mapping is unguessable outside your install. Synthetic IPv4
+  lands in `240.0.0.0/6`; the IPv6 interface identifier is discarded
+  rather than mapped, because SLAAC embeds the MAC address.
+
+The **decode map** — the only thing that can reverse the
+pseudonymisation — is a separate endpoint and is **never included in
+the archive**. It does not leave your install unless you deliberately
+send it to someone.
+
+## 6. The mobile app
+
+The [SpatiumDDI mobile app](https://github.com/spatiumddi/spatiumddi-mobile)
+lives in its own repository and carries the same promise: it speaks
+only to **your** control plane's REST API, at the address you enrol it
+against. It has no backend of its own, no analytics SDK, and no
+account. Enrolment is a QR code minted inside your authenticated
+session (#906), carrying your control plane's address, an API token
+you created, and the TLS certificate fingerprint the client pins.
+
+## 7. Who can see what, inside your install
+
+Privacy from the outside world is one half; the other half is that
+SpatiumDDI is built to be delegated without handing over everything:
+
+* group-based RBAC with per-resource grants — a department admin can
+  hold one subnet or one zone (`docs/PERMISSIONS.md`);
+* every mutation is written to an append-only, hash-chained audit log
+  before the response returns (non-negotiable #4), so administrative
+  access is recorded rather than assumed;
+* credentials at rest (provider secrets, agent keys, cloud tokens) are
+  Fernet-encrypted with your `CREDENTIAL_ENCRYPTION_KEY` (or a key
+  derived from `SECRET_KEY` when you have not set one) and never
+  returned by the API — endpoints report `*_set: true`, not the value.
+
+## 8. Keeping this page true
+
+A privacy statement rots the first time somebody adds a convenience
+fetch. Two guards keep this one honest:
+
+* **`backend/tests/test_outbound_hosts_documented.py`** walks
+  `backend/app` for hostname literals and asserts every one of them
+  appears on this page. A new outbound host fails CI until it is
+  documented here, with its default and its payload. Editing this file
+  runs that suite (it is a declared carve-out in
+  `.github/scripts/ci-backend-must-run.txt`).
+* **CLAUDE.md non-negotiable #17** — *No telemetry.* Never add an
+  outbound connection that is not operator-configured and documented
+  here; anything default-on needs an issue and a decision, not a PR.
+
+The guard covers Python source under `backend/app`. Two things it
+cannot see, and which therefore need a human: hosts assembled at
+runtime from operator input (which is the point — those are *your*
+endpoints), and the feed catalogues in `backend/app/data/`, whose
+entries are all opt-in downloads covered by the blocklist row above.
+
+If you find a connection this page does not describe, that is a bug —
+please [open an issue](https://github.com/spatiumddi/spatiumddi/issues/new).
+
+## Appendix — hostnames in the source that are not connections
+
+The guard in §8 matches text, so these appear in `backend/app` and are
+listed here to keep the check honest. **None of them is contacted.**
+
+**Documentation and homepage links** (shown in the UI or written in a
+comment, never fetched): `github.com`, `www.spatiumddi.com` (the ACME
+client's User-Agent string, as RFC 8555 asks for), `fingerbank.org`,
+`aistudio.google.com` (the "get an API key" link in an error message),
+`bacnet.org`, `kea.readthedocs.io`, `schema.org` (a JSON-LD `@context`
+identifier in a Teams-format webhook payload — a namespace URI, not a
+URL that is dereferenced), and the DNSBL catalogue's homepage fields:
+`www.spamhaus.org`, `www.spamcop.net`, `www.barracudacentral.org`,
+`www.uceprotect.net`, `www.sorbs.net`, `psbl.org`.
+
+**Placeholders in examples, defaults and error messages** — these are
+where *you* type your own address: `app.example.com`,
+`ddi.example.com`, `dns.example.com`, `ipam.example.com`,
+`netbox.example.com`, `nc.example.com`, `nextcloud.example`,
+`my-resource.openai.azure.com`, `pdns.internal`, `tdns.internal`,
+`api.meraki.cn` (named in a docstring as the regional shard a
+China-based operator would enter).
+
+**In-cluster addresses**, which never leave the node:
+`spatium-control-spatiumddi-api.spatium.svc.cluster.local` — the
+Kubernetes service name an appliance supervisor uses to reach the
+control plane it is already part of.
+
+---
+
+*Questions about anything on this page are welcome as a GitHub issue or
+discussion. If a future release adds an outbound connection, it will be
+in the table above and in the CHANGELOG before it is in your install.*

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -9,6 +9,7 @@
       <a href="{{ include.root }}docs.html">Documentation</a>
       <a href="{{ include.root }}GETTING_STARTED.html">Getting started</a>
       <a href="{{ include.root }}ARCHITECTURE.html">Architecture</a>
+      <a href="{{ include.root }}PRIVACY.html">Privacy</a>
       <a href="{{ site.links.releases }}">Releases</a>
       <a href="{{ site.links.issues }}">Issues</a>
       <a href="{{ site.links.discord }}">Discord</a>

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -8,6 +8,7 @@
       <a href="{{ include.root }}index.html#features">Features</a>
       <a href="{{ include.root }}docs.html">Docs</a>
       <a href="{{ include.root }}index.html#install">Install</a>
+      <a href="{{ include.root }}PRIVACY.html">Privacy</a>
       <a href="{{ site.links.discord }}">Community</a>
       <a class="nav-cta" href="{{ site.links.github }}">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.4 7.4 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -27,6 +27,10 @@
       A modern open-source alternative to commercial DDI platforms ·
       <code>linux/amd64</code> + <code>linux/arm64</code>
     </p>
+    <p class="hero-meta">
+      <strong>No telemetry. Your data stays in your install.</strong> ·
+      <a href="{{ root }}PRIVACY.html">Read the privacy statement</a>
+    </p>
   </header>
 
   <!-- ── Why ─────────────────────────────────────────────────────────── -->

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -51,4 +51,5 @@ Every specification, deployment guide and driver internal, grouped by what you'r
 
 ## Project
 
+- [Privacy](PRIVACY.md) — no telemetry, no analytics, no phone-home; every outbound connection the software can make, what it sends, and how to turn it off
 - [Third-Party Components](THIRD_PARTY.md) — every bundled engine, library and OS package, with licenses and which artifact each ships in

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -16,6 +16,7 @@
   <url><loc>https://www.spatiumddi.com/deployment/BAREMETAL</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://www.spatiumddi.com/deployment/APPLIANCE</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://www.spatiumddi.com/deployment/DNS_AGENT</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://www.spatiumddi.com/PRIVACY</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.spatiumddi.com/THIRD_PARTY</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.spatiumddi.com/drivers/DNS_DRIVERS</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.spatiumddi.com/drivers/DHCP_DRIVERS</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -687,8 +687,18 @@ const SECTIONS: SectionDef[] = [
     id: "updates",
     title: "Updates",
     group: "Application",
-    description: "Release-check behavior.",
-    keywords: ["github", "release", "version", "check"],
+    description:
+      "Release-check behavior — the only outbound connection SpatiumDDI makes on its own.",
+    keywords: [
+      "github",
+      "release",
+      "version",
+      "check",
+      "privacy",
+      "telemetry",
+      "phone home",
+      "air-gap",
+    ],
   },
 
   // ── Security ─────────────────────────────────────────────────────────
@@ -2416,16 +2426,42 @@ export function SettingsPage() {
             )}
 
             {activeId === "updates" && (
-              <Field
-                label="Check for GitHub Releases"
-                description="Periodically check GitHub for new SpatiumDDI releases."
-              >
-                <Toggle
-                  checked={!!values.github_release_check_enabled}
-                  onChange={(v) => set("github_release_check_enabled", v)}
-                  disabled={!isSuperadmin}
-                />
-              </Field>
+              <>
+                <Field
+                  label="Check for GitHub Releases"
+                  description="Once a day, ask GitHub whether a newer SpatiumDDI release exists, so the UI can show an update pill."
+                >
+                  <Toggle
+                    checked={!!values.github_release_check_enabled}
+                    onChange={(v) => set("github_release_check_enabled", v)}
+                    disabled={!isSuperadmin}
+                  />
+                </Field>
+                {/* The privacy statement (docs/PRIVACY.md) names this as the
+                    one connection that is on by default, so the screen that
+                    turns it off has to say exactly what it sends — an
+                    unlabelled switch is what makes a reader assume the worst. */}
+                <p className="pb-2 text-xs leading-relaxed text-muted-foreground">
+                  Unauthenticated <code>GET</code> to{" "}
+                  <code>api.github.com</code> — no token, and nothing about this
+                  install is sent: no version, no counts, no identifiers. GitHub
+                  sees this server&rsquo;s IP address and an HTTP User-Agent,
+                  and the SpatiumDDI project receives nothing (there is no
+                  project-controlled endpoint). This is the only outbound
+                  connection SpatiumDDI makes that you did not configure;
+                  turning it off closes it entirely and nothing else changes.
+                  See the{" "}
+                  <a
+                    className="underline hover:text-foreground"
+                    href="https://www.spatiumddi.com/PRIVACY.html"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    privacy statement
+                  </a>{" "}
+                  for every other connection the product can make.
+                </p>
+              </>
             )}
 
             {activeId === "utilization" && (

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -2455,7 +2455,7 @@ export function SettingsPage() {
                     className="underline hover:text-foreground"
                     href="https://www.spatiumddi.com/PRIVACY.html"
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                   >
                     privacy statement
                   </a>{" "}


### PR DESCRIPTION
Closes #976

SpatiumDDI is privacy-first by construction and **said so nowhere**, so an operator evaluating a platform that will hold every hostname, lease and subnet they own had to infer the answer from the absence of a settings page. Written from a sweep of every outbound connection in the tree rather than from a slogan.

## The decision: default-on, disclosed in the first paragraph

The issue offered two options for the daily GitHub release check — flip it to opt-in so the headline sentence needs no exception, or keep it on and disclose it up front. **Option 2.** It is an unauthenticated GET carrying nothing about the install (no version, no counts, no identifiers), GitHub is the only party that sees it, and an operator who misses a security fix is worse off than one whose firewall logged a daily GET to GitHub.

So the toggle had to stop being an unlabelled switch. Settings → Application → Updates now states exactly what the request contains, that the project receives nothing because there is no project-controlled endpoint, and that turning it off changes nothing else. The section also gained `privacy` / `telemetry` / `phone home` / `air-gap` keywords, so the person looking for it can find it.

## The guard is the deliverable, not the prose

A statement like this rots the first time somebody adds a convenience fetch — it does not go vague, it goes **false**, which is worse than never having made it.

`backend/tests/test_outbound_hosts_documented.py` scans `backend/app` for hostname literals and fails until each appears in `docs/PRIVACY.md`. A second test pins §3.1 to **one** row, because the README, the docs hero and the Settings copy all state there is exactly one default-on connection — a second would falsify three surfaces at once, and per non-negotiable #17 that is an issue and a decision, not a table edit nobody noticed.

**Both lists live in PRIVACY.md, not in a test allowlist.** A host that is *not* a connection — a documentation link, a homepage shown in the UI, an `example.com` placeholder — goes in that page's appendix. That costs a line of prose and buys the property that matters: filing a real endpoint under "not a connection" is a lie a human has to type into the document readers actually read.

`docs/PRIVACY.md` is a declared carve-out in `.github/scripts/ci-backend-must-run.txt` and in `_KNOWN_REPO_ROOT_READS`. `docs/` is denied wholesale by the backend gate, so without it a PR that quietly deletes a row would go green — the one edit that must run the guard.

**The sweep found six hostnames the issue's hand-written table missed** (`deb.debian.org`, `security.debian.org`, `www.sorbs.net`, `pdns.internal`, `tdns.internal`, and an in-cluster service name), which is the argument for the guard in one line.

Stated limits, in §8 of the page itself: the guard covers Python under `backend/app`, so it cannot see hosts assembled at runtime from operator input (which is the point — those are the operator's own endpoints) or the feed catalogues in `backend/app/data/`, which are covered as a category by the blocklist row.

## What landed

- **`docs/PRIVACY.md`** — the statement, then a normative table of every outbound connection in four tiers (default-on / on-demand / off-until-configured / appliance-host OS traffic), plus air-gapped operation, the support bundle's two scrub tiers and why the decode map is a separate endpoint, the mobile app, in-install access control, and the not-a-connection appendix.
- **`README.md`** — short form between *Why SpatiumDDI* and *What's in the box*, plus a Contents entry.
- **Docs site** — nav, footer, `docs.md`, `sitemap.xml`, and the hero claim *"No telemetry. Your data stays in your install."*
- **`SettingsPage.tsx`** — the toggle copy above.
- **`CLAUDE.md`** — non-negotiable #17, a document-map row, a roadmap entry.

Also corrected on the way: the settings path in the issue draft was wrong. The section is under **Application**, not Platform — fixed in all four places that name it.

## Verification

- ruff / black / mypy clean; frontend format / lint / typecheck / build / vitest clean.
- The two test files run green against a full checkout (54 passed, including the CI-gate suite they extend).
- **Both guards negative-controlled**: an undocumented host in `app/main.py` and a second row in §3.1 each fail with the intended message. A guard whose default is "pass" proves nothing.
- Docs rendered locally — tables intact, no kramdown leakage, nav / footer / hero links resolve.
- No migration, no new endpoint, no MCP change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
