### PR TITLE
ci(nightly): gate the image scan on whether the fix is installable; rebuild the apk layer nightly

### DIFF
--- a/.github/scripts/trivy-gate.sh
+++ b/.github/scripts/trivy-gate.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# trivy-gate.sh — turn a Trivy image report into a publish/refuse verdict.
+#
+#   usage: .github/scripts/trivy-gate.sh <trivy-report.json> <image-ref>
+#
+# The report is what `trivy image --format json` wrote for <image-ref>,
+# scanned with `--severity HIGH,CRITICAL --ignore-unfixed` — so every
+# finding in it is one Trivy believes has a fix. This script asks the
+# one question Trivy cannot: is that fix INSTALLABLE from the package
+# index the image builds against, right now?
+#
+# Trivy's "fixed" comes from the distro's security database. Alpine's
+# secdb is updated when the fix is COMMITTED to aports; the built .apk
+# reaches dl-cdn hours later (the builders and the CDN sync are separate
+# steps). In that window a finding is "fixed" to Trivy and unfixable to
+# `apk upgrade` — no Dockerfile change can clear it, and a gate that
+# fails on it just blocks the nightly until the mirrors catch up.
+# nightly-20260905 died exactly this way: util-linux 2.42.3 landed in
+# aports at 00:08Z, the frontend image's fresh `apk upgrade` at 10:45Z
+# picked up every other fix on the mirror but libuuid stayed at
+# 2.42.1-r0 (7 HIGH), and the package appeared on the CDN at 13:53Z.
+#
+# Each finding is sorted into one of three outcomes:
+#
+#   FAIL   the index offers a version >= the fixed one. A rebuild would
+#          cure this (stale layer cache, missing `apk upgrade`, a floor
+#          that needs bumping) — the image must not ship. Exit 1.
+#   DEFER  the index offers nothing newer, or something newer that is
+#          still below the fixed version. Announced, not published.
+#          Nothing a rebuild can do until the mirrors catch up, so it
+#          is treated the way `--ignore-unfixed` already treats the
+#          rest: reported (a workflow warning + step summary), not
+#          blocking. The next build — whose package layer is rebuilt
+#          against the current index — picks the fix up. Exit 0.
+#   FAIL   the image's package manager is not one this script can ask
+#          (only apk today), or the finding is a language package (a
+#          new PyPI/npm release is always installable). Availability is
+#          unknown, so the outcome is what it was before this script
+#          existed: refuse. Exit 1.
+#
+# A missing, empty or unparsable report is a hard failure: an image
+# nothing scanned is never a pass.
+#
+# Requires jq and docker (the image must be present locally). If trivy is
+# on PATH the familiar table is printed first (`trivy convert`); otherwise
+# a compact one is rendered from the JSON.
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <trivy-report.json> <image-ref>" >&2
+  exit 2
+}
+[ $# -eq 2 ] || usage
+report=$1
+image=$2
+
+fail() {
+  echo "::error::$*"
+  exit 1
+}
+
+[ -s "$report" ] \
+  || fail "trivy report '$report' is missing or empty — refusing to pass an unscanned image"
+jq -e . "$report" >/dev/null 2>&1 \
+  || fail "trivy report '$report' is not valid JSON"
+
+# ── The report, for humans ──────────────────────────────────────────────
+if command -v trivy >/dev/null 2>&1; then
+  trivy convert --quiet --format table "$report" || true
+else
+  jq -r '
+    .Results[]? as $r
+    | ($r.Vulnerabilities // [])[]
+    | "\($r.Target)\t\(.PkgName)\t\(.VulnerabilityID)\t\(.Severity)\t\(.InstalledVersion) -> \(.FixedVersion // "-")"
+  ' "$report" | column -t -s $'\t' || true
+fi
+echo
+
+# ── Findings: class, pkg, installed, fixed, id, severity ────────────────
+# FixedVersion can list several versions ("1.2-r0, 1.3-r0"); the first
+# is the lowest one that clears the CVE, which is the one to test for.
+# An absent one is emitted as "-" — `read` collapses adjacent tabs, so an
+# empty field would shift every column after it.
+findings=$(jq -r '
+  .Results[]? as $r
+  | ($r.Vulnerabilities // [])[]
+  | [ $r.Class, .PkgName, .InstalledVersion,
+      ((.FixedVersion // "") | split(",") | (.[0] // "") | gsub("^\\s+|\\s+$"; "")
+        | if . == "" then "-" else . end),
+      .VulnerabilityID, .Severity ]
+  | @tsv' "$report")
+
+os_family=$(jq -r '.Metadata.OS.Family // ""' "$report")
+os_name=$(jq -r '.Metadata.OS.Name // ""' "$report")
+
+echo "── trivy-gate: ${image} (${os_family:-unknown os} ${os_name})"
+if [ -z "$findings" ]; then
+  echo "✓ no HIGH/CRITICAL findings with a fix"
+  exit 0
+fi
+
+# ── What can the image's own package index install today? ──────────────
+# One `apk upgrade --simulate` against the live index yields, for every
+# upgradable package, the version `apk upgrade` WOULD install — the exact
+# thing the Dockerfile's `apk upgrade` line can reach. `--no-cache` fetches
+# a fresh index; `--user 0` because runtime images drop privileges and
+# apk needs root to resolve. Kept as "pkg<TAB>version" lines (no bash-4
+# associative arrays, so this also runs under macOS's bash 3).
+available=""
+probe_ok=0
+if [ "$os_family" = "alpine" ]; then
+  if sim=$(docker run --rm --user 0 --entrypoint sh "$image" \
+             -c 'apk upgrade --simulate --no-cache 2>/dev/null'); then
+    probe_ok=1
+    available=$(printf '%s\n' "$sim" \
+      | sed -nE 's/^\([0-9]+\/[0-9]+\) Upgrading ([^ ]+) \(([^ ]+) -> ([^)]+)\)$/\1\t\3/p')
+  else
+    echo "::warning::could not run 'apk upgrade --simulate' in ${image}; availability unknown"
+  fi
+fi
+
+# Version the index would install for $1, empty if nothing newer.
+offered_for() {
+  printf '%s\n' "$available" | awk -F '\t' -v p="$1" '$1 == p { print $2; exit }'
+}
+
+# apk's own comparator, so "-r1 vs -r0", "_p1" and friends are judged the
+# way apk judges them. Prints one of < = > per line of "A B" on stdin.
+apk_compare() {
+  docker run --rm -i --user 0 --entrypoint sh "$image" -c '
+    while read -r a b; do apk version -t "$a" "$b"; done'
+}
+
+fails=0
+defers=0
+summary=()
+while IFS=$'\t' read -r class pkg installed fixed id sev; do
+  [ -n "$pkg" ] || continue
+  [ "$fixed" != "-" ] || fixed=""
+  where="${pkg} ${id} (${sev}): installed ${installed}, fixed ${fixed:-?}"
+  verdict=""
+  reason=""
+  if [ "$class" != "os-pkgs" ]; then
+    verdict=FAIL
+    reason="language package — a newer release is always installable; update the pin"
+  elif [ "$os_family" != "alpine" ]; then
+    verdict=FAIL
+    reason="cannot query a ${os_family:-unknown} package index; treating as installable"
+  elif [ "$probe_ok" -ne 1 ]; then
+    verdict=FAIL
+    reason="package index probe failed; treating as installable"
+  elif [ -z "$fixed" ]; then
+    # Should not happen under --ignore-unfixed; if it does, the finding
+    # is unfixed and the scan policy already says those do not block.
+    verdict=DEFER
+    reason="no fixed version known"
+  elif offered=$(offered_for "$pkg") && [ -z "$offered" ]; then
+    verdict=DEFER
+    reason="the index offers nothing newer than ${installed} — fix announced, not yet published"
+  else
+    cmp=$(printf '%s %s\n' "$offered" "$fixed" | apk_compare) || cmp=""
+    case "$cmp" in
+      '>' | '=')
+        verdict=FAIL
+        reason="the index offers ${offered} — rebuild the package layer"
+        ;;
+      '<')
+        verdict=DEFER
+        reason="the index offers ${offered}, still below the fix — announced, not yet published"
+        ;;
+      *)
+        verdict=FAIL
+        reason="could not compare ${offered} with ${fixed} (apk said '${cmp}'); treating as installable"
+        ;;
+    esac
+  fi
+
+  case "$verdict" in
+    FAIL)
+      fails=$((fails + 1))
+      echo "✗ FAIL  ${where} — ${reason}"
+      echo "::error title=${image} ${id}::${where} — ${reason}"
+      ;;
+    DEFER)
+      defers=$((defers + 1))
+      echo "⏳ DEFER ${where} — ${reason}"
+      echo "::warning title=${image} ${id} deferred::${where} — ${reason}"
+      ;;
+  esac
+  summary+=("| ${verdict} | \`${pkg}\` | ${id} | ${sev} | ${installed} | ${fixed:-?} | ${reason} |")
+done <<< "$findings"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Trivy gate — \`${image}\`"
+    echo
+    echo "| Verdict | Package | CVE | Severity | Installed | Fixed | Why |"
+    echo "|---|---|---|---|---|---|---|"
+    printf '%s\n' "${summary[@]}"
+    echo
+    echo "FAIL blocks the push. DEFER = the fix is in the distro's security database but not yet on the package mirrors; it is reported like an unfixed finding and picked up by the next build."
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+echo
+if [ "$fails" -gt 0 ]; then
+  echo "✗ ${fails} finding(s) have an installable fix — refusing to publish ${image}"
+  exit 1
+fi
+echo "✓ ${image}: ${defers} finding(s) deferred (fix announced, not yet on the mirrors); nothing a rebuild could cure"
+exit 0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -285,6 +285,17 @@ jobs:
       # `fail-fast: false` the registry is left holding a mixed set of
       # some-new / some-old images. Cost is one extra amd64 build, which
       # the shared buildx cache makes near-free.
+      #
+      # APK_SNAPSHOT keeps that cache from defeating the scan. BuildKit
+      # keys a layer on its command text, so `RUN apk upgrade` is a cache
+      # hit from whenever this scope was last written — the package set
+      # of that first build, frozen. A fix Alpine publishes afterwards is
+      # then never installed but IS flagged by Trivy, and every later
+      # night fails on it. The Alpine Dockerfiles declare
+      # `ARG APK_SNAPSHOT` immediately before that RUN; passing the date
+      # tag rebuilds the package layer once a night (everything above it
+      # still caches), and passing the SAME value to both builds below
+      # makes the push's amd64 half the exact layers the scan saw.
       - name: Build amd64 for scanning
         uses: docker/build-push-action@v7
         with:
@@ -297,17 +308,41 @@ jobs:
           tags: scan-target:${{ matrix.image }}
           build-args: |
             VITE_APP_VERSION=${{ needs.gate.outputs.version }}
+            APK_SNAPSHOT=${{ needs.gate.outputs.date_tag }}
           cache-from: type=gha,scope=nightly-${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=nightly-${{ matrix.image }}
 
+      # Trivy reports; trivy-gate.sh decides. Trivy's "fixed" means the
+      # distro's security database names a fixed version — not that the
+      # package is on the mirrors yet, and for Alpine the two diverge by
+      # hours after every security commit (secdb updates when the fix is
+      # committed to aports; the .apk reaches dl-cdn once the builders and
+      # the CDN sync are done). nightly-20260905 died in that window: the
+      # frontend's fresh `apk upgrade` at 10:45Z installed every other fix
+      # on the mirror, libuuid's arrived there at 13:53Z, and Trivy failed
+      # the image on 7 HIGH that nothing could have installed. The gate
+      # asks the image's own package index whether each fix is installable
+      # today: yes → fail (a rebuild would cure it); not yet → defer,
+      # reported as a warning and treated like the unfixed findings
+      # `ignore-unfixed` already skips, picked up by the next night's
+      # rebuilt package layer. Anything it cannot verify fails, as before.
       - name: Trivy
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: scan-target:${{ matrix.image }}
           severity: HIGH,CRITICAL
           ignore-unfixed: true
-          exit-code: "1"
-          format: table
+          # The verdict belongs to the gate step; a non-zero exit here
+          # would stop the job before it runs.
+          exit-code: "0"
+          format: json
+          output: trivy-${{ matrix.image }}.json
+
+      - name: Gate on the scan
+        run: >-
+          .github/scripts/trivy-gate.sh
+          "trivy-${{ matrix.image }}.json"
+          "scan-target:${{ matrix.image }}"
 
       # Only now, with the scan green, does anything reach the registry.
       # The multi-arch build reuses the cache the scan build just warmed,
@@ -327,6 +362,7 @@ jobs:
             ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:${{ needs.gate.outputs.date_tag }}
           build-args: |
             VITE_APP_VERSION=${{ needs.gate.outputs.version }}
+            APK_SNAPSHOT=${{ needs.gate.outputs.date_tag }}
           cache-from: type=gha,scope=nightly-${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=nightly-${{ matrix.image }}
 

--- a/agent/dhcp/images/kea/Dockerfile
+++ b/agent/dhcp/images/kea/Dockerfile
@@ -85,7 +85,15 @@ FROM alpine:3.23 AS runtime
 # The old explicit ``libcrypto3>=3.5.7-r0`` / ``libssl3>=3.5.7-r0`` bounds
 # (CVE-2026-45447) are gone: the alpine 3.23 base already ships openssl
 # 3.5.7-r0, so they were redundant. ``apk upgrade`` above keeps them current.
-RUN apk upgrade --no-cache \
+# ``APK_SNAPSHOT`` is what makes that upgrade actually run in CI. BuildKit
+# keys a layer on its RUN text, so a ``type=gha`` cache serves this whole
+# layer — package set included — from whenever it was first built, until
+# the text changes. The nightly passes its date tag so the layer is
+# rebuilt once a night against the current index; local builds default
+# to ``dev``. Full story: agent/supervisor/images/supervisor/Dockerfile.
+ARG APK_SNAPSHOT=dev
+RUN echo "apk snapshot ${APK_SNAPSHOT}" >/dev/null \
+ && apk upgrade --no-cache \
  && apk add --no-cache \
       'kea>=3.0.3-r0' kea-dhcp4 kea-dhcp6 kea-admin \
       kea-hook-lease-cmds kea-hook-ha \

--- a/agent/dns/images/bind9/Dockerfile
+++ b/agent/dns/images/bind9/Dockerfile
@@ -40,7 +40,15 @@ FROM alpine:3.23 AS runtime
 # * ``libcrypto3`` / ``libssl3`` ``>=3.5.7-r0`` — CVE-2026-45447 (HIGH,
 #   OpenSSL). The 3.23 base already satisfies this one; the bound is
 #   kept because it still busts a pre-3.23 cache layer.
-RUN apk upgrade --no-cache \
+# ``APK_SNAPSHOT`` is what makes that upgrade actually run in CI. BuildKit
+# keys a layer on its RUN text, so a ``type=gha`` cache serves this whole
+# layer — package set included — from whenever it was first built, until
+# the text changes. The nightly passes its date tag so the layer is
+# rebuilt once a night against the current index; local builds default
+# to ``dev``. Full story: agent/supervisor/images/supervisor/Dockerfile.
+ARG APK_SNAPSHOT=dev
+RUN echo "apk snapshot ${APK_SNAPSHOT}" >/dev/null \
+ && apk upgrade --no-cache \
  && apk add --no-cache \
       'bind>=9.20.26-r0' 'bind-tools>=9.20.26-r0' \
       tini su-exec \

--- a/agent/dns/images/dnsdist/Dockerfile
+++ b/agent/dns/images/dnsdist/Dockerfile
@@ -11,7 +11,15 @@ FROM alpine:3.23 AS runtime
 
 # apk upgrade before add so the layer cache can't serve a stale index that
 # Trivy would then flag (mirrors the powerdns image rationale).
-RUN apk upgrade --no-cache \
+# ``APK_SNAPSHOT`` is what makes that upgrade actually run in CI. BuildKit
+# keys a layer on its RUN text, so a ``type=gha`` cache serves this whole
+# layer — package set included — from whenever it was first built, until
+# the text changes. The nightly passes its date tag so the layer is
+# rebuilt once a night against the current index; local builds default
+# to ``dev``. Full story: agent/supervisor/images/supervisor/Dockerfile.
+ARG APK_SNAPSHOT=dev
+RUN echo "apk snapshot ${APK_SNAPSHOT}" >/dev/null \
+    && apk upgrade --no-cache \
     && apk add --no-cache dnsdist libcap bash tini \
     # uid/gid PINNED (#50) — must match the powerdns image, whose agent
     # writes the DoT/DoH listener key at mode 0600 into the volume this

--- a/agent/dns/images/powerdns/Dockerfile
+++ b/agent/dns/images/powerdns/Dockerfile
@@ -63,7 +63,15 @@ FROM alpine:3.23 AS runtime
 # * ``libcrypto3`` / ``libssl3`` ``>=3.5.7-r0`` — CVE-2026-45447 (HIGH,
 #   OpenSSL). The 3.23 base already satisfies it; the bound is kept
 #   because it still busts a pre-3.23 cache layer.
-RUN apk upgrade --no-cache \
+# ``APK_SNAPSHOT`` is what makes that upgrade actually run in CI. BuildKit
+# keys a layer on its RUN text, so a ``type=gha`` cache serves this whole
+# layer — package set included — from whenever it was first built, until
+# the text changes. The nightly passes its date tag so the layer is
+# rebuilt once a night against the current index; local builds default
+# to ``dev``. Full story: agent/supervisor/images/supervisor/Dockerfile.
+ARG APK_SNAPSHOT=dev
+RUN echo "apk snapshot ${APK_SNAPSHOT}" >/dev/null \
+ && apk upgrade --no-cache \
  && apk add --no-cache \
       pdns pdns-backend-lmdb \
       'bind-tools>=9.20.26-r0' \

--- a/agent/looking-glass/images/gobgp/Dockerfile
+++ b/agent/looking-glass/images/gobgp/Dockerfile
@@ -89,7 +89,15 @@ FROM alpine:3.23 AS runtime
 # libssl/libcrypto (or other base) version gets re-resolved against the
 # current alpine 3.22 index rather than serving a stale GitHub Actions
 # layer cache that Trivy would then flag.
-RUN apk upgrade --no-cache \
+# ``APK_SNAPSHOT`` is what makes that upgrade actually run in CI. BuildKit
+# keys a layer on its RUN text, so a ``type=gha`` cache serves this whole
+# layer — package set included — from whenever it was first built, until
+# the text changes. The nightly passes its date tag so the layer is
+# rebuilt once a night against the current index; local builds default
+# to ``dev``. Full story: agent/supervisor/images/supervisor/Dockerfile.
+ARG APK_SNAPSHOT=dev
+RUN echo "apk snapshot ${APK_SNAPSHOT}" >/dev/null \
+ && apk upgrade --no-cache \
  && apk add --no-cache \
       tini su-exec \
       python3 py3-pip \

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -339,8 +339,18 @@ because
 nothing else builds the *release* image except a release — which is how
 [#732](https://github.com/spatiumddi/spatiumddi/issues/732) shipped an api
 image carrying pytest as root, undetected until the next release cut it.
-The nightly also runs the same Trivy gate CI uses on PRs, so a base-image
-CVE surfaces the night the Dockerfile changes rather than at the next tag.
+The nightly also runs the same Trivy scan CI uses on PRs (HIGH/CRITICAL,
+fix available), *before* anything is pushed, so a base-image CVE surfaces
+the night it lands rather than at the next tag. The verdict comes from
+[`.github/scripts/trivy-gate.sh`](../.github/scripts/trivy-gate.sh),
+which asks the image's own package index whether each flagged fix is
+installable today: if it is, the image fails (a rebuild would cure it);
+if Alpine has committed the fix but the package has not reached the
+mirrors yet, the finding is **deferred** — a warning, not a failure — and
+the next night picks it up. That works because every Alpine image
+declares `ARG APK_SNAPSHOT` right before its `apk upgrade`, and the
+nightly passes the date tag, so the package layer is rebuilt against the
+current index each night instead of being served from the layer cache.
 
 To run current `main` without cutting a release:
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -41,7 +41,15 @@ FROM nginx:1.31.4-alpine AS runtime
 # and CVE-2026-76641 in libexpat), all already fixed upstream. It is now
 # in the Makefile's TRIVY_IMAGES, so `make trivy IMAGE=frontend` catches
 # the next set.
-RUN apk upgrade --no-cache
+# ``APK_SNAPSHOT`` is what makes that upgrade actually run in CI. BuildKit
+# keys a layer on its RUN text, so a ``type=gha`` cache serves this whole
+# layer — package set included — from whenever it was first built, until
+# the text changes. The nightly passes its date tag so the layer is
+# rebuilt once a night against the current index; local builds default
+# to ``dev``. Full story: agent/supervisor/images/supervisor/Dockerfile.
+ARG APK_SNAPSHOT=dev
+RUN echo "apk snapshot ${APK_SNAPSHOT}" >/dev/null \
+ && apk upgrade --no-cache
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 # Issue #176: the API upstream + DNS resolver are now templated so the


### PR DESCRIPTION
## Summary

**The first scheduled nightly to build since #970 failed, and would keep failing.** Run [33961415588](https://github.com/spatiumddi/spatiumddi/actions/runs/33961415588) (2026-09-05, the `23 6` twin, gate decided correctly and built) died on `spatiumddi-frontend` at the Trivy step: 7 HIGH in `libuuid 2.42.1-r0`, fixed version `2.42.3-r0`, so the scan-before-push gate refused the image, the appliance build was skipped, and `finalize` opened #978. Every other image passed.

The image had done everything it could. Its `RUN apk upgrade --no-cache` ran fresh (cache miss — the line was new in 2026.09.04-1) and installed every other fix on the mirror at 10:45Z (libssl3/libcrypto3 3.5.8-r0, libexpat 2.8.4-r0, curl, pcre2), but libuuid stayed at 2.42.1-r0 because there was nothing newer to install:

| when (UTC) | what |
|---|---|
| 09-05 00:08 | `main/util-linux: security upgrade to 2.42.3` committed to aports `3.24-stable` → Alpine's secdb lists the fix → Trivy's DB (cache key `cache-trivy-2026-09-05`) knows it as *fixed* |
| 09-05 10:45 | nightly's frontend build: `apk upgrade` against dl-cdn — index still offers `libuuid-2.42.1-r0` |
| 09-05 10:45 | Trivy: `Status: fixed`, `Fixed Version: 2.42.3-r0` → 7 HIGH → exit 1 |
| 09-05 13:01 | `main/util-linux: patch CVE-2026-78408` (2.42.3-r1) committed |
| 09-05 13:53 | `libuuid-2.42.3-r1.apk` + new `APKINDEX` land on dl-cdn (`Last-Modified`) |

`--ignore-unfixed` is meant to keep the gate from blocking on things nobody can act on. Trivy's notion of "fixed" is *the distro's security database names a version* — not *the package is downloadable* — and for Alpine those diverge by hours after every security commit. In that window no change to this repo can produce a passing image.

**And it would not have been a one-night outage.** The scan build exports its layers to the `type=gha` cache (`mode=max`), and BuildKit keys `RUN apk upgrade --no-cache` on its text, so from tonight on that step is a cache hit: the 10:45Z layer with `libuuid 2.42.1-r0` frozen in it. With the fix now on the mirror that is a *legitimate* red, and it recurs every night until the Dockerfile or the `nginx:1.31.4-alpine` digest changes. The same freeze applies to every Alpine image's `apk upgrade` layer once its scope has been written once (the bind9 job's push build in the failed run already shows its amd64 apk layer `CACHED` from the scan build) — the supervisor image documented this exact failure and grew `APK_SNAPSHOT` for it, but the nightly never passed one, and the other Alpine Dockerfiles never declared one.

### What this PR does

1. **`.github/scripts/trivy-gate.sh` decides; Trivy reports.** The Trivy step now writes JSON with `exit-code: "0"`, and the gate asks the image's own package index — one `apk upgrade --simulate --no-cache` inside the built image — whether each flagged fix is installable *today*:
   - installable (index offers ≥ the fixed version) → **FAIL**, a rebuild would cure it (stale layer, missing upgrade, a floor to bump);
   - not installable (nothing newer, or newer-but-below-the-fix) → **DEFER**: `::warning` annotation + step-summary table, treated like the unfixed findings the policy already skips, picked up by the next night's build;
   - anything it cannot verify — non-apk images (api, technitium), language packages, a missing/empty/unparsable report — **FAIL**, exactly as before.

   Version comparisons use `apk version -t` inside the image, so `-r1` vs `-r0` and `_p` suffixes are judged apk's way, not `sort -V`'s. The human-readable table is still printed (`trivy convert`).

2. **`APK_SNAPSHOT=<date tag>` on both nightly builds**, and `ARG APK_SNAPSHOT=dev` immediately before the `apk upgrade` RUN in the six Alpine Dockerfiles that lacked it (frontend, bind9, powerdns, dnsdist, kea, gobgp) — the supervisor image's existing convention. The package layer is rebuilt once a night against the current index; everything above it (npm install, wheel builds, the Go build) still caches. Passing the **same** value to the scan build and the push build keeps the scan→push identity: the push's amd64 half is the layer the scan saw, and the arm64 half (never scanned — pre-existing) is at least rebuilt against the same index.

Without (2), (1) would only have bought one night: the deferred finding becomes installable the next day, and the frozen layer would fail it — correctly — forever.

### Not changed, deliberately

- `trivy-scheduled.yml` — a weekly report that funnels into an issue, not a publish gate; an "announced, not yet on the mirror" finding there is an early heads-up, not a block.
- The per-image PR workflows (`build-dns-images.yml`, `build-dhcp-images.yml`, `build-looking-glass-images.yml`) don't pass `APK_SNAPSHOT` either; they now *could* (the ARG is declared, default `dev`, so their behaviour is unchanged by this PR). Wiring them the way `build-supervisor-image.yml` does (ISO year-week) is a small follow-up — it would end the "unrelated PR trips a stale-layer CVE" failure the bind9 Dockerfile's comment describes.
- `make trivy` — a local pre-push gate; a developer reads the table.
- The two Debian-based images (api, technitium) don't `apt-get upgrade`; the gate fails on them exactly as before.

Considered and not taken: a wait-and-retry loop in the images job (poll the index until the fix lands, then rebuild). It never publishes a deferred finding, but holds a runner for hours (today: 3 h+), delays the appliance build behind it, and still fails when Alpine's builders take longer than the window. DEFER is what `--ignore-unfixed` already means from the image's point of view.

## Area

- [x] Deployment (Compose / K8s / Appliance) — CI (`nightly.yml`, a new `.github/scripts/` gate), six Dockerfiles (one `ARG` + a comment each, no package changes), `docs/DEVELOPMENT.md`

## Test plan

- [x] **Gate verdicts on a real `ubuntu-latest` runner** (private `spatiumddi-qa` sandbox, run [33982595066](https://github.com/spatiumddi/spatiumddi-qa/actions/runs/33982595066), plain `run:` steps because that repo allows local actions only) with **Trivy 0.70.0** — the version `trivy-action@v0.36.0` installs:
  - A — the frontend image built from this branch with today's snapshot → `✓ no HIGH/CRITICAL findings with a fix`, exit 0
  - B — the exact `nginx@sha256:db35bfc6…` digest the failed run built from (libuuid 2.42.1-r0, fix now on the mirror) → every finding `FAIL … the index offers 2.42.3-r1 — rebuild the package layer`, exit 1
  - C — same image, fixed version rewritten to one no mirror has → `DEFER … the index offers 2.42.3-r1, still below the fix`, exit 0
  - D — the upgraded image with a claimed fix beyond the index → `DEFER … the index offers nothing newer`, exit 0
  - E — report re-labelled `debian` → `cannot query a debian package index`, exit 1
  - F — a `lang-pkgs` finding → exit 1
  - G — missing / empty / invalid report → exit 1 each
  - H — a finding with no fixed version → exit 0 (policy already ignores unfixed)

  <details><summary>Gate output on <code>ubuntu-latest</code>, Trivy 0.70.0 (run 33982595066, job <em>trivy-gate.sh verdicts</em>)</summary>

  ```
  A  ── trivy-gate: scan-target:spatiumddi-frontend (alpine 3.24.1)
     ✓ no HIGH/CRITICAL findings with a fix

  B  ── trivy-gate: scan-target:stale (alpine 3.24.1)
     ✗ FAIL  libcrypto3 CVE-2026-14456 (HIGH): installed 3.5.7-r0, fixed 3.5.8-r0 — the index offers 3.5.8-r0 — rebuild the package layer
     ✗ FAIL  libssl3 CVE-2026-14456 (HIGH): installed 3.5.7-r0, fixed 3.5.8-r0 — the index offers 3.5.8-r0 — rebuild the package layer
     ✗ FAIL  libuuid CVE-2026-53612 (HIGH): installed 2.42.1-r0, fixed 2.42.3-r0 — the index offers 2.42.3-r1 — rebuild the package layer
     … (six more libuuid rows)
     ✗ 9 finding(s) have an installable fix — refusing to publish scan-target:stale

  C  ⏳ DEFER libuuid CVE-2026-53612 (HIGH): installed 2.42.1-r0, fixed 2.42.99-r0 — the index offers 2.42.3-r1, still below the fix — announced, not yet published
     ✓ scan-target:stale: 7 finding(s) deferred (fix announced, not yet on the mirrors); nothing a rebuild could cure

  D  ⏳ DEFER libuuid CVE-0000-0001 (HIGH): installed 2.42.3-r1, fixed 99.0-r0 — the index offers nothing newer than 2.42.3-r1 — fix announced, not yet published

  E  ✗ FAIL  libcrypto3 CVE-2026-14456 (HIGH): installed 3.5.7-r0, fixed 3.5.8-r0 — cannot query a debian package index; treating as installable
  F  ✗ FAIL  libcrypto3 CVE-2026-14456 (HIGH): installed 3.5.7-r0, fixed 3.5.8-r0 — language package — a newer release is always installable; update the pin
  G  nope.json: refused as expected / empty.json: refused as expected / bad.json: refused as expected
  H  ⏳ DEFER libuuid CVE-2026-53612 (HIGH): installed 2.42.1-r0, fixed ? — no fixed version known
  ```
  </details>

- [x] **Layer-cache behaviour, five builds with a fresh buildx builder each and cache only via `type=local`** (same run, job *APK_SNAPSHOT vs the layer cache*):
  - original `frontend/Dockerfile` (upstream `b769108`), build 2 from build 1's cache → `RUN apk upgrade --no-cache` **CACHED** — the defect;
  - this branch's Dockerfile, `APK_SNAPSHOT=nightly-20260905` then `nightly-20260906` → apk layer **rebuilt**, `npm install` above it **CACHED**;
  - `nightly-20260906` again → apk layer **CACHED** (scan build → push build identity).

  <details><summary>BuildKit progress excerpts (same run, job <em>APK_SNAPSHOT vs the layer cache</em>)</summary>

  ```
  defect — original Dockerfile, build 2 (from build 1's cache)
  #12 [runtime 2/5] RUN apk upgrade --no-cache
  #12 CACHED
  ✓ defect reproduced: 'RUN apk upgrade --no-cache' was CACHED on the second build — the package set is frozen

  fix — APK_SNAPSHOT=nightly-20260906 (from the nightly-20260905 cache)
  #13 [builder 4/6] RUN npm install --prefer-offline
  #13 CACHED
  #17 [runtime 2/5] RUN echo "apk snapshot nightly-20260906" >/dev/null  && apk upgrade --no-cache
  ✓ fix: new snapshot re-ran apk upgrade while 'npm install' above it stayed CACHED

  fix — APK_SNAPSHOT=nightly-20260906 again (scan build → push build)
  #16 [runtime 2/5] RUN echo "apk snapshot nightly-20260906" >/dev/null  && apk upgrade --no-cache
  #16 CACHED
  ✓ same snapshot: the push build's amd64 half is the scanned layer (CACHED)
  ```
  </details>

- [x] Same fixture matrix locally on macOS (bash 3.2 — the script avoids bash-4 features on purpose), Trivy 0.70.0 in Docker: identical verdicts.
- [x] `shellcheck -S style` clean on the script; `actionlint` on `nightly.yml`: no new findings (the one pre-existing SC2129 style note on the `Decide` step's `$GITHUB_OUTPUT` echoes is unchanged); `docker buildx build --check` clean on all six Dockerfiles.
- [ ] Not exercisable in the sandbox: the `trivy-action` step wiring itself (`format: json` + `output:` → the gate step). The inputs are the action's documented ones; the gate takes the report path and image ref and is tested independently above. First real proof is the next nightly on `main` after merge — with the fix now published, tonight's build should show the `Gate on the scan` step green on all nine images and `nightly-2026.09.06` published.
- [ ] A manual `workflow_dispatch` of the nightly *before* this merges would fail again on the frontend: the frozen 10:45Z layer is now in the `nightly-spatiumddi-frontend` cache scope and the fix is installable.

Downstream context: ddi-pg's full-lane QA walks the nightly's ISO + slot image; nightly-2026.09.05 never published, so its wall banner goes amber tonight.

## Related issues

Closes #978 (once tonight's nightly is green). Refs #970, #849, #805, #973 (which added the frontend's `apk upgrade`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
