### PR TITLE
feat(charts): Kubernetes 1.36 posture — PriorityClasses, seccomp RuntimeDefault, PSA labels, version floors

### DIFF
--- a/.github/scripts/chart-pod-posture.py
+++ b/.github/scripts/chart-pod-posture.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Pod-posture gate for the rendered charts (#983).
+
+Two properties that are trivially forgotten on a NEW workload and invisible
+once forgotten, because nothing fails — the pod schedules and runs, just
+without the protection:
+
+  seccomp        every pod template carries ``securityContext.seccompProfile``.
+                 Kubernetes runs a container ``Unconfined`` unless asked;
+                 docker-compose applies the runtime's default profile to every
+                 service. A workload that omits this runs with FEWER syscall
+                 restrictions under Kubernetes than under Compose.
+
+  priority       every pod template carries a non-empty ``priorityClassName``.
+                 With every pod at priority 0, kubelet eviction under memory
+                 pressure picks the pod that grew the most rather than the one
+                 that matters least. Only asserted for renders that opted in
+                 (``--require-priority``), because the umbrella chart's default
+                 is deliberately empty: naming a PriorityClass that does not
+                 exist makes the apiserver reject the pod outright, so a
+                 bring-your-own cluster must not get one by default.
+                 A workload that is MEANT to sit at priority 0 is named in
+                 ``--allow-no-priority``, so the decision is visible at the
+                 call site and a NEW workload still fails the gate.
+
+Both are checked against the RENDERED manifests rather than the templates: a
+``with`` guard on the wrong values path renders nothing and reads fine in the
+template. Reference: the #917 lesson that a guard which inspects intent instead
+of output reports clean while the defect ships.
+
+Usage:
+    chart-pod-posture.py [--require-priority] [--allow-no-priority a,b] file...
+"""
+
+from __future__ import annotations
+
+import sys
+
+import yaml
+
+# Workload kinds whose spec carries a pod template, and the path to it.
+POD_TEMPLATE_PATHS: dict[str, tuple[str, ...]] = {
+    "Deployment": ("spec", "template"),
+    "StatefulSet": ("spec", "template"),
+    "DaemonSet": ("spec", "template"),
+    "Job": ("spec", "template"),
+    "ReplicaSet": ("spec", "template"),
+    "CronJob": ("spec", "jobTemplate", "spec", "template"),
+}
+
+# CRs that manage their own pods, with the field on the CR that carries each
+# property through to them. CNPG's ``Cluster`` is the only one either chart
+# renders today.
+MANAGED_POD_CRS: dict[str, dict[str, tuple[str, ...]]] = {
+    "postgresql.cnpg.io/Cluster": {
+        "seccomp": ("spec", "seccompProfile"),
+        "priority": ("spec", "priorityClassName"),
+    },
+}
+
+
+def dig(obj, path):
+    for key in path:
+        if not isinstance(obj, dict):
+            return None
+        obj = obj.get(key)
+    return obj
+
+
+def main(argv: list[str]) -> int:
+    require_priority = "--require-priority" in argv
+    exempt: set[str] = set()
+    args = argv[1:]
+    files: list[str] = []
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--allow-no-priority":
+            i += 1
+            if i >= len(args):
+                print("--allow-no-priority needs a comma-separated list", file=sys.stderr)
+                return 2
+            exempt.update(x for x in args[i].split(",") if x)
+        elif not a.startswith("--"):
+            files.append(a)
+        i += 1
+    if not files:
+        print(__doc__.strip().splitlines()[-1].strip(), file=sys.stderr)
+        return 2
+
+    problems: list[str] = []
+    checked = 0
+
+    for path in files:
+        with open(path, encoding="utf-8") as fh:
+            docs = [d for d in yaml.safe_load_all(fh) if isinstance(d, dict)]
+        for doc in docs:
+            kind = doc.get("kind")
+            api = str(doc.get("apiVersion", ""))
+            group = api.rsplit("/", 1)[0] if "/" in api else ""
+            name = dig(doc, ("metadata", "name")) or "<unnamed>"
+            where = f"{path}: {kind}/{name}"
+
+            cr_key = f"{group}/{kind}"
+            if cr_key in MANAGED_POD_CRS:
+                checked += 1
+                fields = MANAGED_POD_CRS[cr_key]
+                if not dig(doc, fields["seccomp"]):
+                    problems.append(f"{where}: no {'.'.join(fields['seccomp'])}")
+                if require_priority and name not in exempt and not dig(doc, fields["priority"]):
+                    problems.append(f"{where}: no {'.'.join(fields['priority'])}")
+                continue
+
+            if kind not in POD_TEMPLATE_PATHS:
+                continue
+            pod = dig(doc, POD_TEMPLATE_PATHS[kind] + ("spec",))
+            if pod is None:
+                problems.append(f"{where}: pod template has no spec")
+                continue
+            checked += 1
+
+            profile = dig(pod, ("securityContext", "seccompProfile", "type"))
+            if not profile:
+                problems.append(f"{where}: pod securityContext has no seccompProfile.type")
+
+            if require_priority and name not in exempt and not pod.get("priorityClassName"):
+                problems.append(
+                    f"{where}: no priorityClassName "
+                    "(add one, or name it in --allow-no-priority to record the decision)"
+                )
+
+    if problems:
+        print(f"pod-posture: {len(problems)} problem(s) across {checked} workload(s)", file=sys.stderr)
+        for p in problems:
+            print(f"  {p}", file=sys.stderr)
+        return 1
+
+    print(f"pod-posture: {checked} workload(s) OK" + (" (priority required)" if require_priority else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/chart-pod-posture.py
+++ b/.github/scripts/chart-pod-posture.py
@@ -23,13 +23,25 @@ without the protection:
                  ``--allow-no-priority``, so the decision is visible at the
                  call site and a NEW workload still fails the gate.
 
+``--allow-no-seccomp`` exists for the same reason and is used for exactly one
+thing: a vendored subchart whose templates expose no pod-securityContext knob,
+so no values override can supply a profile. Exempting it is strictly better
+than the alternative, which is not rendering that chart at all — which is how
+its pods got missed in the first place.
+
+Exemption names match either exactly or on a ``-<name>`` suffix, because helm
+prefixes a subchart's workload names with the release name. The suffix is not
+segment-aware — ``k8s`` would also match ``frr-k8s`` — so write exemptions as
+the full workload name, never an abbreviation.
+
 Both are checked against the RENDERED manifests rather than the templates: a
 ``with`` guard on the wrong values path renders nothing and reads fine in the
 template. Reference: the #917 lesson that a guard which inspects intent instead
 of output reports clean while the defect ships.
 
 Usage:
-    chart-pod-posture.py [--require-priority] [--allow-no-priority a,b] file...
+    chart-pod-posture.py [--require-priority] [--allow-no-priority a,b]
+                         [--allow-no-seccomp a,b] file...
 """
 
 from __future__ import annotations
@@ -59,6 +71,22 @@ MANAGED_POD_CRS: dict[str, dict[str, tuple[str, ...]]] = {
 }
 
 
+def _exempt(name: str, names: set[str]) -> bool:
+    """Match an exemption exactly, or on a ``-<name>`` suffix.
+
+    Helm prefixes a subchart's workload names with the release name, so the
+    same object is ``frr-k8s`` in the chart and ``metallb-bgp-frr-k8s`` in a
+    render — an exact-match-only exemption would silently stop applying the
+    moment the render name changed.
+
+    The suffix test is not segment-aware, so a short exemption over-matches
+    (``k8s`` catches ``frr-k8s``). That is a reason to write full workload
+    names, not a reason to hand-roll boundary parsing: an over-broad
+    exemption still has to be typed by someone, in a file under review.
+    """
+    return any(name == n or name.endswith(f"-{n}") for n in names)
+
+
 def dig(obj, path):
     for key in path:
         if not isinstance(obj, dict):
@@ -69,18 +97,20 @@ def dig(obj, path):
 
 def main(argv: list[str]) -> int:
     require_priority = "--require-priority" in argv
-    exempt: set[str] = set()
+    exempt_priority: set[str] = set()
+    exempt_seccomp: set[str] = set()
     args = argv[1:]
     files: list[str] = []
     i = 0
     while i < len(args):
         a = args[i]
-        if a == "--allow-no-priority":
+        if a in ("--allow-no-priority", "--allow-no-seccomp"):
+            target = exempt_priority if a == "--allow-no-priority" else exempt_seccomp
             i += 1
             if i >= len(args):
-                print("--allow-no-priority needs a comma-separated list", file=sys.stderr)
+                print(f"{a} needs a comma-separated list", file=sys.stderr)
                 return 2
-            exempt.update(x for x in args[i].split(",") if x)
+            target.update(x for x in args[i].split(",") if x)
         elif not a.startswith("--"):
             files.append(a)
         i += 1
@@ -105,9 +135,13 @@ def main(argv: list[str]) -> int:
             if cr_key in MANAGED_POD_CRS:
                 checked += 1
                 fields = MANAGED_POD_CRS[cr_key]
-                if not dig(doc, fields["seccomp"]):
+                if not _exempt(name, exempt_seccomp) and not dig(doc, fields["seccomp"]):
                     problems.append(f"{where}: no {'.'.join(fields['seccomp'])}")
-                if require_priority and name not in exempt and not dig(doc, fields["priority"]):
+                if (
+                    require_priority
+                    and not _exempt(name, exempt_priority)
+                    and not dig(doc, fields["priority"])
+                ):
                     problems.append(f"{where}: no {'.'.join(fields['priority'])}")
                 continue
 
@@ -120,10 +154,14 @@ def main(argv: list[str]) -> int:
             checked += 1
 
             profile = dig(pod, ("securityContext", "seccompProfile", "type"))
-            if not profile:
+            if not profile and not _exempt(name, exempt_seccomp):
                 problems.append(f"{where}: pod securityContext has no seccompProfile.type")
 
-            if require_priority and name not in exempt and not pod.get("priorityClassName"):
+            if (
+                require_priority
+                and not _exempt(name, exempt_priority)
+                and not pod.get("priorityClassName")
+            ):
                 problems.append(
                     f"{where}: no priorityClassName "
                     "(add one, or name it in --allow-no-priority to record the decision)"
@@ -135,7 +173,10 @@ def main(argv: list[str]) -> int:
             print(f"  {p}", file=sys.stderr)
         return 1
 
-    print(f"pod-posture: {checked} workload(s) OK" + (" (priority required)" if require_priority else ""))
+    note = " (priority required)" if require_priority else ""
+    if exempt_priority or exempt_seccomp:
+        note += f", {len(exempt_priority | exempt_seccomp)} exempted"
+    print(f"pod-posture: {checked} workload(s) OK{note}")
     return 0
 
 

--- a/.github/scripts/chart-pod-posture.py
+++ b/.github/scripts/chart-pod-posture.py
@@ -119,6 +119,7 @@ def main(argv: list[str]) -> int:
         return 2
 
     problems: list[str] = []
+    exempted: list[str] = []
     checked = 0
 
     for path in files:
@@ -135,14 +136,15 @@ def main(argv: list[str]) -> int:
             if cr_key in MANAGED_POD_CRS:
                 checked += 1
                 fields = MANAGED_POD_CRS[cr_key]
-                if not _exempt(name, exempt_seccomp) and not dig(doc, fields["seccomp"]):
+                if _exempt(name, exempt_seccomp):
+                    exempted.append(f"{name} (seccomp)")
+                elif not dig(doc, fields["seccomp"]):
                     problems.append(f"{where}: no {'.'.join(fields['seccomp'])}")
-                if (
-                    require_priority
-                    and not _exempt(name, exempt_priority)
-                    and not dig(doc, fields["priority"])
-                ):
-                    problems.append(f"{where}: no {'.'.join(fields['priority'])}")
+                if require_priority:
+                    if _exempt(name, exempt_priority):
+                        exempted.append(f"{name} (priority)")
+                    elif not dig(doc, fields["priority"]):
+                        problems.append(f"{where}: no {'.'.join(fields['priority'])}")
                 continue
 
             if kind not in POD_TEMPLATE_PATHS:
@@ -153,19 +155,19 @@ def main(argv: list[str]) -> int:
                 continue
             checked += 1
 
-            profile = dig(pod, ("securityContext", "seccompProfile", "type"))
-            if not profile and not _exempt(name, exempt_seccomp):
+            if _exempt(name, exempt_seccomp):
+                exempted.append(f"{name} (seccomp)")
+            elif not dig(pod, ("securityContext", "seccompProfile", "type")):
                 problems.append(f"{where}: pod securityContext has no seccompProfile.type")
 
-            if (
-                require_priority
-                and not _exempt(name, exempt_priority)
-                and not pod.get("priorityClassName")
-            ):
-                problems.append(
-                    f"{where}: no priorityClassName "
-                    "(add one, or name it in --allow-no-priority to record the decision)"
-                )
+            if require_priority:
+                if _exempt(name, exempt_priority):
+                    exempted.append(f"{name} (priority)")
+                elif not pod.get("priorityClassName"):
+                    problems.append(
+                        f"{where}: no priorityClassName "
+                        "(add one, or name it in --allow-no-priority to record the decision)"
+                    )
 
     if problems:
         print(f"pod-posture: {len(problems)} problem(s) across {checked} workload(s)", file=sys.stderr)
@@ -173,9 +175,12 @@ def main(argv: list[str]) -> int:
             print(f"  {p}", file=sys.stderr)
         return 1
 
+    # Name what was skipped rather than counting the flags: a count of names
+    # GIVEN reads as "1 exempted" on a render where that workload is not even
+    # present, which quietly overstates how much the gate let through.
     note = " (priority required)" if require_priority else ""
-    if exempt_priority or exempt_seccomp:
-        note += f", {len(exempt_priority | exempt_seccomp)} exempted"
+    if exempted:
+        note += f" — exempted: {', '.join(sorted(exempted))}"
     print(f"pod-posture: {checked} workload(s) OK{note}")
     return 0
 

--- a/.github/scripts/charts-render-check.sh
+++ b/.github/scripts/charts-render-check.sh
@@ -26,6 +26,11 @@
 #                      CPU + memory request or limit (#965). A ``with`` guard
 #                      that tests the wrong values path renders no
 #                      ``resources:`` block and passes the three gates above.
+#   pod-posture      — every render: each pod template carries a seccomp
+#                      profile, and (where the render opts in) a
+#                      PriorityClass (#983). Same failure mode as the line
+#                      above — a workload added without either one runs
+#                      perfectly well, just unprotected and unranked.
 #   toggle-coverage  — every ``.Values.x.enabled`` / ``.kind`` a template is
 #                      gated on must be flipped by at least one render, so a
 #                      new gate cannot silently fall out of the matrix.
@@ -64,6 +69,10 @@ lint() { # chart [helm --set args...]
 KUBECONFORM_CACHE="${KUBECONFORM_CACHE:-$OUT/.schema-cache}"
 mkdir -p "$KUBECONFORM_CACHE"
 
+# Extra flags handed to chart-pod-posture.py, set per render group below.
+# Word-split on purpose (simple flags only).
+POSTURE_ARGS=""
+
 render() { # name chart [helm --set args...]
     local name="$1" chart="$2"; shift 2
     local file="$OUT/$name.yaml"
@@ -84,6 +93,9 @@ render() { # name chart [helm --set args...]
         -cache "$KUBECONFORM_CACHE" \
         "$file" || failures=$((failures + 1))
     python3 "$ROOT/.github/scripts/chart-no-besteffort.py" "$file" || failures=$((failures + 1))
+    # shellcheck disable=SC2086  # POSTURE_ARGS is a deliberate flag list
+    python3 "$ROOT/.github/scripts/chart-pod-posture.py" $POSTURE_ARGS "$file" \
+        || failures=$((failures + 1))
 }
 
 coverage() { # chart [every --set arg from every render of that chart...]
@@ -129,6 +141,18 @@ UMBRELLA_EXTERNAL=(
     --set postgresql.enabled=false --set externalDatabase.host=pg.example
     --set redis.enabled=false --set externalRedis.host=redis.example
 )
+# #983 — the appliance overlay's shape: both PriorityClass knobs set, and
+# every optional workload on, so the posture gate sees each one wired. Agent
+# StatefulSets only render when ``servers`` is non-empty, so the ``enabled``
+# toggle alone leaves those two templates unrendered — name a server.
+UMBRELLA_POSTURE=(
+    "${UMBRELLA_ALL_ON[@]}"
+    --set global.priorityClassName=spatium-control-plane
+    --set global.servicePriorityClassName=spatium-service
+    --set dnsAgents.servers[0].name=ns1
+    --set dhcpAgents.servers[0].name=dhcp1
+)
+
 lint "$UMBRELLA"
 lint "$UMBRELLA" "${UMBRELLA_ALL_ON[@]}"
 lint "$UMBRELLA" "${UMBRELLA_HA[@]}"
@@ -137,6 +161,9 @@ render umbrella-all-on "$UMBRELLA" "${UMBRELLA_ALL_ON[@]}"
 render umbrella-ha "$UMBRELLA" "${UMBRELLA_HA[@]}"
 # Bring-your-own database + Redis: the shape k8s/ha/ installs use.
 render umbrella-external-db "$UMBRELLA" "${UMBRELLA_EXTERNAL[@]}"
+POSTURE_ARGS="--require-priority"
+render umbrella-posture "$UMBRELLA" "${UMBRELLA_POSTURE[@]}"
+POSTURE_ARGS=""
 coverage "$UMBRELLA" "${UMBRELLA_ALL_ON[@]}" "${UMBRELLA_HA[@]}" "${UMBRELLA_EXTERNAL[@]}"
 
 # ── Appliance chart ─────────────────────────────────────────────────────────
@@ -158,11 +185,17 @@ APPLIANCE_ALL_ON=(
 )
 lint "$APPLIANCE"
 lint "$APPLIANCE" "${APPLIANCE_ALL_ON[@]}"
+# #983 — this chart renders the PriorityClasses it names, so every appliance
+# pod must carry one. ``agent-landing`` is the recorded exception: a courtesy
+# redirect page that must not outrank anything, and at priority 0 it is also
+# the natural first eviction candidate.
+POSTURE_ARGS="--require-priority --allow-no-priority agent-landing"
 render appliance-defaults "$APPLIANCE"
 render appliance-all-on "$APPLIANCE" "${APPLIANCE_ALL_ON[@]}"
 # The single-node default install shape: one DNS driver + DHCP + supervisor.
 render appliance-full-stack "$APPLIANCE" \
     --set dnsBind9.enabled=true --set dhcpKea.enabled=true --set supervisor.enabled=true
+POSTURE_ARGS=""
 coverage "$APPLIANCE" "${APPLIANCE_ALL_ON[@]}"
 
 if [ "$failures" -ne 0 ]; then

--- a/.github/scripts/charts-render-check.sh
+++ b/.github/scripts/charts-render-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Lint, render and schema-check both Helm charts (#966).
+# Lint, render and schema-check the Helm charts (#966, #983).
 #
 # Until this existed nothing on a PR parsed the charts at all: the one
 # PR-time helm job (agent-e2e) is path-filtered to charts/spatiumddi/** and
@@ -50,6 +50,7 @@ CRD_SCHEMAS='https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Gro
 
 UMBRELLA="$ROOT/charts/spatiumddi"
 APPLIANCE="$ROOT/charts/spatiumddi-appliance"
+METALLB="$ROOT/charts/spatiumddi-metallb"
 
 for tool in helm kubeconform python3; do
     command -v "$tool" >/dev/null || { echo "missing: $tool" >&2; exit 1; }
@@ -108,6 +109,7 @@ coverage() { # chart [every --set arg from every render of that chart...]
 # and this is the first time the dependency resolves before release.
 helm dependency update "$UMBRELLA"
 helm dependency update "$APPLIANCE"
+helm dependency update "$METALLB"
 
 # ── Umbrella chart ──────────────────────────────────────────────────────────
 # Every template gate on: the agents, ingress, the slot-image mirror, HPA, the
@@ -163,6 +165,12 @@ render umbrella-ha "$UMBRELLA" "${UMBRELLA_HA[@]}"
 render umbrella-external-db "$UMBRELLA" "${UMBRELLA_EXTERNAL[@]}"
 POSTURE_ARGS="--require-priority"
 render umbrella-posture "$UMBRELLA" "${UMBRELLA_POSTURE[@]}"
+# ...and again on the HA topology. The CNPG ``Cluster`` and the Sentinel
+# StatefulSet only exist in this shape, and the Cluster carries the posture on
+# its OWN fields rather than on a pod template — so without this render a
+# wrong values path in cnpg-cluster.yaml ships green with Postgres at
+# priority 0, which is precisely what the gate exists to prevent.
+render umbrella-posture-ha "$UMBRELLA" "${UMBRELLA_POSTURE[@]}" "${UMBRELLA_HA[@]}"
 POSTURE_ARGS=""
 coverage "$UMBRELLA" "${UMBRELLA_ALL_ON[@]}" "${UMBRELLA_HA[@]}" "${UMBRELLA_EXTERNAL[@]}"
 
@@ -197,6 +205,35 @@ render appliance-full-stack "$APPLIANCE" \
     --set dnsBind9.enabled=true --set dhcpKea.enabled=true --set supervisor.enabled=true
 POSTURE_ARGS=""
 coverage "$APPLIANCE" "${APPLIANCE_ALL_ON[@]}"
+
+# ── MetalLB wrapper chart ───────────────────────────────────────────────────
+# #983 — this chart was rendered by NOTHING on a PR (the two blocks above name
+# the other two charts explicitly), which is how its speaker and controller
+# stayed BestEffort at priority 0 while every workload around them was ranked:
+# no gate could see them. It ships ``metallb.enabled: false``, so the
+# render that matters is the one with it on — the shape the supervisor
+# applies the moment an operator sets a control-plane VIP.
+METALLB_ALL_ON=(
+    --set metallb.enabled=true
+    --set metallb.ipPool.addresses[0]=10.0.0.20-10.0.0.30
+    --set metallb.bgp.enabled=true
+)
+lint "$METALLB"
+lint "$METALLB" "${METALLB_ALL_ON[@]}"
+render metallb-defaults "$METALLB"
+POSTURE_ARGS="--require-priority"
+render metallb-all-on "$METALLB" "${METALLB_ALL_ON[@]}"
+# BGP mode (#566 D1) — the supervisor flips ``frrk8s.enabled`` on together
+# with ``bgp.enabled`` the moment a peer is configured, so this shape reaches
+# real appliances and has to be rendered. The two frr-k8s workloads are
+# exempted from the seccomp check ONLY: the frr-k8s 0.0.21 subchart exposes no
+# pod-securityContext knob, so no values override can supply a profile.
+# Exempting them by name is strictly better than not rendering the chart,
+# which is how their missing priority class and BestEffort QoS survived #965.
+POSTURE_ARGS="--require-priority --allow-no-seccomp frr-k8s,frr-k8s-statuscleaner"
+render metallb-bgp "$METALLB" "${METALLB_ALL_ON[@]}" --set metallb.frrk8s.enabled=true
+POSTURE_ARGS=""
+coverage "$METALLB" "${METALLB_ALL_ON[@]}" --set metallb.frrk8s.enabled=true
 
 if [ "$failures" -ne 0 ]; then
     echo "charts: $failures gate(s) failed" >&2

--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -75,9 +75,21 @@ jobs:
           version: v3.20.2
 
       - name: Create kind cluster
+        # #983 — kind and the node image are BOTH pinned, and the node image
+        # is what matters: without it the Kubernetes version this job tests
+        # against is whatever kind's default happened to be on the day the
+        # action version was written (v0.22.0, Feb 2024, defaulted to 1.29),
+        # so the number was real but written down nowhere.
+        #
+        # v1.36.4 matches the k3s the appliance ISO bakes (Makefile
+        # K3S_VERSION, #974), so a chart change that only breaks on the
+        # appliance's Kubernetes minor fails here first. The digest pins the
+        # exact image kind v0.33.0 publishes for that tag — a floating tag
+        # would silently drift the thing being pinned.
         uses: helm/kind-action@v1
         with:
-          version: v0.22.0
+          version: v0.33.0
+          node_image: kindest/node:v1.36.4@sha256:099e049362a1526b2db71494e1947aae99bd16290d7c895f2b7ea312e3cbfaed
           cluster_name: spatium-e2e
           wait: 120s
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1684,8 +1684,10 @@ make docs                              # local Jekyll preview of docs/ on :4000 
 make docs-verify                       # diagram-geometry gate — same check CI's "Docs — Diagram Geometry" job runs.
                                        #   Run before pushing ANY docs/assets/**.svg change. Needs chromium on PATH.
 make charts-lint                       # Charts — Lint & Template gate (#966), via a helm container: helm lint + template
-                                       #   with every toggle on + kubeconform -strict + the no-BestEffort check (#965).
-                                       #   Run before pushing ANY charts/** change; renders land in .charts-render/.
+                                       #   with every toggle on + kubeconform -strict + the no-BestEffort check (#965)
+                                       #   + the pod-posture check (#983 — seccomp everywhere, a PriorityClass on every
+                                       #   appliance pod). Run before pushing ANY charts/** change; renders land in
+                                       #   .charts-render/.
 make perf-test                         # Perf — Tests (#968), via Docker. perf/ is denied by the backend path filter,
                                        #   so a perf-only PR runs this and NOT the 8 backend shards.
 make trivy IMAGE=kea                   #   ...one image only. Same gate CI uses (HIGH/CRITICAL, ignore-unfixed).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1686,8 +1686,9 @@ make docs-verify                       # diagram-geometry gate — same check CI
 make charts-lint                       # Charts — Lint & Template gate (#966), via a helm container: helm lint + template
                                        #   with every toggle on + kubeconform -strict + the no-BestEffort check (#965)
                                        #   + the pod-posture check (#983 — seccomp everywhere, a PriorityClass on every
-                                       #   appliance pod). Run before pushing ANY charts/** change; renders land in
-                                       #   .charts-render/.
+                                       #   appliance pod). Covers ALL THREE charts: #983 added spatiumddi-metallb, which
+                                       #   nothing had ever rendered on a PR. Run before pushing ANY charts/** change;
+                                       #   renders land in .charts-render/.
 make perf-test                         # Perf — Tests (#968), via Docker. perf/ is denied by the backend path filter,
                                        #   so a perf-only PR runs this and NOT the 8 backend shards.
 make trivy IMAGE=kea                   #   ...one image only. Same gate CI uses (HIGH/CRITICAL, ignore-unfixed).

--- a/README.md
+++ b/README.md
@@ -1353,7 +1353,7 @@ EOF
 ### Requirements
 
 - Docker 24+ and Docker Compose v2, **or**
-- Kubernetes 1.27+ with Helm 3, **or**
+- Kubernetes 1.31+ with Helm 3, **or**
 - Ubuntu 22.04 / Debian 12 / Alpine 3.20+ for bare metal
 
 ---

--- a/appliance/mkosi.extra/etc/rancher/k3s/config.yaml
+++ b/appliance/mkosi.extra/etc/rancher/k3s/config.yaml
@@ -69,8 +69,20 @@ disable:
 # provider integrations to reconcile.
 disable-cloud-controller: true
 
-# Don't render NetworkPolicy in kube-proxy — single node, no need
-# for inter-pod policies that the CNI plugin would have to enforce.
+# Don't run k3s's NetworkPolicy controller.
+#
+# The rationale used to read "single node, no need" — that stopped being
+# true when #272 made the appliance multi-node. The setting still holds,
+# for different reasons: nothing in either chart renders a NetworkPolicy,
+# so the controller would reconcile an empty set; and it is another
+# always-resident daemon on a node whose floor is 4 GiB.
+#
+# Revisit when we actually ship policies (Kubernetes 1.36 started a
+# NetworkPolicy conformance effort, still alpha). Turning it on later is a
+# config change plus a k3s restart, not a migration — and turning it on
+# BEFORE there are policies to enforce is strictly worse than leaving it
+# off, because an empty policy set changes nothing while the daemon costs
+# memory on every node.
 disable-network-policy: true
 
 # Flannel backend ``host-gw`` writes Linux routes directly instead

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -494,11 +494,34 @@ fi
 APPLIANCE_API_URL="http://spatium-control-spatiumddi-api.spatium.svc.cluster.local:8000"
 
 _render_namespace_yaml() {
+    # #983 — Pod Security Admission at ``baseline``, report-only.
+    #
+    # ``enforce`` is impossible here and always will be: the role
+    # DaemonSets bind :53 / :67 on the host (hostNetwork), the supervisor
+    # mounts host paths and runs with hostPID, and the frontend takes :80 /
+    # :443 on the node. Every one of those violates ``baseline`` on purpose,
+    # so enforcing would reject the appliance's entire reason for existing.
+    #
+    # ``warn`` + ``audit`` are still worth carrying: neither can reject a
+    # pod, and they turn "a workload quietly started wanting hostPath" from
+    # invisible into a line in the helm-controller job log and an annotation
+    # in /var/log/spatiumddi/k3s-audit.log (the apiserver audit log this
+    # appliance already writes — see config.yaml's kube-apiserver-arg).
+    # Expect standing warnings from dns-*, dhcp-kea, looking-glass,
+    # node-exporter, the supervisor and the frontend; a warning from
+    # anything ELSE is the signal.
+    #
+    # Re-rendered on every boot (firstboot rewrites this manifest each
+    # time), so this reaches appliances installed before #983 as soon as
+    # they boot the slot carrying it — no host patch needed.
     cat <<EOF
 apiVersion: v1
 kind: Namespace
 metadata:
   name: spatium
+  labels:
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/audit: baseline
 EOF
 }
 
@@ -646,6 +669,18 @@ place_metallb_frrk8s_crds() {
 #        full-stack=false because the appliance chart owns them)
 _render_control_helmchart() {
     local chart_b64="$1"
+    # #983 — only rank the control-plane workloads if the chart that RENDERS
+    # ``spatium-control-plane`` is also going into the auto-deploy dir. A pod
+    # naming a PriorityClass that does not exist is refused by the apiserver
+    # (the Deployment is accepted; the ReplicaSet controller then cannot
+    # create pods, and says so in an event). Running pods are untouched and
+    # the whole thing self-heals the moment the class appears — but there is
+    # no reason to enter that state on a box whose appliance chart is
+    # missing, which already means no supervisor and no role pods.
+    local cp_priority_class=""
+    if [ -f "$CHART_TGZ" ]; then
+        cp_priority_class="spatium-control-plane"
+    fi
     cat <<EOF
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -670,6 +705,15 @@ spec:
     global:
       controlPlaneNodeSelector:
         spatium.io/role-control-plane: "true"
+      # #983 — rank the control-plane workloads. ``spatium-control-plane``
+      # is rendered by the spatiumddi-appliance chart (spatium-bootstrap),
+      # which firstboot writes into the auto-deploy dir BEFORE this one
+      # (the control chart is held back as ``.deferred`` until the CNPG
+      # webhook is up), so the class exists by the time any pod here names
+      # it. That ordering is load-bearing: the apiserver REFUSES a pod
+      # naming a PriorityClass that does not exist. Empty when the
+      # appliance chart is absent — see the guard above.
+      priorityClassName: "${cp_priority_class}"
     # Appliance overrides — collapse the frontend to a single
     # replica with hostNetwork on the node IP so http://<ip>/
     # serves the SpatiumDDI UI. klipper-lb is disabled in our

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -669,14 +669,15 @@ place_metallb_frrk8s_crds() {
 #        full-stack=false because the appliance chart owns them)
 _render_control_helmchart() {
     local chart_b64="$1"
-    # #983 — only rank the control-plane workloads if the chart that RENDERS
-    # ``spatium-control-plane`` is also going into the auto-deploy dir. A pod
-    # naming a PriorityClass that does not exist is refused by the apiserver
-    # (the Deployment is accepted; the ReplicaSet controller then cannot
-    # create pods, and says so in an event). Running pods are untouched and
-    # the whole thing self-heals the moment the class appears — but there is
-    # no reason to enter that state on a box whose appliance chart is
-    # missing, which already means no supervisor and no role pods.
+    # #983 — first of two gates on naming ``spatium-control-plane`` here.
+    # This one is cheap and early: no appliance chart tarball means the chart
+    # that RENDERS the class is not going into the auto-deploy dir at all.
+    #
+    # It is not sufficient on its own — a tarball that exists proves nothing
+    # about whether its release SUCCEEDED — so ``release_control_manifest``
+    # re-checks against the live cluster before the manifest is applied. Both
+    # matter: this one keeps a known-hopeless value out of the file, that one
+    # catches the failure this one cannot see.
     local cp_priority_class=""
     if [ -f "$CHART_TGZ" ]; then
         cp_priority_class="spatium-control-plane"
@@ -1094,6 +1095,49 @@ if [ -x /usr/local/bin/spatium-upgrade-slot ] && [ -e /etc/spatiumddi/role-confi
         echo "WARN: sync-versions failed — OS Image card will show 'unknown' for slot versions"
 fi
 
+# #983 — release the deferred control manifest, dropping the PriorityClass
+# reference if the class is not actually there.
+#
+# The control chart names ``spatium-control-plane``, which is rendered by a
+# DIFFERENT release: spatium-bootstrap, from the spatiumddi-appliance chart.
+# Render time can only check that that chart's tarball exists. If its release
+# then fails — a bad values patch, a helm-controller wedge, a broken bake —
+# every control-plane Deployment is still ACCEPTED by the apiserver and the
+# ReplicaSet controller cannot create a single pod for it. Pre-#983 that
+# failure left the operator a working UI to diagnose the supervisor with; it
+# must not now take the UI down as well, and because the manifest would
+# already be applied it could not self-heal on its own.
+#
+# So: ask the cluster. A missing class — or an apiserver we cannot reach to
+# ask, which is the "k3s never came ready" release path below — falls back to
+# no class at all. Unranked is exactly the pre-#983 behaviour and is always
+# schedulable, and nothing is lost permanently: firstboot re-renders this
+# manifest from scratch on every boot, so the ranking comes back on the first
+# boot where bootstrap is healthy.
+_strip_control_priority_class() {
+    # Tolerant of indentation on purpose — the pattern has to keep matching
+    # what _render_control_helmchart emits, and that pairing is asserted by
+    # appliance/tests/test_firstboot_pod_posture.py.
+    sed -i -E 's/^([[:space:]]*)priorityClassName: "spatium-control-plane"$/\1priorityClassName: ""/' "$1"
+}
+
+release_control_manifest() {
+    local deferred="${CONTROL_MANIFEST}.deferred"
+    [ -f "$deferred" ] || return 0
+    if ! /usr/local/bin/k3s kubectl get priorityclass spatium-control-plane \
+            >/dev/null 2>&1; then
+        echo "WARN: PriorityClass spatium-control-plane is absent, or the apiserver could not be reached." >&2
+        echo "      Releasing the control chart WITHOUT it — a pod naming a PriorityClass that does" >&2
+        echo "      not exist cannot be created at all, which would take the Web UI down alongside" >&2
+        echo "      the spatium-bootstrap release instead of leaving it up to diagnose with." >&2
+        echo "      Check: k3s kubectl -n kube-system get helmchart spatium-bootstrap" >&2
+        echo "      The ranking returns on the first boot where that release is healthy." >&2
+        _strip_control_priority_class "$deferred"
+    fi
+    mv -f "$deferred" "$CONTROL_MANIFEST"
+    chmod 0600 "$CONTROL_MANIFEST"
+}
+
 # #554 — is this a TRIAL boot (running slot != durable default)? Blocking
 # the slot commit on a host-migrate failure only matters during a trial
 # boot; on a steady-state boot there's nothing to commit, so a persistent
@@ -1122,7 +1166,7 @@ if [ -x /usr/local/bin/spatium-host-migrate ]; then
         echo "ERROR: host-migration reconcile failed." >&2
         # Still release any deferred control manifest so the control plane
         # comes up regardless.
-        mv -f "${CONTROL_MANIFEST}.deferred" "$CONTROL_MANIFEST" 2>/dev/null || true
+        release_control_manifest || true
         if is_trial_boot; then
             # Trial boot: a bad grub render risks the next reboot, so do NOT
             # commit — exit non-zero so commit_slot_if_healthy never runs and
@@ -1212,8 +1256,7 @@ place_deferred_control_manifest() {
     else
         echo "WARN: CNPG webhook not ready after 4 min — applying control chart anyway (helm-controller retries)." >&2
     fi
-    mv -f "$deferred" "$CONTROL_MANIFEST"
-    chmod 0600 "$CONTROL_MANIFEST"
+    release_control_manifest
 }
 
 # Wait for k3s to come up + helm-controller to apply the bootstrap
@@ -1253,6 +1296,8 @@ echo "WARN: k3s /readyz did not respond within 5 minutes." >&2
 echo "      Check 'systemctl status k3s' + 'journalctl -u k3s'." >&2
 # k3s never became ready, but don't strand the deferred control chart —
 # place it so a later k3s recovery (or manual restart) still deploys the
-# control plane. helm-controller will retry the webhook on its own.
-mv -f "${CONTROL_MANIFEST}.deferred" "$CONTROL_MANIFEST" 2>/dev/null || true
+# control plane. helm-controller will retry the webhook on its own. #983 —
+# the class lookup necessarily fails here (no apiserver), so this path always
+# releases unranked; the next boot restores it.
+release_control_manifest || true
 exit 1

--- a/appliance/tests/README.md
+++ b/appliance/tests/README.md
@@ -1,17 +1,21 @@
 # Appliance host-script tests (#395)
 
-Host-portable pytest suite for the appliance host scripts.  These tests
-run on any developer machine or CI runner with Python 3 and do NOT
-require a database, Docker, or an appliance ISO.
+Host-portable pytest suite for the appliance host scripts — and for the
+CI gates that guard the appliance's Helm charts, which have nowhere else
+hermetic to live.  These tests run on any developer machine or CI runner
+with Python 3 and do NOT require a database, Docker, an appliance ISO,
+helm or a cluster.
 
 ## Files
 
 | File | What it tests |
 |---|---|
+| `test_chart_pod_posture.py` | `.github/scripts/chart-pod-posture.py` — the seccomp + PriorityClass gate on both charts (#983) |
 | `test_cluster_join_failure_reason.py` | `spatium-cluster-join`'s failure-reason classifier (#590) |
 | `test_cluster_join_identity.py` | `spatium-cluster-join`'s cluster-identity wipe (#590) |
 | `test_firewall_webui_sentinel.py` | Web UI reachability before the supervisor exists (#769) |
 | `test_firstboot_member_guard.py` | `spatiumddi-firstboot` not re-seeding manifests on a joined member (#590) |
+| `test_firstboot_pod_posture.py` | `spatiumddi-firstboot`'s PSA namespace labels + control-plane PriorityClass overlay (#983) |
 | `test_frontend_boot_gate.py` | SPA fallback landing on the initialising page (#767) |
 | `test_grub_render.py` | `spatium-grub-render` renderer via `--print` (DRY-RUN) |
 | `test_host_migrate.py` | `spatium-host-migrate` orchestrator via a patched subprocess |

--- a/appliance/tests/README.md
+++ b/appliance/tests/README.md
@@ -15,7 +15,7 @@ helm or a cluster.
 | `test_cluster_join_identity.py` | `spatium-cluster-join`'s cluster-identity wipe (#590) |
 | `test_firewall_webui_sentinel.py` | Web UI reachability before the supervisor exists (#769) |
 | `test_firstboot_member_guard.py` | `spatiumddi-firstboot` not re-seeding manifests on a joined member (#590) |
-| `test_firstboot_pod_posture.py` | `spatiumddi-firstboot`'s PSA namespace labels + control-plane PriorityClass overlay (#983) |
+| `test_firstboot_pod_posture.py` | `spatiumddi-firstboot`'s PSA namespace labels, the control-plane PriorityClass overlay, and the release-time gate that strips it when the class is absent (#983) |
 | `test_frontend_boot_gate.py` | SPA fallback landing on the initialising page (#767) |
 | `test_grub_render.py` | `spatium-grub-render` renderer via `--print` (DRY-RUN) |
 | `test_host_migrate.py` | `spatium-host-migrate` orchestrator via a patched subprocess |

--- a/appliance/tests/test_chart_pod_posture.py
+++ b/appliance/tests/test_chart_pod_posture.py
@@ -1,0 +1,167 @@
+"""The #983 pod-posture gate actually fails when it should.
+
+``.github/scripts/chart-pod-posture.py`` is the guard that stops a NEW
+workload shipping without a seccomp profile or a PriorityClass. It fails
+OPEN by construction — a bug that makes it skip a workload reports "OK" and
+the defect ships — so every assertion here is paired with a negative
+control that must FAIL, per the lesson recorded on the #861 harness work.
+
+Lives in ``appliance/tests`` because that is the hermetic pytest job with
+PyYAML that runs unconditionally on every PR; the gate itself runs inside
+the Charts job, which has helm and kubeconform but no pytest. The alternative
+was a fourth test root for one file.
+
+HOW TO RUN (from the repo root or this directory):
+    python3 -m pytest appliance/tests/test_chart_pod_posture.py -v
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).parent.parent.parent / ".github" / "scripts" / "chart-pod-posture.py"
+)
+
+GOOD_DEPLOYMENT = """
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    spec:
+      priorityClassName: spatium-control-plane
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: api
+          image: example:1
+"""
+
+GOOD_CNPG = """
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: pg
+spec:
+  instances: 1
+  priorityClassName: spatium-control-plane
+  seccompProfile:
+    type: RuntimeDefault
+"""
+
+
+def _run(manifest: str, tmp_path: Path, *flags: str) -> subprocess.CompletedProcess:
+    f = tmp_path / "render.yaml"
+    f.write_text(textwrap.dedent(manifest))
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *flags, str(f)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_script_exists() -> None:
+    assert SCRIPT.is_file(), f"{SCRIPT} missing — the Charts job calls it by path"
+
+
+def test_a_correct_workload_passes(tmp_path: Path) -> None:
+    r = _run(GOOD_DEPLOYMENT, tmp_path, "--require-priority")
+    assert r.returncode == 0, r.stderr
+    assert "1 workload(s) OK" in r.stdout
+
+
+def test_missing_seccomp_fails(tmp_path: Path) -> None:
+    bad = GOOD_DEPLOYMENT.replace(
+        "      securityContext:\n        seccompProfile:\n          type: RuntimeDefault\n",
+        "",
+    )
+    assert "seccompProfile" not in bad, "fixture edit missed — the test would be vacuous"
+    r = _run(bad, tmp_path)
+    assert r.returncode == 1, r.stdout
+    assert "seccompProfile" in r.stderr
+
+
+def test_missing_priority_fails_only_when_required(tmp_path: Path) -> None:
+    bad = GOOD_DEPLOYMENT.replace("      priorityClassName: spatium-control-plane\n", "")
+    assert "priorityClassName" not in bad
+    # The umbrella chart's default is deliberately no class at all.
+    assert _run(bad, tmp_path).returncode == 0
+    r = _run(bad, tmp_path, "--require-priority")
+    assert r.returncode == 1
+    assert "no priorityClassName" in r.stderr
+
+
+def test_an_empty_priority_class_is_not_a_class(tmp_path: Path) -> None:
+    """``priorityClassName: ""`` renders when a values path resolves empty.
+    It must not read as "set" — that is precisely the silent-nothing case
+    this gate exists to catch."""
+    bad = GOOD_DEPLOYMENT.replace(
+        "priorityClassName: spatium-control-plane", 'priorityClassName: ""'
+    )
+    assert _run(bad, tmp_path, "--require-priority").returncode == 1
+
+
+def test_exemption_records_a_deliberate_priority_zero(tmp_path: Path) -> None:
+    bad = GOOD_DEPLOYMENT.replace("      priorityClassName: spatium-control-plane\n", "")
+    r = _run(bad, tmp_path, "--require-priority", "--allow-no-priority", "api")
+    assert r.returncode == 0, r.stderr
+    # ...and the exemption is by name, not a blanket switch.
+    r2 = _run(bad, tmp_path, "--require-priority", "--allow-no-priority", "something-else")
+    assert r2.returncode == 1
+
+
+def test_every_pod_bearing_kind_is_inspected(tmp_path: Path) -> None:
+    """A workload kind the script does not know about is skipped silently,
+    so the set of kinds it walks is itself part of the guard."""
+    for kind in ("Deployment", "StatefulSet", "DaemonSet", "Job"):
+        bad = GOOD_DEPLOYMENT.replace("kind: Deployment", f"kind: {kind}").replace(
+            "      securityContext:\n        seccompProfile:\n          type: RuntimeDefault\n",
+            "",
+        )
+        r = _run(bad, tmp_path)
+        assert r.returncode == 1, f"{kind} was not inspected: {r.stdout}"
+
+
+def test_cnpg_cluster_is_checked_through_its_own_fields(tmp_path: Path) -> None:
+    """CNPG owns its instance pods, so the properties ride on the CR rather
+    than on a pod template. A gate that only knew about pod templates would
+    report the database as fine while it ran unranked."""
+    assert _run(GOOD_CNPG, tmp_path, "--require-priority").returncode == 0
+    without = GOOD_CNPG.replace("  priorityClassName: spatium-control-plane\n", "")
+    assert _run(without, tmp_path, "--require-priority").returncode == 1
+    without_seccomp = GOOD_CNPG.replace(
+        "  seccompProfile:\n    type: RuntimeDefault\n", ""
+    )
+    assert _run(without_seccomp, tmp_path).returncode == 1
+
+
+def test_non_workload_documents_are_ignored(tmp_path: Path) -> None:
+    """Services, Secrets and the PriorityClasses themselves have no pod
+    template; flagging them would make the gate unusable."""
+    r = _run(
+        """
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: api
+        spec:
+          ports: [{port: 80}]
+        ---
+        apiVersion: scheduling.k8s.io/v1
+        kind: PriorityClass
+        metadata:
+          name: spatium-service
+        value: 100000
+        """,
+        tmp_path,
+        "--require-priority",
+    )
+    assert r.returncode == 0, r.stderr
+    assert "0 workload(s) OK" in r.stdout

--- a/appliance/tests/test_chart_pod_posture.py
+++ b/appliance/tests/test_chart_pod_posture.py
@@ -165,3 +165,59 @@ def test_non_workload_documents_are_ignored(tmp_path: Path) -> None:
     )
     assert r.returncode == 0, r.stderr
     assert "0 workload(s) OK" in r.stdout
+
+
+def test_seccomp_exemption(tmp_path: Path) -> None:
+    """Used for exactly one thing: a vendored subchart (frr-k8s) whose
+    templates expose no pod-securityContext knob, so no values override can
+    supply a profile. Exempting it beats not rendering the chart at all."""
+    bad = GOOD_DEPLOYMENT.replace(
+        "      securityContext:\n        seccompProfile:\n          type: RuntimeDefault\n",
+        "",
+    )
+    assert _run(bad, tmp_path).returncode == 1
+    r = _run(bad, tmp_path, "--allow-no-seccomp", "api")
+    assert r.returncode == 0, r.stderr
+    # ...by name, not a blanket switch.
+    assert _run(bad, tmp_path, "--allow-no-seccomp", "other").returncode == 1
+
+
+def test_exemptions_are_independent(tmp_path: Path) -> None:
+    """Exempting seccomp must not quietly exempt the priority check too."""
+    bad = GOOD_DEPLOYMENT.replace(
+        "      securityContext:\n        seccompProfile:\n          type: RuntimeDefault\n",
+        "",
+    ).replace("      priorityClassName: spatium-control-plane\n", "")
+    r = _run(bad, tmp_path, "--require-priority", "--allow-no-seccomp", "api")
+    assert r.returncode == 1
+    assert "no priorityClassName" in r.stderr
+    assert "seccompProfile" not in r.stderr
+
+
+def test_exemptions_match_the_release_prefixed_name(tmp_path: Path) -> None:
+    """Helm prefixes a subchart's workloads with the release name, so the
+    same object is ``frr-k8s`` in the chart and ``metallb-bgp-frr-k8s`` in a
+    render. An exact-match-only exemption would stop applying the moment a
+    render was renamed — silently, since the gate would then just fail."""
+    bad = GOOD_DEPLOYMENT.replace("name: api", "name: metallb-bgp-frr-k8s").replace(
+        "      securityContext:\n        seccompProfile:\n          type: RuntimeDefault\n",
+        "",
+    )
+    assert _run(bad, tmp_path, "--allow-no-seccomp", "frr-k8s").returncode == 0
+    # An unrelated name must not match — the property that actually matters.
+    assert _run(bad, tmp_path, "--allow-no-seccomp", "api").returncode == 1
+    # The suffix test is NOT segment-aware, so a short exemption over-matches.
+    # Pinned rather than fixed: the docstring tells callers to write full
+    # workload names, and an over-broad exemption is still typed by a human
+    # into a reviewed file.
+    assert _run(bad, tmp_path, "--allow-no-seccomp", "k8s").returncode == 0
+
+
+def test_exemption_flag_without_a_value_is_a_usage_error(tmp_path: Path) -> None:
+    f = tmp_path / "render.yaml"
+    f.write_text(GOOD_DEPLOYMENT)
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), str(f), "--allow-no-seccomp"],
+        capture_output=True, text=True, check=False,
+    )
+    assert r.returncode == 2, r.stdout

--- a/appliance/tests/test_firstboot_pod_posture.py
+++ b/appliance/tests/test_firstboot_pod_posture.py
@@ -12,12 +12,21 @@ Two things ``spatiumddi-firstboot`` emits that nothing else can:
     workloads pick up the ``spatium-control-plane`` class that the
     spatiumddi-appliance chart renders.
 
-The second one has a hazard worth a test of its own: a pod naming a
+The second one has a hazard worth several tests: a pod naming a
 PriorityClass that does not exist is REFUSED by the apiserver — the
 Deployment is accepted and the ReplicaSet controller then cannot create
-pods. So the override is emitted only when the chart that defines the class
-is also going into the auto-deploy dir, and the negative case is asserted
-here rather than reasoned about.
+pods. The class comes from a *different* release (spatium-bootstrap), so
+there are two gates, and both negative cases are asserted here rather than
+reasoned about:
+
+  * render time can only see whether the appliance chart's TARBALL exists;
+  * ``release_control_manifest`` re-checks against the live cluster and
+    strips the reference when the class is not there, so a failed bootstrap
+    release costs the ranking rather than the whole control plane.
+
+The stripper is a ``sed`` pattern that has to keep matching what the
+renderer emits — a coupling that would otherwise rot silently, so the round
+trip is exercised end to end.
 
 Both renderers sit BELOW the ``SPATIUM_FIRSTBOOT_LIB`` early-return, so
 they cannot be reached by sourcing the script the way
@@ -147,3 +156,89 @@ def test_extractor_reports_a_missing_function() -> None:
     would pass against nothing at all."""
     with pytest.raises(AssertionError, match="not found"):
         _extract_function("_render_no_such_thing")
+
+
+# ── The release-time gate ───────────────────────────────────────────────────
+
+
+def _render_control_manifest(tmp_path: Path, *, chart_present: bool) -> Path:
+    tgz = tmp_path / "spatiumddi-appliance.tgz"
+    if chart_present:
+        tgz.write_bytes(b"x")
+    out = tmp_path / "spatium-control.yaml.deferred"
+    out.write_text(_run("_render_control_helmchart", {"CHART_TGZ": str(tgz)}))
+    return out
+
+
+def _strip(manifest: Path) -> dict:
+    """Run the real ``_strip_control_priority_class`` over a real render."""
+    body = _extract_function("_strip_control_priority_class")
+    proc = subprocess.run(
+        ["bash", "-c", f'{body}\n_strip_control_priority_class "{manifest}"'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    doc = yaml.safe_load(manifest.read_text())
+    return yaml.safe_load(doc["spec"]["valuesContent"])
+
+
+def test_stripper_matches_what_the_renderer_emits(tmp_path: Path) -> None:
+    """The coupling that would rot silently: a sed pattern on one side, a
+    heredoc on the other. Assert the round trip, not either half."""
+    m = _render_control_manifest(tmp_path, chart_present=True)
+    before = yaml.safe_load(yaml.safe_load(m.read_text())["spec"]["valuesContent"])
+    assert before["global"]["priorityClassName"] == "spatium-control-plane"
+    after = _strip(m)
+    assert after["global"]["priorityClassName"] == ""
+
+
+def test_stripping_leaves_the_rest_of_the_values_intact(tmp_path: Path) -> None:
+    """An over-broad pattern would be worse than no pattern — this manifest
+    carries the agent PSKs, the node-selector gate and the cp-size markers."""
+    m = _render_control_manifest(tmp_path, chart_present=True)
+    before = yaml.safe_load(yaml.safe_load(m.read_text())["spec"]["valuesContent"])
+    after = _strip(m)
+    before["global"]["priorityClassName"] = ""
+    assert after == before
+
+
+def test_stripping_is_idempotent(tmp_path: Path) -> None:
+    """It runs on every boot that cannot confirm the class."""
+    m = _render_control_manifest(tmp_path, chart_present=False)
+    assert _strip(m)["global"]["priorityClassName"] == ""
+    assert _strip(m)["global"]["priorityClassName"] == ""
+
+
+def test_every_release_site_goes_through_the_gate() -> None:
+    """Three code paths release the deferred manifest — the CNPG-webhook
+    wait, the host-migrate failure path and the k3s-never-ready path. A bare
+    ``mv`` at any of them puts the un-checked value straight into effect."""
+    body = SCRIPT.read_text(encoding="utf-8")
+    gate = _extract_function("release_control_manifest")
+    outside = body.replace(gate, "")
+    # A release moves FROM the deferred path INTO $CONTROL_MANIFEST. Writing
+    # the deferred file (``mv "$tmp" "${CONTROL_MANIFEST}.deferred"``) is the
+    # other direction and is fine.
+    offenders = [
+        ln.strip()
+        for ln in outside.splitlines()
+        if ln.strip().startswith("mv ")
+        and "deferred" in ln
+        and ln.rstrip().endswith('"$CONTROL_MANIFEST"')
+    ]
+    assert offenders == [], (
+        f"deferred manifest released outside release_control_manifest: {offenders}"
+    )
+    # ...and the gate is actually reached: its definition plus three callers.
+    assert body.count("release_control_manifest") >= 4
+
+
+def test_the_gate_negative_control() -> None:
+    """The scan above must actually be able to fail, or it is decoration."""
+    gate = _extract_function("release_control_manifest")
+    assert 'mv -f "$deferred" "$CONTROL_MANIFEST"' in gate, (
+        "the one legitimate release moved or was renamed — the scan in the "
+        "test above keys off exactly this shape and would now pass vacuously"
+    )

--- a/appliance/tests/test_firstboot_pod_posture.py
+++ b/appliance/tests/test_firstboot_pod_posture.py
@@ -1,0 +1,149 @@
+"""firstboot's rendered manifests carry the #983 posture bits.
+
+Two things ``spatiumddi-firstboot`` emits that nothing else can:
+
+  * the ``spatium`` Namespace's Pod Security Admission labels — the chart
+    deliberately does NOT own the namespace (a chart-owned namespace is what
+    ``spatiumddi-helm-stuck-recover`` exists to clean up after), so the
+    labels can only come from here;
+
+  * ``global.priorityClassName`` in the ``spatium-control`` HelmChart's
+    values, which is what makes the umbrella chart's control-plane
+    workloads pick up the ``spatium-control-plane`` class that the
+    spatiumddi-appliance chart renders.
+
+The second one has a hazard worth a test of its own: a pod naming a
+PriorityClass that does not exist is REFUSED by the apiserver — the
+Deployment is accepted and the ReplicaSet controller then cannot create
+pods. So the override is emitted only when the chart that defines the class
+is also going into the auto-deploy dir, and the negative case is asserted
+here rather than reasoned about.
+
+Both renderers sit BELOW the ``SPATIUM_FIRSTBOOT_LIB`` early-return, so
+they cannot be reached by sourcing the script the way
+``test_firstboot_member_guard.py`` does. They are extracted by name and
+evaluated on their own instead; ``_extract_function`` fails loudly if the
+name is not found, so a rename shows up as an error rather than as a
+vacuously passing test.
+
+HOW TO RUN (from the repo root or this directory):
+    python3 -m pytest appliance/tests/test_firstboot_pod_posture.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCRIPT = (
+    Path(__file__).parent.parent
+    / "mkosi.extra"
+    / "usr"
+    / "local"
+    / "bin"
+    / "spatiumddi-firstboot"
+)
+
+
+def _extract_function(name: str) -> str:
+    """Return the shell source of a top-level ``name() { ... }`` function.
+
+    Brace-matched from the opening line to a closing ``}`` at column 0,
+    which is how every function in this script is written.
+    """
+    lines = SCRIPT.read_text(encoding="utf-8").splitlines()
+    opener = f"{name}() {{"
+    for i, line in enumerate(lines):
+        if line == opener:
+            break
+    else:  # pragma: no cover - the assert below is the real reporter
+        raise AssertionError(f"{name}() not found in {SCRIPT} (renamed?)")
+    for j in range(i + 1, len(lines)):
+        if lines[j] == "}":
+            return "\n".join(lines[i : j + 1])
+    raise AssertionError(f"{name}() has no closing brace at column 0")
+
+
+def _run(func_name: str, env: dict[str, str] | None = None) -> str:
+    """Define one extracted function in a fresh shell and call it."""
+    body = _extract_function(func_name)
+    script = f"{body}\n{func_name}\n"
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        env={**os.environ, **(env or {})},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"{func_name} exited {proc.returncode}: {proc.stderr}"
+    assert proc.stdout.strip(), f"{func_name} rendered nothing"
+    return proc.stdout
+
+
+# ── Namespace ───────────────────────────────────────────────────────────────
+
+
+def test_namespace_carries_psa_warn_and_audit() -> None:
+    doc = yaml.safe_load(_run("_render_namespace_yaml"))
+    assert doc["kind"] == "Namespace"
+    assert doc["metadata"]["name"] == "spatium"
+    labels = doc["metadata"]["labels"]
+    assert labels["pod-security.kubernetes.io/warn"] == "baseline"
+    assert labels["pod-security.kubernetes.io/audit"] == "baseline"
+
+
+def test_namespace_never_enforces() -> None:
+    """``enforce`` would reject the role DaemonSets, the supervisor and the
+    hostNetwork frontend — every one of which violates ``baseline`` on
+    purpose. Report-only is the only mode this namespace can carry."""
+    doc = yaml.safe_load(_run("_render_namespace_yaml"))
+    assert "pod-security.kubernetes.io/enforce" not in doc["metadata"]["labels"]
+
+
+# ── Control-plane HelmChart values ──────────────────────────────────────────
+
+
+def _control_values(chart_tgz: Path | None) -> dict:
+    env = {"CHART_TGZ": str(chart_tgz) if chart_tgz else "/nonexistent/appliance.tgz"}
+    doc = yaml.safe_load(_run("_render_control_helmchart", env))
+    assert doc["kind"] == "HelmChart"
+    return yaml.safe_load(doc["spec"]["valuesContent"])
+
+
+def test_control_plane_workloads_get_the_priority_class(tmp_path: Path) -> None:
+    tgz = tmp_path / "spatiumddi-appliance.tgz"
+    tgz.write_bytes(b"not really a chart, only its presence is read")
+    values = _control_values(tgz)
+    assert values["global"]["priorityClassName"] == "spatium-control-plane"
+
+
+def test_no_priority_class_when_the_chart_that_defines_it_is_absent() -> None:
+    """The class is rendered by the spatiumddi-appliance chart. With that
+    chart missing there is nothing to define it, and naming it anyway leaves
+    the ReplicaSet controller unable to create a single control-plane pod."""
+    values = _control_values(None)
+    assert values["global"]["priorityClassName"] == ""
+
+
+def test_the_node_selector_gate_still_renders(tmp_path: Path) -> None:
+    """#272's control-plane node gate shares the ``global`` block the
+    priority knob was added to; a bad edit there would drop it silently and
+    schedule control-plane pods onto DNS-only nodes (non-negotiable #16)."""
+    tgz = tmp_path / "chart.tgz"
+    tgz.write_bytes(b"x")
+    values = _control_values(tgz)
+    assert values["global"]["controlPlaneNodeSelector"] == {
+        "spatium.io/role-control-plane": "true"
+    }
+
+
+def test_extractor_reports_a_missing_function() -> None:
+    """Negative control for the harness itself: if ``_extract_function``
+    quietly returned an empty string for an unknown name, every test above
+    would pass against nothing at all."""
+    with pytest.raises(AssertionError, match="not found"):
+        _extract_function("_render_no_such_thing")

--- a/charts/spatiumddi-appliance/Chart.yaml
+++ b/charts/spatiumddi-appliance/Chart.yaml
@@ -8,7 +8,15 @@ description: |
 type: application
 version: 0.1.0
 appVersion: "0.0.0-dev"
-kubeVersion: ">=1.27.0-0"
+# #983 — these charts only ever run on the k3s the appliance ISO bakes, which
+# is Kubernetes 1.36 as of #974. The floor is deliberately ONE MINOR BELOW
+# that rather than at it: during a rolling OS upgrade the cluster transiently
+# serves a mix of 1.35 and 1.36 apiservers, and helm validates kubeVersion
+# against whichever apiserver it reaches. A floor of 1.36 would turn an
+# ordinary role toggle made mid-upgrade — the supervisor patches this chart's
+# values on every role change — into a failed release, for no gain: nothing
+# in either chart uses API surface newer than 1.35.
+kubeVersion: ">=1.35.0-0"
 home: https://www.spatiumddi.com/
 sources:
   - https://github.com/spatiumddi/spatiumddi

--- a/charts/spatiumddi-appliance/templates/_helpers.tpl
+++ b/charts/spatiumddi-appliance/templates/_helpers.tpl
@@ -43,3 +43,26 @@ helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
 {{- $tag := default $.global.imageTag .tag -}}
 {{- printf "%s:%s" $repo $tag -}}
 {{- end -}}
+
+{{/*
+#983 — pod-level seccomp profile, shared by every workload this chart
+renders. Mirrors ``spatiumddi.seccompProfileType`` in the umbrella chart;
+duplicated rather than shared because Helm named templates are per-chart
+and the appliance chart is not a subchart of the umbrella.
+
+Kubernetes runs a container ``Unconfined`` unless a profile is asked for,
+while docker-compose applies the runtime's default profile to every
+service — so without this the appliance runs the SAME images with fewer
+syscall restrictions than a Compose install. ``RuntimeDefault`` under
+containerd is the same profile family Compose gets from Docker.
+
+Returns the bare type string, or nothing when disabled.
+*/}}
+{{- define "spatiumddi-appliance.seccompProfileType" -}}
+{{- $t := default "" (.Values.global).seccompProfile -}}
+{{- if and $t (not (has $t (list "RuntimeDefault" "Unconfined"))) -}}
+{{- fail (printf "global.seccompProfile must be \"RuntimeDefault\", \"Unconfined\" or \"\" — got %q. Localhost profiles need a localhostProfile path this chart cannot place on the node." $t) -}}
+{{- end -}}
+{{- $t -}}
+{{- end -}}
+

--- a/charts/spatiumddi-appliance/templates/agent-landing.yaml
+++ b/charts/spatiumddi-appliance/templates/agent-landing.yaml
@@ -37,6 +37,14 @@ spec:
         app.kubernetes.io/name: agent-landing
         app.kubernetes.io/component: agent-landing
     spec:
+      {{- with .Values.agentLanding.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi-appliance.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:

--- a/charts/spatiumddi-appliance/templates/dhcp-kea.yaml
+++ b/charts/spatiumddi-appliance/templates/dhcp-kea.yaml
@@ -31,6 +31,14 @@ spec:
         app.kubernetes.io/name: dhcp-kea
         app.kubernetes.io/component: dhcp-kea
     spec:
+      {{- with .Values.dhcpKea.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi-appliance.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
         # Phase 10 (#183) — per-role scheduling label. The supervisor

--- a/charts/spatiumddi-appliance/templates/dns-bind9.yaml
+++ b/charts/spatiumddi-appliance/templates/dns-bind9.yaml
@@ -47,6 +47,14 @@ spec:
         app.kubernetes.io/name: dns-bind9
         app.kubernetes.io/component: dns-bind9
     spec:
+      {{- with .Values.dnsBind9.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi-appliance.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       {{- if not .Values.dns.useMetalLBVIP }}
       # #272 Phase 5 — default path: bind on the node IP so non-cluster
       # clients resolve against the appliance directly. When a DNS VIP

--- a/charts/spatiumddi-appliance/templates/dns-powerdns.yaml
+++ b/charts/spatiumddi-appliance/templates/dns-powerdns.yaml
@@ -34,6 +34,14 @@ spec:
         app.kubernetes.io/name: dns-powerdns
         app.kubernetes.io/component: dns-powerdns
     spec:
+      {{- with .Values.dnsPowerdns.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi-appliance.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       {{- if not .Values.dns.useMetalLBVIP }}
       # #272 Phase 5 — default path: bind :53 on the node IP. A DNS VIP
       # drops hostNetwork in favour of the LoadBalancer Service below.

--- a/charts/spatiumddi-appliance/templates/dns-technitium.yaml
+++ b/charts/spatiumddi-appliance/templates/dns-technitium.yaml
@@ -35,6 +35,14 @@ spec:
         app.kubernetes.io/name: dns-technitium
         app.kubernetes.io/component: dns-technitium
     spec:
+      {{- with .Values.dnsTechnitium.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi-appliance.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       {{- if not .Values.dns.useMetalLBVIP }}
       # #272 Phase 5 — default path: bind :53 on the node IP. A DNS VIP
       # drops hostNetwork in favour of the LoadBalancer Service below.

--- a/charts/spatiumddi-appliance/templates/looking-glass.yaml
+++ b/charts/spatiumddi-appliance/templates/looking-glass.yaml
@@ -45,6 +45,14 @@ spec:
         app.kubernetes.io/name: looking-glass
         app.kubernetes.io/component: looking-glass
     spec:
+      {{- with .Values.lookingGlass.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi-appliance.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
         # Phase 10 (#183) per-role scheduling label pattern, extended

--- a/charts/spatiumddi-appliance/templates/observability-kube-state-metrics.yaml
+++ b/charts/spatiumddi-appliance/templates/observability-kube-state-metrics.yaml
@@ -100,6 +100,14 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/component: kube-state-metrics
     spec:
+      {{- with .Values.observability.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi-appliance.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       serviceAccountName: kube-state-metrics
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}

--- a/charts/spatiumddi-appliance/templates/observability-node-exporter.yaml
+++ b/charts/spatiumddi-appliance/templates/observability-node-exporter.yaml
@@ -44,6 +44,14 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
     spec:
+      {{- with .Values.observability.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi-appliance.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       serviceAccountName: node-exporter
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}

--- a/charts/spatiumddi-appliance/templates/priorityclasses.yaml
+++ b/charts/spatiumddi-appliance/templates/priorityclasses.yaml
@@ -42,6 +42,29 @@ it also stops Helm patching a kept resource on UPGRADE, so retuning a
 class's value would silently do nothing. A few seconds of "cannot create
 pods" beats a value that reads as changed and is not.
 */}}
+{{/*
+Refuse the render outright when ``create`` is off while workloads still name
+a class. The apiserver REFUSES a pod naming a PriorityClass that does not
+exist, so that combination does not degrade the appliance — it stops every
+role pod and the supervisor being created at all, with the reason buried in
+a ReplicaSet event. The chart already fails for a less severe seccomp
+misconfiguration; this one earns it more.
+
+Named rather than counted, so the message says what to clear.
+*/}}
+{{- if not .Values.priorityClasses.create }}
+{{- $named := list -}}
+{{- range $key, $wl := .Values -}}
+{{- if kindIs "map" $wl -}}
+{{- if get $wl "priorityClassName" -}}
+{{- $named = append $named (printf "%s.priorityClassName=%s" $key (get $wl "priorityClassName")) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $named -}}
+{{- fail (printf "priorityClasses.create is false, but these still name a class this chart would no longer render: %s. A pod naming a PriorityClass that does not exist is REFUSED by the apiserver — set each of them to \"\" as well, or leave create: true." (join ", " $named)) -}}
+{{- end -}}
+{{- end }}
 {{- if .Values.priorityClasses.create }}
 {{- range $key, $class := .Values.priorityClasses.classes }}
 ---

--- a/charts/spatiumddi-appliance/templates/priorityclasses.yaml
+++ b/charts/spatiumddi-appliance/templates/priorityclasses.yaml
@@ -1,0 +1,61 @@
+{{/*
+#983 — the appliance's own PriorityClasses.
+
+Before this, every pod on an appliance was Burstable at priority 0, which
+makes them indistinguishable to the two rankings that matter when a node
+runs out of room:
+
+  * kubelet eviction under memory / ephemeral-storage pressure orders
+    victims by priority FIRST, then by usage-over-request. With all
+    priorities equal the likeliest victim is whichever pod grew the most —
+    on an appliance that is BIND with a warm cache, i.e. the one pod the
+    LAN actually needs.
+
+  * scheduler preemption gives a pending pod no claim on a full node, so a
+    role DaemonSet landing on a freshly joined node can sit Pending behind
+    kube-state-metrics.
+
+Kubernetes' own ``system-cluster-critical`` (2000000000) and
+``system-node-critical`` (2000001000) are restricted to ``kube-system`` by
+default, hence our own classes. All three sit far below those so k3s's own
+components still outrank everything here.
+
+``globalDefault`` is false on all three — a global default would silently
+re-rank every pod in every namespace on the cluster, including workloads an
+operator joined to it themselves.
+
+These are CLUSTER-SCOPED objects rendered by a namespaced release. That is
+deliberate: this chart is installed exactly once per appliance cluster (the
+seed renders it; joined members render nothing into the auto-deploy dir —
+see spatiumddi-firstboot's member guard), and the umbrella control-plane
+release references the names it defines. Ordering works out because
+firstboot writes spatium-bootstrap.yaml immediately and holds
+spatium-control.yaml back as ``.deferred`` until the CNPG webhook is ready,
+so the classes exist before any pod names one.
+
+Deliberately NOT annotated ``helm.sh/resource-policy: keep``, unlike the
+CNPG ``Cluster``. ``keep`` would survive the k3s helm-controller's
+uninstall+reinstall recovery for a failed release — during which these
+objects briefly vanish and no new pod naming one can be created (running
+pods are untouched, and the reinstall puts them back seconds later) — but
+it also stops Helm patching a kept resource on UPGRADE, so retuning a
+class's value would silently do nothing. A few seconds of "cannot create
+pods" beats a value that reads as changed and is not.
+*/}}
+{{- if .Values.priorityClasses.create }}
+{{- range $key, $class := .Values.priorityClasses.classes }}
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ $class.name }}
+  labels:
+    {{- include "spatiumddi-appliance.labels" $ | nindent 4 }}
+value: {{ $class.value }}
+globalDefault: false
+{{- if $class.preemptionPolicy }}
+preemptionPolicy: {{ $class.preemptionPolicy }}
+{{- end }}
+description: {{ $class.description | quote }}
+{{- end }}
+{{- end }}

--- a/charts/spatiumddi-appliance/templates/supervisor.yaml
+++ b/charts/spatiumddi-appliance/templates/supervisor.yaml
@@ -24,6 +24,14 @@ spec:
         app.kubernetes.io/name: spatium-supervisor
         app.kubernetes.io/component: supervisor
     spec:
+      {{- with .Values.supervisor.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi-appliance.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
       # Pin the resolver so the supervisor's own bootstrap can't be broken by

--- a/charts/spatiumddi-appliance/values.yaml
+++ b/charts/spatiumddi-appliance/values.yaml
@@ -28,12 +28,64 @@ global:
   # operator override).
   extraEnv: []
 
+  # #983 — pod-level seccomp profile for every workload this chart renders.
+  # Kubernetes leaves a container ``Unconfined`` unless asked; docker-compose
+  # applies the runtime's default profile to every service, so the appliance
+  # was running the same images with FEWER syscall restrictions than a
+  # Compose install. ``RuntimeDefault`` under containerd is the same profile
+  # family Docker applies.
+  # ``RuntimeDefault`` | ``Unconfined`` | ``""`` (omit the block entirely).
+  seccompProfile: RuntimeDefault
+
+# #983 — PriorityClasses. Unlike the umbrella chart these default to ON and
+# the per-workload names below default to NON-empty, because this chart
+# renders the classes it names. Turning ``create`` off without also clearing
+# every ``priorityClassName`` below leaves pods naming a class that does not
+# exist — which the apiserver REJECTS, so those pods never schedule at all.
+#
+# Values sit far below Kubernetes' own ``system-cluster-critical``
+# (2000000000) / ``system-node-critical`` (2000001000) so k3s components
+# still outrank everything here.
+priorityClasses:
+  create: true
+  classes:
+    # Serving pods — BIND / PowerDNS / Technitium / Kea / the BGP collector.
+    # The LAN stops working without these, so they are the last thing the
+    # kubelet should evict and the first thing the scheduler should place.
+    service:
+      name: spatium-service
+      value: 100000
+      description: >-
+        SpatiumDDI serving workloads (DNS / DHCP / BGP collector). Evicted
+        last under node pressure; the LAN depends on them.
+    # Control plane — the API, workers, database, cache, supervisor. Losing
+    # these costs the operator the UI and the config path, which is bad but
+    # recoverable; losing DNS costs everyone on the network.
+    controlPlane:
+      name: spatium-control-plane
+      value: 90000
+      description: >-
+        SpatiumDDI control plane (api / worker / beat / frontend / postgres /
+        redis / supervisor). Ranked below the serving pods on purpose.
+    # Observability — metrics exporters. First to be evicted, and
+    # ``preemptionPolicy: Never`` so a pending exporter can never displace a
+    # running pod to get itself scheduled: monitoring must not cause the
+    # outage it would then report.
+    observability:
+      name: spatium-observability
+      value: 10000
+      preemptionPolicy: Never
+      description: >-
+        SpatiumDDI observability exporters (kube-state-metrics /
+        node-exporter). Evicted first; never preempts anything.
+
 # DNS — bind9 backend. Exactly one of dnsBind9 / dnsPowerdns /
 # dnsTechnitium runs per appliance; the supervisor enforces mutual-
 # exclusion at the CRD reconciler level so flipping more than one
 # ``enabled: true`` is a server-side validation error.
 dnsBind9:
   enabled: false
+  priorityClassName: spatium-service  # #983 — see ``priorityClasses`` above
   image:
     repository: ghcr.io/spatiumddi/dns-bind9
   # Scheduling weight for the serving pod. Requests only, no limits: a
@@ -93,6 +145,7 @@ dnsBind9:
 # DNS — PowerDNS backend. Same shape as dnsBind9.
 dnsPowerdns:
   enabled: false
+  priorityClassName: spatium-service  # #983 — see ``priorityClasses`` above
   image:
     repository: ghcr.io/spatiumddi/dns-powerdns
   # Scheduling weight for the serving pod — see dnsBind9.resources. The
@@ -129,6 +182,7 @@ dnsPowerdns:
 # Technitium needs no dnsdist-style sidecar the way PowerDNS does.
 dnsTechnitium:
   enabled: false
+  priorityClassName: spatium-service  # #983 — see ``priorityClasses`` above
   image:
     repository: ghcr.io/spatiumddi/dns-technitium
   # Scheduling weight for the serving pod — see dnsBind9.resources. The
@@ -168,6 +222,7 @@ dnsTechnitium:
 # ``network_mode: host`` docker-compose entry.
 dhcpKea:
   enabled: false
+  priorityClassName: spatium-service  # #983 — see ``priorityClasses`` above
   image:
     repository: ghcr.io/spatiumddi/dhcp-kea
   # Scheduling weight for the DHCP server pod — see dnsBind9.resources.
@@ -218,6 +273,7 @@ dhcpKea:
 # the collector daemon + the hard receive-only invariant.
 lookingGlass:
   enabled: false
+  priorityClassName: spatium-service  # #983 — see ``priorityClasses`` above
   image:
     repository: ghcr.io/spatiumddi/looking-glass
   # #965 — a floor, not a measurement. gobgpd holds real BGP sessions with
@@ -268,6 +324,10 @@ observer:
 # metrics at the standard endpoints; future Phase 8 work adds a
 # control-plane Prometheus scraper that federates across appliances.
 observability:
+  # #983 — PriorityClass for both exporters. ``spatium-observability``
+  # carries ``preemptionPolicy: Never``, so a pending exporter can never
+  # evict a running service pod to schedule itself.
+  priorityClassName: spatium-observability
   # kube-state-metrics exposes cluster-state metrics (pod count,
   # deployment status, restart counts, …) at /metrics. ~30 MB RSS.
   # Standard k8s observability primitive.
@@ -310,6 +370,7 @@ observability:
 # stable from the start.
 supervisor:
   enabled: false
+  priorityClassName: spatium-control-plane  # #983 — see ``priorityClasses`` above
   image:
     repository: ghcr.io/spatiumddi/spatium-supervisor
   # #965 — a floor, not a measurement. The supervisor is not a data-plane
@@ -362,6 +423,10 @@ supervisor:
 # mounts that dir read-only.
 agentLanding:
   enabled: true
+  # #983 — deliberately UNSET. The landing page is a courtesy redirect on
+  # an Application appliance; it must not outrank anything, and at priority
+  # 0 it is also the natural first eviction candidate.
+  priorityClassName: ""
   image:
     repository: nginx
     tag: 1.30.3-alpine
@@ -400,6 +465,17 @@ cnpg:
   # rendered consistently) back to ``cloudnative-pg`` so self-discovery
   # works. Do NOT remove without also de-aliasing the dependency.
   nameOverride: cloudnative-pg
+  # #983 — the operator is control-plane machinery: while it is gone,
+  # nothing reconciles Postgres failover, switchover or a replica rejoin.
+  # Ranking it alongside the rest of the control plane is the same argument
+  # #315 made for giving it resource requests — the upstream chart's
+  # defaults leave it the first casualty of node pressure, and the failure
+  # is silent until the next time Postgres needs it.
+  #
+  # Passed straight through to the vendored subchart's own
+  # ``priorityClassName`` value; the class itself is rendered by
+  # templates/priorityclasses.yaml in this chart.
+  priorityClassName: spatium-control-plane
   # #315 — pin the operator pod's resources + loosen its startup probe.
   #
   # The upstream chart ships ``resources: {}``, which makes the operator

--- a/charts/spatiumddi-metallb/Chart.yaml
+++ b/charts/spatiumddi-metallb/Chart.yaml
@@ -12,7 +12,15 @@ description: |
 type: application
 version: 0.1.0
 appVersion: "0.0.0-dev"
-kubeVersion: ">=1.27.0-0"
+# #983 — these charts only ever run on the k3s the appliance ISO bakes, which
+# is Kubernetes 1.36 as of #974. The floor is deliberately ONE MINOR BELOW
+# that rather than at it: during a rolling OS upgrade the cluster transiently
+# serves a mix of 1.35 and 1.36 apiservers, and helm validates kubeVersion
+# against whichever apiserver it reaches. A floor of 1.36 would turn an
+# ordinary role toggle made mid-upgrade — the supervisor patches this chart's
+# values on every role change — into a failed release, for no gain: nothing
+# in either chart uses API surface newer than 1.35.
+kubeVersion: ">=1.35.0-0"
 home: https://www.spatiumddi.com/
 sources:
   - https://github.com/spatiumddi/spatiumddi

--- a/charts/spatiumddi-metallb/values.yaml
+++ b/charts/spatiumddi-metallb/values.yaml
@@ -22,6 +22,14 @@
 # once #3063 is fixed upstream. KEEP the image tags below in lock-step
 # with the chart version + appliance/scripts/bake-images.sh
 # ``METALLB_IMAGES``.
+# POD POSTURE (#983) — the ``priorityClassName`` values below name classes
+# rendered by a DIFFERENT release (spatium-bootstrap, the spatiumddi-appliance
+# chart), which normally needs care: the apiserver REFUSES a pod naming a
+# PriorityClass that does not exist. It is safe here specifically because
+# MetalLB ships disabled and is only ever enabled by the supervisor when an
+# operator sets a VIP — and the supervisor itself comes from that same
+# bootstrap release. If bootstrap never succeeded there is nothing to turn
+# MetalLB on, so there are no speaker/controller pods to refuse.
 metallb:
   enabled: false
 
@@ -51,12 +59,56 @@ metallb:
     # control-plane nodes via the per-role label (CLAUDE.md non-neg #16).
     nodeSelector:
       spatium.io/role-control-plane: "true"
+    # #983 — the speaker is ON THE DATA PATH. It answers ARP/NDP for the
+    # control-plane VIP and, with ``dns.useMetalLBVIP=true``, for the DNS
+    # VIP too — so evicting it takes out the address that dns-bind9's
+    # ``spatium-service`` ranking exists to protect. Leaving it at priority
+    # 0 while everything around it moved to 90000/100000 would have made
+    # the ARP responder the FIRST thing the kubelet reclaims under memory
+    # pressure. Same class as the DNS/DHCP pods, for the same reason.
+    priorityClassName: spatium-service
+    # #965 — requests only, a floor rather than a measurement. Upstream
+    # ships ``resources: {}``, which is BestEffort: cgroup cpu.weight 1 and
+    # first in the OOM queue, on the pod that owns the VIP.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+    # #983 — upstream leaves the speaker's pod securityContext empty (it
+    # needs to run as root for raw ARP/NDP), so nothing asked for a seccomp
+    # profile and the container ran ``Unconfined``. ``RuntimeDefault`` under
+    # containerd permits ``socket(AF_PACKET, …)`` for a container holding
+    # CAP_NET_RAW, which the speaker does — the capability, not the profile,
+    # is what gates the raw socket.
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
   controller:
     image:
       repository: quay.io/metallb/controller
       tag: v0.15.3  # lock-step with the 0.15.3 chart — metallb#3063 (header note)
     nodeSelector:
       spatium.io/role-control-plane: "true"
+    # #983 — the controller allocates IPs from the pool; it is not on the
+    # packet path, so it ranks with the rest of the control plane rather
+    # than with the speaker.
+    priorityClassName: spatium-control-plane
+    # #965 — see the speaker's note.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+    # #983 — MUST repeat upstream's three keys: the chart renders this map
+    # wholesale (``toYaml .Values.controller.securityContext``), so a
+    # values override REPLACES it rather than merging, and dropping
+    # runAsNonRoot / runAsUser / fsGroup here would silently put the
+    # controller back to running as root.
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 65534    # nobody
+      fsGroup: 65534
+      seccompProfile:
+        type: RuntimeDefault
 
   # ── L2 IP pool ────────────────────────────────────────────────────
   # ``ipPool.addresses`` is the L2 range MetalLB hands out. The operator
@@ -153,6 +205,43 @@ metallb:
       # above (non-negotiable #16) — BGP is a control-plane concern.
       nodeSelector:
         spatium.io/role-control-plane: "true"
+      # #983 — in BGP mode frr-k8s IS the data path: the speaker delegates
+      # advertisement to it, so an evicted frr-k8s withdraws the VIP's route
+      # exactly as an evicted speaker stops answering ARP in L2 mode. Same
+      # class as the speaker for the same reason. One key covers both the
+      # DaemonSet and the status-cleaner Deployment (the chart reads
+      # ``.Values.frrk8s.priorityClassName`` in both templates).
+      priorityClassName: spatium-service
+      # #965 — floors, not measurements. Upstream ships ``resources: {}`` for
+      # all five containers, i.e. a five-container BestEffort pod holding the
+      # BGP session. ``frrk8s.resources`` covers the controller container AND
+      # the status-cleaner Deployment; the other four are per-container keys.
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+      reloader:
+        resources:
+          requests:
+            cpu: 5m
+            memory: 32Mi
+      frrMetrics:
+        resources:
+          requests:
+            cpu: 5m
+            memory: 32Mi
+      frrStatus:
+        resources:
+          requests:
+            cpu: 5m
+            memory: 32Mi
+      # #983 — NO seccomp profile here, and it is not an oversight: the
+      # frr-k8s 0.0.21 chart exposes no pod-securityContext knob at all
+      # (grep its templates — ``.Values.frrk8s.*`` covers image, nodeSelector,
+      # resources and priorityClassName, nothing else), so no values override
+      # can supply one. The render check therefore exempts these two
+      # workloads by name rather than skipping the chart, which is how they
+      # went unnoticed until #983. Revisit on a chart bump.
       # Explicit image tags, locked to what the vendored 0.15.3 metallb
       # package's frr-k8s@0.0.21 subchart defaults to (verified by
       # inspecting charts/frr-k8s/values.yaml + Chart.yaml inside the
@@ -167,6 +256,11 @@ metallb:
         image:
           repository: quay.io/frrouting/frr
           tag: 10.4.1
+        # #965 — the FRR daemon itself; see the resources note above.
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
 
 # Cross-namespace pod-read for the control-plane api SA so the
 # Network & Host MetalLB status card works now that MetalLB is in

--- a/charts/spatiumddi/Chart.yaml
+++ b/charts/spatiumddi/Chart.yaml
@@ -7,7 +7,14 @@ type: application
 # --app-version` using the CalVer release tag.
 version: 0.1.0
 appVersion: "0.0.0-dev"
-kubeVersion: ">=1.26.0-0"
+# #983 — 1.26 was a claim, not a tested floor: nobody has run this chart on
+# it. The oldest behaviour the charts actually depend on is the >= 1.31
+# EndpointSlice loopback validation the appliance's k3s config comments
+# describe, so that is the floor. Raise it when a template starts using an
+# API only a later version serves — not speculatively, because the check is
+# enforced by the apiserver's reported version and a floor above what an
+# operator runs refuses the install outright.
+kubeVersion: ">=1.31.0-0"
 home: https://www.spatiumddi.com/
 sources:
   - https://github.com/spatiumddi

--- a/charts/spatiumddi/README.md
+++ b/charts/spatiumddi/README.md
@@ -202,7 +202,7 @@ dhcpAgents:
 | `global.seccompProfile` | `RuntimeDefault` | Pod-level seccomp for every workload. `Unconfined` or `""` (omit) also accepted; `Localhost` is rejected |
 | `global.priorityClassName` | `""` | PriorityClass for the control-plane workloads. **Leave empty unless the class exists** — the apiserver refuses a pod naming one that does not |
 | `global.servicePriorityClassName` | `""` | Same, for the DNS / DHCP agent StatefulSets |
-| `<component>.priorityClassName` | `""` | Per-workload override of the two keys above |
+| `<component>.priorityClassName` | unset | Per-workload override. Unset inherits the chart-wide key above; `""` means *no class for this workload*, even when the chart-wide key is set |
 
 ### Control plane
 

--- a/charts/spatiumddi/README.md
+++ b/charts/spatiumddi/README.md
@@ -24,7 +24,7 @@ Default login: **`admin` / `admin`** (forced password change on first login).
 
 ## Prerequisites
 
-- Kubernetes 1.26+
+- Kubernetes 1.31+
 - Helm 3.8+ (needed for OCI)
 - A StorageClass supporting `ReadWriteOnce` (Postgres, Redis, and
   agent state all use PVCs)
@@ -198,6 +198,11 @@ dhcpAgents:
 | `auth.existingSecret` | `""` | BYO secret with key `secret-key` |
 | `fullnameOverride` | `""` |  |
 | `nameOverride` | `""` |  |
+| `global.controlPlaneNodeSelector` | `{}` | Merged into every control-plane workload's `nodeSelector` |
+| `global.seccompProfile` | `RuntimeDefault` | Pod-level seccomp for every workload. `Unconfined` or `""` (omit) also accepted; `Localhost` is rejected |
+| `global.priorityClassName` | `""` | PriorityClass for the control-plane workloads. **Leave empty unless the class exists** — the apiserver refuses a pod naming one that does not |
+| `global.servicePriorityClassName` | `""` | Same, for the DNS / DHCP agent StatefulSets |
+| `<component>.priorityClassName` | `""` | Per-workload override of the two keys above |
 
 ### Control plane
 

--- a/charts/spatiumddi/templates/_helpers.tpl
+++ b/charts/spatiumddi/templates/_helpers.tpl
@@ -568,7 +568,20 @@ renders.
 
 Args: ``component`` (the per-workload override) and ``fallback`` (the
 chart-wide default). Returns the resolved name, or nothing.
+
+UNSET and EMPTY are different, deliberately: a per-workload key left unset
+(the shipped default, YAML null) INHERITS the chart-wide value, while
+setting it to ``""`` means "no class for this one" and overrides a
+non-empty chart-wide value. Sprig's ``default`` cannot express that — it
+treats null and "" alike — so the nil test is explicit. Without it
+``priorityClassName: ""`` would silently inherit, which is the opposite of
+what a key documented as an override should do, and there would be no way
+to leave a single workload unranked on a cluster that has a global policy.
 */}}
 {{- define "spatiumddi.priorityClassName" -}}
-{{- default (default "" .fallback) .component -}}
+{{- if kindIs "invalid" .component -}}
+{{- default "" .fallback -}}
+{{- else -}}
+{{- .component -}}
+{{- end -}}
 {{- end -}}

--- a/charts/spatiumddi/templates/_helpers.tpl
+++ b/charts/spatiumddi/templates/_helpers.tpl
@@ -510,3 +510,65 @@ URL comes from commonEnv.
   env:
     {{- include "spatiumddi.commonEnv" . | nindent 4 }}
 {{- end -}}
+
+{{/*
+#983 — the pod-level seccomp profile applied to every workload this chart
+renders.
+
+Kubernetes runs a container ``Unconfined`` unless a profile is asked for,
+while docker-compose applies the runtime's default profile to every
+service. So without this the SAME container images run with FEWER syscall
+restrictions under Kubernetes than under Compose — a regression, not a
+gap. ``RuntimeDefault`` under containerd is the same profile family
+Compose gets from Docker, which is also why it is low-risk: the raw
+sockets Kea needs, the api's pcap capture (#59) and nmap (#58) all
+already run under it on a Compose install.
+
+Returns the bare type string (or nothing when disabled) so a caller can
+place it inside an existing ``securityContext:`` block or open its own:
+
+    {{- with (include "spatiumddi.seccompProfileType" .) }}
+    securityContext:
+      seccompProfile:
+        type: {{ . }}
+    {{- end }}
+
+``Localhost`` is rejected rather than passed through: it needs a
+``localhostProfile`` path relative to the kubelet's seccomp root, which
+this chart has no way to place on the node. Set the value to ``""`` to
+omit the block entirely (an exotic runtime whose default profile breaks a
+workload) — that restores the pre-#983 behaviour, it does not harden
+anything.
+*/}}
+{{- define "spatiumddi.seccompProfileType" -}}
+{{- $t := default "" (.Values.global).seccompProfile -}}
+{{- if and $t (not (has $t (list "RuntimeDefault" "Unconfined"))) -}}
+{{- fail (printf "global.seccompProfile must be \"RuntimeDefault\", \"Unconfined\" or \"\" — got %q. Localhost profiles need a localhostProfile path this chart cannot place on the node." $t) -}}
+{{- end -}}
+{{- $t -}}
+{{- end -}}
+
+{{/*
+#983 — resolve a workload's PriorityClass name.
+
+Every pod this chart renders is Burstable at priority 0 by default, which
+makes them indistinguishable to two schedulers' worth of ranking:
+kubelet eviction under memory / ephemeral-storage pressure orders victims
+by priority THEN usage-over-request, and scheduler preemption gives a
+pending pod no claim on a full node. With every priority equal, the
+likeliest eviction victim is whichever pod grew the most — on an
+appliance, BIND with a warm cache.
+
+Defaults to empty: a bring-your-own cluster has its own priority policy,
+and naming a PriorityClass that does not exist makes the apiserver
+REJECT the pod outright, so this must never be set speculatively. The
+appliance overlay (spatiumddi-firstboot's spatium-control valuesContent)
+sets ``global.priorityClassName`` to the class the appliance chart
+renders.
+
+Args: ``component`` (the per-workload override) and ``fallback`` (the
+chart-wide default). Returns the resolved name, or nothing.
+*/}}
+{{- define "spatiumddi.priorityClassName" -}}
+{{- default (default "" .fallback) .component -}}
+{{- end -}}

--- a/charts/spatiumddi/templates/api.yaml
+++ b/charts/spatiumddi/templates/api.yaml
@@ -21,6 +21,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with (include "spatiumddi.priorityClassName" (dict "component" .Values.api.priorityClassName "fallback" (.Values.global).priorityClassName)) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       terminationGracePeriodSeconds: 30
       {{- if .Values.api.serviceAccount.enabled }}
       # Phase 11 wave 4 (#183) — the api uses kubeapi for two things

--- a/charts/spatiumddi/templates/beat.yaml
+++ b/charts/spatiumddi/templates/beat.yaml
@@ -50,6 +50,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with (include "spatiumddi.priorityClassName" (dict "component" .Values.beat.priorityClassName "fallback" (.Values.global).priorityClassName)) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/spatiumddi/templates/cnpg-cluster.yaml
+++ b/charts/spatiumddi/templates/cnpg-cluster.yaml
@@ -68,6 +68,26 @@ spec:
   instances: {{ .Values.postgresql.cnpg.instances }}
   imageName: {{ .Values.postgresql.cnpg.imageName | quote }}
 
+  {{- with (include "spatiumddi.priorityClassName" (dict "component" .Values.postgresql.priorityClassName "fallback" (.Values.global).priorityClassName)) }}
+  # #983 — CNPG passes this straight through to the instance pods.
+  priorityClassName: {{ . | quote }}
+  {{- end }}
+  {{- with (include "spatiumddi.seccompProfileType" $) }}
+  # #983 — CNPG owns the instance pods' securityContext, so the chart-wide
+  # knob has to be handed to the operator rather than set on a pod template.
+  # The CRD already defaults this field to ``RuntimeDefault``; setting it
+  # explicitly is what makes ``global.seccompProfile: Unconfined`` mean the
+  # same thing here as everywhere else.
+  seccompProfile:
+    type: {{ . }}
+  {{- end }}
+  # NOTE both fields above only reach a cluster on FIRST CREATE. The
+  # ``helm.sh/resource-policy: keep`` annotation stops Helm patching this CR
+  # on upgrade, so an appliance installed before #983 keeps whatever the
+  # operator defaulted to until the Cluster is recreated. That is the
+  # accepted trade — the annotation exists because a Helm-driven delete of
+  # this CR destroys the database, which is far worse than an unranked pod.
+
   # #296 Phase A — PDB on by default (set in values.yaml). Suspended
   # during a rolling-upgrade node's maintenance window — the api-side
   # orchestrator stamps + clears

--- a/charts/spatiumddi/templates/dhcp-agent.yaml
+++ b/charts/spatiumddi/templates/dhcp-agent.yaml
@@ -42,6 +42,14 @@ spec:
         app.kubernetes.io/instance-name: {{ $server.name | quote }}
         spatiumddi.org/dhcp-flavor: {{ $flavor }}
     spec:
+      {{- with (include "spatiumddi.priorityClassName" (dict "component" $root.Values.dhcpAgents.priorityClassName "fallback" ($root.Values.global).servicePriorityClassName)) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       {{- if $server.hostNetwork }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/spatiumddi/templates/dns-agent.yaml
+++ b/charts/spatiumddi/templates/dns-agent.yaml
@@ -65,6 +65,14 @@ spec:
         app.kubernetes.io/instance-name: {{ $server.name | quote }}
         spatiumddi.org/dns-flavor: {{ $flavor }}
     spec:
+      {{- with (include "spatiumddi.priorityClassName" (dict "component" $root.Values.dnsAgents.priorityClassName "fallback" ($root.Values.global).servicePriorityClassName)) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/spatiumddi/templates/frontend.yaml
+++ b/charts/spatiumddi/templates/frontend.yaml
@@ -44,6 +44,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with (include "spatiumddi.priorityClassName" (dict "component" .Values.frontend.priorityClassName "fallback" (.Values.global).priorityClassName)) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/spatiumddi/templates/migrate-job.yaml
+++ b/charts/spatiumddi/templates/migrate-job.yaml
@@ -32,6 +32,14 @@ spec:
       labels:
         {{- include "spatiumddi.componentSelectorLabels" (merge (dict "component" "migrate") .) | nindent 8 }}
     spec:
+      {{- with (include "spatiumddi.priorityClassName" (dict "component" .Values.migrate.priorityClassName "fallback" (.Values.global).priorityClassName)) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       restartPolicy: OnFailure
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/spatiumddi/templates/postgres.yaml
+++ b/charts/spatiumddi/templates/postgres.yaml
@@ -33,8 +33,15 @@ spec:
       labels:
         {{- include "spatiumddi.componentSelectorLabels" (merge (dict "component" $cmp) .) | nindent 8 }}
     spec:
+      {{- with (include "spatiumddi.priorityClassName" (dict "component" .Values.postgresql.priorityClassName "fallback" (.Values.global).priorityClassName)) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       terminationGracePeriodSeconds: 30
       securityContext:
+        {{- with (include "spatiumddi.seccompProfileType" $) }}
+        seccompProfile:
+          type: {{ . }}
+        {{- end }}
         # Match the postgres image's UID — the Alpine ``postgres`` user
         # runs as 70:70. fsGroup makes the mounted PVC writable.
         fsGroup: 70

--- a/charts/spatiumddi/templates/redis-sentinel.yaml
+++ b/charts/spatiumddi/templates/redis-sentinel.yaml
@@ -122,8 +122,15 @@ spec:
       labels:
         {{- include "spatiumddi.componentSelectorLabels" (merge (dict "component" $cmp) .) | nindent 8 }}
     spec:
+      {{- with (include "spatiumddi.priorityClassName" (dict "component" .Values.redis.priorityClassName "fallback" (.Values.global).priorityClassName)) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       terminationGracePeriodSeconds: 30
       securityContext:
+        {{- with (include "spatiumddi.seccompProfileType" $) }}
+        seccompProfile:
+          type: {{ . }}
+        {{- end }}
         fsGroup: 999
       initContainers:
         # Render redis.conf + sentinel.conf from the ConfigMap

--- a/charts/spatiumddi/templates/redis.yaml
+++ b/charts/spatiumddi/templates/redis.yaml
@@ -30,8 +30,15 @@ spec:
       labels:
         {{- include "spatiumddi.componentSelectorLabels" (merge (dict "component" $cmp) .) | nindent 8 }}
     spec:
+      {{- with (include "spatiumddi.priorityClassName" (dict "component" .Values.redis.priorityClassName "fallback" (.Values.global).priorityClassName)) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       terminationGracePeriodSeconds: 30
       securityContext:
+        {{- with (include "spatiumddi.seccompProfileType" $) }}
+        seccompProfile:
+          type: {{ . }}
+        {{- end }}
         # Redis Alpine image runs as 999:999 by default.
         fsGroup: 999
       containers:

--- a/charts/spatiumddi/templates/slot-image-mirror.yaml
+++ b/charts/spatiumddi/templates/slot-image-mirror.yaml
@@ -123,6 +123,14 @@ spec:
       labels:
         {{- include "spatiumddi.componentSelectorLabels" (merge (dict "component" $cmp) .) | nindent 8 }}
     spec:
+      {{- with (include "spatiumddi.priorityClassName" (dict "component" .Values.slotImageMirror.priorityClassName "fallback" (.Values.global).priorityClassName)) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       terminationGracePeriodSeconds: 30
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/spatiumddi/templates/worker.yaml
+++ b/charts/spatiumddi/templates/worker.yaml
@@ -21,6 +21,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with (include "spatiumddi.priorityClassName" (dict "component" .Values.worker.priorityClassName "fallback" (.Values.global).priorityClassName)) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with (include "spatiumddi.seccompProfileType" $) }}
+      securityContext:
+        seccompProfile:
+          type: {{ . }}
+      {{- end }}
       terminationGracePeriodSeconds: 60
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -38,6 +38,31 @@ global:
   # phases) configures the gate from the umbrella valuesContent.
   controlPlaneNodeSelector: {}
 
+  # #983 — pod-level seccomp profile for every workload this chart renders.
+  # Kubernetes leaves a container ``Unconfined`` unless asked; docker-compose
+  # applies the runtime's default profile to every service. So the default
+  # here restores parity — without it the same images run with FEWER syscall
+  # restrictions under Kubernetes than under Compose.
+  # ``RuntimeDefault`` | ``Unconfined`` | ``""`` (omit the block entirely).
+  seccompProfile: RuntimeDefault
+
+  # #983 — PriorityClass applied to every CONTROL-PLANE workload (api,
+  # worker, beat, frontend, migrate, postgres, redis, sentinel, the slot-image
+  # mirror). Per-workload ``<component>.priorityClassName`` overrides it.
+  #
+  # Empty by default and it must stay that way for a bring-your-own cluster:
+  # the apiserver REJECTS a pod naming a PriorityClass that does not exist, so
+  # setting this without creating the class first takes the whole release
+  # down. The appliance overlay sets it to ``spatium-control-plane``, which
+  # the spatiumddi-appliance chart renders.
+  priorityClassName: ""
+
+  # #983 — same, for the SERVICE workloads (the optional DNS / DHCP agent
+  # StatefulSets). Split from the control-plane knob because a DNS agent
+  # answering the LAN should outrank the API that configures it when a node
+  # runs out of memory.
+  servicePriorityClassName: ""
+
 # Cluster-wide app name override. Leave empty to use `.Release.Name`.
 fullnameOverride: ""
 nameOverride: ""
@@ -53,6 +78,7 @@ auth:
 # ── API ──────────────────────────────────────────────────────────────────────
 api:
   replicas: 2
+  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
   service:
     type: ClusterIP
     port: 8000
@@ -209,6 +235,7 @@ api:
 # BYO-Kubernetes installs, where nothing tracks the replica count for you.
 slotImageMirror:
   enabled: false
+  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
   storage:
     # 32 GiB default — fits ~7-8 typical slot images (4 GiB cap each,
     # but real images today are ~800 MiB-1.2 GiB compressed). Bump
@@ -241,6 +268,7 @@ slotImageMirror:
 # ── Frontend (nginx + Vite build) ────────────────────────────────────────────
 frontend:
   replicas: 2
+  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
   service:
     type: ClusterIP
     port: 80
@@ -326,6 +354,7 @@ frontend:
 # ── Worker (Celery queues: ipam, dns, dhcp, default) ─────────────────────────
 worker:
   replicas: 2
+  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
   concurrency: 4
   queues: "ipam,dns,dhcp,default"
   resources:
@@ -348,6 +377,7 @@ worker:
 
 # ── Beat (singleton scheduler — always 1 replica) ────────────────────────────
 beat:
+  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
   resources:
     requests: { cpu: 50m, memory: 128Mi }
     limits:   { cpu: 200m, memory: 256Mi }
@@ -369,6 +399,7 @@ beat:
 # migrations from CI/CD instead of Helm.
 migrate:
   enabled: true
+  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
   backoffLimit: 3
   # Garbage-collect each migrate Job this many seconds after completion.
   # Without a TTL the cluster would slowly accumulate one completed Job
@@ -420,6 +451,7 @@ ingress:
 # and fill in the ``externalDatabase`` block below.
 postgresql:
   enabled: true
+  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
   kind: standalone
   image:
     repository: postgres
@@ -556,6 +588,7 @@ externalDatabase:
 # fill in ``externalRedis``.
 redis:
   enabled: true
+  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
   kind: standalone
   image:
     repository: redis
@@ -648,6 +681,7 @@ externalRedis:
 # closer to the network edge.
 dnsAgents:
   enabled: false
+  priorityClassName: ""  # #983 — overrides ``global.servicePriorityClassName``
   # Default image — used when a server entry doesn't override.
   # Configures the BIND9 driver (the historical default flavor).
   image:
@@ -704,6 +738,7 @@ dnsAgents:
 # ── DHCP agents (optional — managed Kea StatefulSets) ────────────────────────
 dhcpAgents:
   enabled: false
+  priorityClassName: ""  # #983 — overrides ``global.servicePriorityClassName``
   image:
     repository: ghcr.io/spatiumddi/dhcp-kea
     tag: ""

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -78,7 +78,7 @@ auth:
 # ── API ──────────────────────────────────────────────────────────────────────
 api:
   replicas: 2
-  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
+  priorityClassName:  # #983 — unset inherits ``global.priorityClassName``; "" means no class
   service:
     type: ClusterIP
     port: 8000
@@ -235,7 +235,7 @@ api:
 # BYO-Kubernetes installs, where nothing tracks the replica count for you.
 slotImageMirror:
   enabled: false
-  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
+  priorityClassName:  # #983 — unset inherits ``global.priorityClassName``; "" means no class
   storage:
     # 32 GiB default — fits ~7-8 typical slot images (4 GiB cap each,
     # but real images today are ~800 MiB-1.2 GiB compressed). Bump
@@ -268,7 +268,7 @@ slotImageMirror:
 # ── Frontend (nginx + Vite build) ────────────────────────────────────────────
 frontend:
   replicas: 2
-  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
+  priorityClassName:  # #983 — unset inherits ``global.priorityClassName``; "" means no class
   service:
     type: ClusterIP
     port: 80
@@ -354,7 +354,7 @@ frontend:
 # ── Worker (Celery queues: ipam, dns, dhcp, default) ─────────────────────────
 worker:
   replicas: 2
-  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
+  priorityClassName:  # #983 — unset inherits ``global.priorityClassName``; "" means no class
   concurrency: 4
   queues: "ipam,dns,dhcp,default"
   resources:
@@ -377,7 +377,7 @@ worker:
 
 # ── Beat (singleton scheduler — always 1 replica) ────────────────────────────
 beat:
-  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
+  priorityClassName:  # #983 — unset inherits ``global.priorityClassName``; "" means no class
   resources:
     requests: { cpu: 50m, memory: 128Mi }
     limits:   { cpu: 200m, memory: 256Mi }
@@ -399,7 +399,7 @@ beat:
 # migrations from CI/CD instead of Helm.
 migrate:
   enabled: true
-  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
+  priorityClassName:  # #983 — unset inherits ``global.priorityClassName``; "" means no class
   backoffLimit: 3
   # Garbage-collect each migrate Job this many seconds after completion.
   # Without a TTL the cluster would slowly accumulate one completed Job
@@ -451,7 +451,7 @@ ingress:
 # and fill in the ``externalDatabase`` block below.
 postgresql:
   enabled: true
-  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
+  priorityClassName:  # #983 — unset inherits ``global.priorityClassName``; "" means no class
   kind: standalone
   image:
     repository: postgres
@@ -588,7 +588,7 @@ externalDatabase:
 # fill in ``externalRedis``.
 redis:
   enabled: true
-  priorityClassName: ""  # #983 — overrides ``global.priorityClassName``
+  priorityClassName:  # #983 — unset inherits ``global.priorityClassName``; "" means no class
   kind: standalone
   image:
     repository: redis
@@ -681,7 +681,7 @@ externalRedis:
 # closer to the network edge.
 dnsAgents:
   enabled: false
-  priorityClassName: ""  # #983 — overrides ``global.servicePriorityClassName``
+  priorityClassName:  # #983 — unset inherits ``global.servicePriorityClassName``; "" means no class
   # Default image — used when a server entry doesn't override.
   # Configures the BIND9 driver (the historical default flavor).
   image:
@@ -738,7 +738,7 @@ dnsAgents:
 # ── DHCP agents (optional — managed Kea StatefulSets) ────────────────────────
 dhcpAgents:
   enabled: false
-  priorityClassName: ""  # #983 — overrides ``global.servicePriorityClassName``
+  priorityClassName:  # #983 — unset inherits ``global.servicePriorityClassName``; "" means no class
   image:
     repository: ghcr.io/spatiumddi/dhcp-kea
     tag: ""

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -362,6 +362,131 @@ and runtime/airgap pulls need a persistent home.
 
 ---
 
+## Kubernetes posture (#983)
+
+What the appliance's k3s asks for beyond the defaults, and why. Each of
+these is a chart or config setting, not a runtime feature — an operator can
+read the whole posture out of `charts/spatiumddi-appliance/values.yaml` and
+`/etc/rancher/k3s/config.yaml`.
+
+### PriorityClasses
+
+Three cluster-scoped classes, rendered by
+`charts/spatiumddi-appliance/templates/priorityclasses.yaml`:
+
+| Class | Value | Applied to |
+|---|---|---|
+| `spatium-service` | 100000 | `dns-bind9`, `dns-powerdns`, `dns-technitium`, `dhcp-kea`, `looking-glass` |
+| `spatium-control-plane` | 90000 | `api`, `worker`, `beat`, `frontend`, Postgres / CNPG (operator + instances), `redis`, `redis-sentinel`, `supervisor` |
+| `spatium-observability` | 10000 | `kube-state-metrics`, `node-exporter` — plus `preemptionPolicy: Never` |
+
+Before this every pod ran at priority 0, which is not a neutral state: it
+is a *tie*, and the two rankings that break it both do the wrong thing with
+a tie. Kubelet eviction under memory or ephemeral-storage pressure orders
+victims by priority first and usage-over-request second, so with every
+priority equal the pod evicted is whichever grew the most — on this box,
+BIND with a warm cache. Scheduler preemption has the mirror-image gap: a
+role DaemonSet landing on a freshly joined node has no claim over
+kube-state-metrics if the node is already full.
+
+`preemptionPolicy: Never` on the observability class is the one piece that
+is not just ordering: a pending exporter can never evict a running pod to
+schedule itself. Monitoring must not cause the outage it would then report.
+
+All three sit far below Kubernetes' own `system-cluster-critical`
+(2000000000) and `system-node-critical` (2000001000), so k3s's components
+still outrank everything here, and none of them is `globalDefault` — a
+global default would silently re-rank every pod in the cluster, including
+anything an operator joined to it themselves.
+
+`agent-landing` is deliberately left at priority 0: it is a courtesy
+redirect page on an Application appliance, it must not outrank anything,
+and at 0 it is also the natural first eviction candidate. That decision is
+recorded in the CI gate (`--allow-no-priority agent-landing`) rather than
+left implicit.
+
+**Failure mode worth knowing.** A pod naming a PriorityClass that does not
+exist is refused by the apiserver: the Deployment is *accepted* and the
+ReplicaSet controller then cannot create pods, reporting it as an event.
+Running pods are untouched, and the whole thing self-heals the moment the
+class appears. That is why `spatiumddi-firstboot` emits
+`global.priorityClassName` into the `spatium-control` values only when the
+appliance chart — which renders the classes — is also going into the
+auto-deploy dir, and why the bootstrap manifest is written before the
+control manifest is released from `.deferred`.
+
+### seccomp
+
+Every pod in both charts carries `securityContext.seccompProfile.type:
+RuntimeDefault` (`global.seccompProfile`, settable to `Unconfined` or `""`
+for an exotic runtime).
+
+This closes a regression rather than adding hardening: docker-compose
+applies the runtime's default seccomp profile to every service, while
+Kubernetes runs a container `Unconfined` unless a profile is asked for. So
+until #983 the appliance ran the *same container images* with fewer syscall
+restrictions than a Compose install. `RuntimeDefault` under containerd is
+the same profile family Docker applies, which is also why the risk is low —
+Kea's raw sockets, the api's pcap capture (#59) and nmap (#58) all already
+run under it on Compose.
+
+Kubernetes 1.36 adds an alpha `SeccompDefault` kubelet gate that would do
+this cluster-wide; it is alpha, so the charts do it instead.
+
+One exception is worth knowing rather than discovering: the **supervisor**
+runs `privileged: true`, and containerd skips seccomp entirely for a
+privileged container. The field is set on that pod like every other, and the
+runtime ignores it. That is not a gap this change could close — a privileged
+container is unconfined by definition — it just means the supervisor's
+posture rests on the pod being privileged for a reason (host mounts,
+`hostPID`, driving the node's own lifecycle), not on the profile.
+
+### Pod Security Admission
+
+The `spatium` namespace carries `pod-security.kubernetes.io/warn: baseline`
+and `.../audit: baseline`, written by `spatiumddi-firstboot`'s namespace
+render (the chart deliberately does not own the namespace — see
+`spatiumddi-helm-stuck-recover`).
+
+`enforce` is absent and cannot be added. The role DaemonSets bind :53 / :67
+on the host, the supervisor runs `hostPID` with host mounts, and the
+frontend takes :80 / :443 on the node — every one of those violates
+`baseline` by design, so enforcing would reject the appliance's reason for
+existing. Expect standing warnings from `dns-*`, `dhcp-kea`,
+`looking-glass`, `node-exporter`, `supervisor` and `frontend`; a warning
+from **anything else** is the signal. Audit annotations land in
+`/var/log/spatiumddi/k3s-audit.log`, the apiserver audit log the appliance
+already writes.
+
+Neither label can reject a pod, so both are safe to carry on a running
+cluster. The namespace manifest is re-rendered on every boot, so this
+reaches appliances installed before #983 as soon as they boot the slot
+carrying it — no host patch needed.
+
+### Version floors
+
+`charts/spatiumddi` declares `kubeVersion: ">=1.31.0-0"`; the appliance and
+MetalLB charts declare `">=1.35.0-0"`. The appliance floor is deliberately
+one minor *below* the k3s the ISO bakes: during a rolling OS upgrade the
+cluster transiently serves a mix of 1.35 and 1.36 apiservers, helm
+validates `kubeVersion` against whichever it reaches, and a floor at 1.36
+would turn an ordinary mid-upgrade role toggle into a failed release.
+
+### What is deliberately not set
+
+`disable-network-policy: true` stays on. The old rationale ("single node,
+no need") stopped being true with #272; the setting holds for different
+reasons — nothing in either chart renders a NetworkPolicy, so the
+controller would reconcile an empty set, and it is another always-resident
+daemon on a node whose floor is 4 GiB.
+
+User namespaces (`hostUsers: false`), fine-grained kubelet API
+authorization (`nodes/stats` in place of `nodes/proxy`), PSI metrics and
+`topologySpreadConstraints` are all Phase 2 of #983 — after the 1.36 ISO
+has soaked on a real 3-node cluster.
+
+---
+
 ## Fleet firewall — declarative per-role policy (#285)
 
 The per-role `spatium-role.nft` renderer (above) grew into a first-class

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -380,6 +380,19 @@ Three cluster-scoped classes, rendered by
 | `spatium-control-plane` | 90000 | `api`, `worker`, `beat`, `frontend`, Postgres / CNPG (operator + instances), `redis`, `redis-sentinel`, `supervisor` |
 | `spatium-observability` | 10000 | `kube-state-metrics`, `node-exporter` — plus `preemptionPolicy: Never` |
 
+MetalLB rides the same classes from `charts/spatiumddi-metallb`: the
+**speaker** takes `spatium-service` because it is on the data path — it
+answers ARP/NDP for the control-plane VIP and, with
+`dns.useMetalLBVIP=true`, for the DNS VIP, so evicting it takes out the
+address `dns-bind9`'s own ranking exists to protect. The **controller**
+allocates from the pool and is not on the packet path, so it ranks with the
+control plane. In BGP mode (#566 D1) **frr-k8s** takes `spatium-service` for
+the same reason the speaker does. Naming classes from another release is
+safe here for a specific reason: MetalLB ships disabled and is only ever
+enabled by the supervisor when an operator sets a VIP — and the supervisor
+comes from the same `spatium-bootstrap` release that renders the classes, so
+if that release never succeeded there is nothing to turn MetalLB on.
+
 Before this every pod ran at priority 0, which is not a neutral state: it
 is a *tie*, and the two rankings that break it both do the wrong thing with
 a tie. Kubelet eviction under memory or ephemeral-storage pressure orders
@@ -408,12 +421,26 @@ left implicit.
 **Failure mode worth knowing.** A pod naming a PriorityClass that does not
 exist is refused by the apiserver: the Deployment is *accepted* and the
 ReplicaSet controller then cannot create pods, reporting it as an event.
-Running pods are untouched, and the whole thing self-heals the moment the
-class appears. That is why `spatiumddi-firstboot` emits
-`global.priorityClassName` into the `spatium-control` values only when the
-appliance chart — which renders the classes — is also going into the
-auto-deploy dir, and why the bootstrap manifest is written before the
-control manifest is released from `.deferred`.
+Running pods are untouched, and it self-heals the moment the class appears.
+
+The control-plane workloads are the exposed case, because their class comes
+from a *different* release (`spatium-bootstrap`) than the one that names it
+(`spatium-control`). `spatiumddi-firstboot` therefore gates it twice:
+
+1. **At render**, on the appliance chart's tarball being present at all — if
+   it is not, nothing will ever render the class.
+2. **At release**, in `release_control_manifest`, by asking the live cluster
+   whether `spatium-control-plane` exists. A missing class — or an apiserver
+   it cannot reach to ask — strips the reference and logs why.
+
+The second gate is the one that matters. The first can only see that a file
+exists, which says nothing about whether its release *succeeded*; without the
+second, a broken `spatium-bootstrap` would take the Web UI down alongside the
+supervisor, removing the surface an operator would use to diagnose it, and it
+could not recover because the manifest would already be applied. Falling back
+to no class is exactly the pre-#983 behaviour and is always schedulable, and
+nothing is lost: firstboot re-renders this manifest on every boot, so the
+ranking returns on the first boot where bootstrap is healthy.
 
 ### seccomp
 
@@ -433,7 +460,14 @@ run under it on Compose.
 Kubernetes 1.36 adds an alpha `SeccompDefault` kubelet gate that would do
 this cluster-wide; it is alpha, so the charts do it instead.
 
-One exception is worth knowing rather than discovering: the **supervisor**
+One workload cannot have it at all: **frr-k8s**, the BGP-mode routing
+daemon, comes from a vendored subchart (`frr-k8s` 0.0.21) that exposes no
+pod-`securityContext` knob, so no values override can supply a profile. It is
+exempted by name in the render check rather than the chart being skipped —
+which is how its missing PriorityClass and BestEffort QoS survived #965
+unnoticed. Revisit on a chart bump.
+
+One further exception is worth knowing rather than discovering: the **supervisor**
 runs `privileged: true`, and containerd skips seccomp entirely for a
 privileged container. The field is set on that pod like every other, and the
 runtime ignores it. That is not a gap this change could close — a privileged

--- a/docs/deployment/KUBERNETES.md
+++ b/docs/deployment/KUBERNETES.md
@@ -472,7 +472,9 @@ global:
   servicePriorityClassName: my-serving  # the DNS / DHCP agent StatefulSets
 ```
 
-Any single workload can override with `<component>.priorityClassName`. The
+Any single workload can override with `<component>.priorityClassName`, where
+*unset* (the shipped default) inherits the chart-wide key and `""` means no
+class for that workload even when the chart-wide key is set. The
 split exists because a DNS agent answering the LAN should outrank the API
 that configures it when a node runs out of memory. The appliance sets
 `global.priorityClassName: spatium-control-plane` against classes its own

--- a/docs/deployment/KUBERNETES.md
+++ b/docs/deployment/KUBERNETES.md
@@ -47,7 +47,7 @@ SemVer 2 identifier (tag `2026.04.20-1` → chart version `2026.4.20-1`).
 
 ### Prerequisites
 
-- Kubernetes 1.26+
+- Kubernetes 1.31+
 - Helm 3.8+ (required for OCI registry support)
 - A `StorageClass` supporting `ReadWriteOnce` (Postgres, Redis, and agent
   state all use PVCs)
@@ -445,6 +445,45 @@ non-negotiable #16 — its `dns-bind9.yaml` / `dns-technitium.yaml` /
 `dhcp-kea.yaml` templates are the reference pattern. On the
 umbrella chart, DNS/DHCP agent placement is controlled per-server through the
 `storage` / `service` / `resources` fields and standard scheduling primitives.
+
+### Pod posture — seccomp and PriorityClasses (#983)
+
+Every pod the chart renders carries
+`securityContext.seccompProfile.type: RuntimeDefault`. This is on by
+default because Kubernetes runs a container `Unconfined` unless a profile is
+asked for, while docker-compose applies the runtime's default profile to
+every service — so without it the same images run *less* restricted under
+Kubernetes than under Compose. Set `global.seccompProfile` to `Unconfined`,
+or to `""` to omit the block, if your runtime's default profile breaks a
+workload; `Localhost` is rejected, because it needs a profile file the chart
+cannot place on your nodes.
+
+PriorityClasses are **off by default and you should keep them off unless you
+create the classes yourself**: a pod naming a PriorityClass that does not
+exist is refused by the apiserver, so setting a name the cluster has never
+heard of stops new pods being created (running ones are untouched, and it
+self-heals once the class exists). When you do have a priority policy:
+
+```yaml
+global:
+  priorityClassName: my-control-plane   # api, worker, beat, frontend,
+                                        # migrate, postgres/CNPG, redis,
+                                        # sentinel, slot-image mirror
+  servicePriorityClassName: my-serving  # the DNS / DHCP agent StatefulSets
+```
+
+Any single workload can override with `<component>.priorityClassName`. The
+split exists because a DNS agent answering the LAN should outrank the API
+that configures it when a node runs out of memory. The appliance sets
+`global.priorityClassName: spatium-control-plane` against classes its own
+chart renders — see
+[APPLIANCE.md § Kubernetes posture](APPLIANCE.md#kubernetes-posture-983) for
+the three classes and their values.
+
+For the raw manifests under `k8s/`, the `spatiumddi` namespace carries
+`pod-security.kubernetes.io/warn` + `audit` at `baseline`. Both are
+report-only — neither can reject a pod — and `enforce` is not usable because
+the DHCP agent needs `hostNetwork` and the DNS agents bind `:53` on the host.
 
 ---
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -166,6 +166,14 @@ have served straight through starts evicting them instead.
 
 The worker pod ships with `securityContext.capabilities.add: ["NET_RAW"]` so `nmap` can run SYN scans + `-O` OS detection from the device-profiling auto-nmap path. The image already grants the cap to the `nmap` binary via `setcap` — this line keeps it in the pod's bounding set so restricted Pod Security Admission (`restricted` profile), OpenShift SCC, and GKE Autopilot don't drop it. The cap is in containerd's default cap set on permissive clusters, so it's a no-op there. If you've turned device profiling off cluster-wide and want a tighter security posture, drop the `securityContext` block from `k8s/base/worker.yaml` (or set `worker.netRawCapability: false` in the Helm chart).
 
+### Pod posture — seccomp + Pod Security Admission (issue #983)
+
+Every pod template in these manifests carries `securityContext.seccompProfile.type: RuntimeDefault`, and the CloudNativePG `Cluster` in `k8s/ha/postgres-cluster.yaml` sets the equivalent CR field. This is parity work, not extra hardening: Kubernetes runs a container `Unconfined` unless a profile is asked for, while Docker Compose applies the runtime's default profile to every service — so without it the *same images* run with fewer syscall restrictions here than on a Compose install. `RuntimeDefault` under containerd is the same profile family Docker applies, which is why the capabilities above (`NET_RAW` for nmap, raw sockets for Kea) still work under it.
+
+The `spatiumddi` namespace carries `pod-security.kubernetes.io/warn: baseline` and `.../audit: baseline`. Both are report-only and neither can reject a pod. `enforce` is deliberately absent and is not usable here — the Kea StatefulSet needs `hostNetwork` to see DHCPDISCOVER broadcasts and the BIND9 StatefulSet binds `:53` on the host, both of which violate `baseline` by design. What warn/audit buy you is that a workload added *later* which quietly starts wanting `hostPath` or `privileged` shows up in `kubectl apply` output and the apiserver audit log rather than nowhere.
+
+These manifests set no `priorityClassName`. That is the correct default for a bring-your-own cluster: a pod naming a PriorityClass the cluster does not define is refused by the apiserver. If you have a priority policy, the Helm chart exposes `global.priorityClassName` / `global.servicePriorityClassName` — see [`docs/deployment/KUBERNETES.md`](../docs/deployment/KUBERNETES.md).
+
 ## TLS / Ingress
 
 The Ingress in `k8s/base/frontend.yaml` uses `ingressClassName: nginx`. For TLS:

--- a/k8s/base/api.yaml
+++ b/k8s/base/api.yaml
@@ -22,6 +22,13 @@ spec:
         app: spatiumddi-api
         app.kubernetes.io/component: api
     spec:
+      # #983 — Kubernetes runs a container ``Unconfined`` unless a profile is
+      # asked for, while docker-compose applies the runtime's default profile
+      # to every service. Without this the same image runs with FEWER syscall
+      # restrictions here than under Compose.
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # #590 — spread replicas across nodes so a single node loss can't
       # take every replica of this workload with it. Soft (preferred): a
       # single-node or replicas>nodes cluster must still schedule. The

--- a/k8s/base/frontend.yaml
+++ b/k8s/base/frontend.yaml
@@ -17,6 +17,13 @@ spec:
         app: spatiumddi-frontend
         app.kubernetes.io/component: frontend
     spec:
+      # #983 — Kubernetes runs a container ``Unconfined`` unless a profile is
+      # asked for, while docker-compose applies the runtime's default profile
+      # to every service. Without this the same image runs with FEWER syscall
+      # restrictions here than under Compose.
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # #590 — spread replicas across nodes so a single node loss can't
       # take every replica of this workload with it. Soft (preferred): a
       # single-node or replicas>nodes cluster must still schedule. The

--- a/k8s/base/migrate-job.yaml
+++ b/k8s/base/migrate-job.yaml
@@ -13,6 +13,13 @@ spec:
   backoffLimit: 3
   template:
     spec:
+      # #983 — Kubernetes runs a container ``Unconfined`` unless a profile is
+      # asked for, while docker-compose applies the runtime's default profile
+      # to every service. Without this the same image runs with FEWER syscall
+      # restrictions here than under Compose.
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       restartPolicy: OnFailure
       containers:
         - name: migrate

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -4,3 +4,19 @@ metadata:
   name: spatiumddi
   labels:
     app.kubernetes.io/name: spatiumddi
+    # #983 — Pod Security Admission at the ``baseline`` level, in
+    # report-only mode.
+    #
+    # ``enforce`` is deliberately absent and cannot be added: several
+    # SpatiumDDI workloads violate ``baseline`` by design — the DHCP agent
+    # needs hostNetwork to see DHCPDISCOVER broadcasts, the DNS agents bind
+    # :53 on the host, and the appliance supervisor mounts host paths.
+    # Enforcing would reject exactly the pods that have to exist.
+    #
+    # ``warn`` + ``audit`` still earn their place: a workload added later
+    # that quietly starts wanting hostPath or privileged shows up in
+    # ``kubectl apply`` output and in the apiserver audit log, instead of
+    # nowhere. Neither label can reject a pod, so this is safe to carry on
+    # a running cluster.
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/audit: baseline

--- a/k8s/base/worker.yaml
+++ b/k8s/base/worker.yaml
@@ -17,6 +17,13 @@ spec:
         app: spatiumddi-worker
         app.kubernetes.io/component: worker
     spec:
+      # #983 — Kubernetes runs a container ``Unconfined`` unless a profile is
+      # asked for, while docker-compose applies the runtime's default profile
+      # to every service. Without this the same image runs with FEWER syscall
+      # restrictions here than under Compose.
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # #590 — spread replicas across nodes so a single node loss can't
       # take every replica of this workload with it. Soft (preferred): a
       # single-node or replicas>nodes cluster must still schedule. The
@@ -130,6 +137,13 @@ spec:
         app: spatiumddi-beat
         app.kubernetes.io/component: beat
     spec:
+      # #983 — Kubernetes runs a container ``Unconfined`` unless a profile is
+      # asked for, while docker-compose applies the runtime's default profile
+      # to every service. Without this the same image runs with FEWER syscall
+      # restrictions here than under Compose.
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: beat
           image: ghcr.io/spatiumddi/spatiumddi-api:latest

--- a/k8s/dhcp/kea-statefulset.yaml
+++ b/k8s/dhcp/kea-statefulset.yaml
@@ -24,6 +24,13 @@ spec:
         app.kubernetes.io/instance: dhcp1
         spatiumddi.org/dhcp-flavor: kea
     spec:
+      # #983 — Kubernetes runs a container ``Unconfined`` unless a profile is
+      # asked for, while docker-compose applies the runtime's default profile
+      # to every service. Without this the same image runs with FEWER syscall
+      # restrictions here than under Compose.
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/k8s/dns/bind9-statefulset.yaml
+++ b/k8s/dns/bind9-statefulset.yaml
@@ -24,6 +24,13 @@ spec:
         app.kubernetes.io/instance: ns1
         spatiumddi.org/dns-flavor: bind9
     spec:
+      # #983 — Kubernetes runs a container ``Unconfined`` unless a profile is
+      # asked for, while docker-compose applies the runtime's default profile
+      # to every service. Without this the same image runs with FEWER syscall
+      # restrictions here than under Compose.
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/k8s/ha/postgres-cluster.yaml
+++ b/k8s/ha/postgres-cluster.yaml
@@ -17,6 +17,13 @@ spec:
   instances: 3
   imageName: ghcr.io/cloudnative-pg/postgresql:16
 
+  # #983 — CNPG owns the instance pods, so the seccomp profile is a field on
+  # the Cluster rather than a pod-template securityContext. The CRD already
+  # defaults it to RuntimeDefault; stating it makes the posture readable
+  # here instead of only in the operator's source.
+  seccompProfile:
+    type: RuntimeDefault
+
   # #590 — spread the instances one per node. CNPG enables anti-affinity by
   # default but only as `preferred` (best effort), which lets two of three
   # instances land on the same node — one node loss then takes the primary

--- a/k8s/ha/redis-sentinel.yaml
+++ b/k8s/ha/redis-sentinel.yaml
@@ -61,6 +61,13 @@ spec:
       labels:
         app: redis
     spec:
+      # #983 — Kubernetes runs a container ``Unconfined`` unless a profile is
+      # asked for, while docker-compose applies the runtime's default profile
+      # to every service. Without this the same image runs with FEWER syscall
+      # restrictions here than under Compose.
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # #590 — spread the replicas one per node. Required (not preferred):
       # a single node hosting two of three replicas takes both the data
       # majority AND the sentinel quorum with it when it dies, and with


### PR DESCRIPTION
Phase 1 of #983 — the Kubernetes posture the charts should have had and did not. A grep of `charts/` + `k8s/` before this returned **zero** for `priorityClassName` and `seccompProfile`, and the `kubeVersion` floors (1.26 / 1.27) claimed support for versions nobody has ever run this on.

Phase 2 of the issue (user namespaces, `nodes/stats` in place of `nodes/proxy`, PSI metrics, `topologySpreadConstraints`) is **not** here — the issue defers it until the #974 ISO has soaked on a real 3-node cluster.

## PriorityClasses

Every pod ran at priority 0. That is not a neutral default, it is a **tie**, and both rankings that break it do the wrong thing with one:

- **Kubelet eviction** under memory / ephemeral-storage pressure orders victims by priority *first*, usage-over-request second. With everything equal, the pod evicted is whichever grew the most — on an appliance, BIND with a warm cache.
- **Scheduler preemption** is the mirror image: a role DaemonSet landing on a freshly joined node has no claim over kube-state-metrics.

Three cluster-scoped classes now come from the appliance chart:

| Class | Value | Applied to |
|---|---|---|
| `spatium-service` | 100000 | DNS (bind9 / powerdns / technitium), `dhcp-kea`, `looking-glass`, MetalLB speaker, frr-k8s |
| `spatium-control-plane` | 90000 | api, worker, beat, frontend, Postgres/CNPG (operator + instances), redis, sentinel, supervisor, MetalLB controller |
| `spatium-observability` | 10000 | kube-state-metrics, node-exporter — plus `preemptionPolicy: Never` |

`preemptionPolicy: Never` is the one piece that is not just ordering: a pending exporter can never evict a running pod to schedule itself. Monitoring must not cause the outage it would then report.

All three sit far below `system-cluster-critical` (2000000000) / `system-node-critical` (2000001000), and none is `globalDefault` — that would re-rank every pod in the cluster, including anything the operator joined to it themselves.

The umbrella chart's knobs are **empty by default and must stay that way**: the apiserver *refuses* a pod naming a class that does not exist, so a bring-your-own cluster must never get one it did not create.

## seccomp

This closes a **regression, not a hardening gap**. Kubernetes runs a container `Unconfined` unless asked; docker-compose applies the runtime's default profile to every service. So the same images ran with *fewer* syscall restrictions under Kubernetes than under Compose. `RuntimeDefault` under containerd is the same profile family, which is why Kea's raw sockets, pcap (#59) and nmap (#58) already run under it on Compose.

Applied to every pod in both charts and in `k8s/`, plus the CNPG `Cluster`'s own field. Two honest exceptions, both documented rather than papered over:

- **supervisor** — `privileged: true`, and containerd skips seccomp for privileged containers. The field is set; the runtime ignores it.
- **frr-k8s** — the vendored 0.0.21 subchart exposes no pod-`securityContext` knob, so no values override can supply one. Exempted by name in the gate.

## PSA

`spatium` / `spatiumddi` get `warn` + `audit` at `baseline`. `enforce` is impossible and always will be — hostNetwork `:53`/`:67`, hostPID and host mounts violate baseline by design. The value is that a workload which *later* starts wanting hostPath shows up in apply output and the audit log instead of nowhere.

## Version floors

Umbrella → `>=1.31.0-0`. Appliance + MetalLB → `>=1.35.0-0`, deliberately **one minor below** the ISO's k3s rather than at it: a rolling OS upgrade transiently serves a mix of 1.35 and 1.36 apiservers, helm validates `kubeVersion` against whichever it reaches, and a 1.36 floor would turn a mid-upgrade role toggle — the supervisor patches this chart's values on every role change — into a failed release.

`agent-e2e` ran on kind v0.22.0 (Feb 2024), i.e. against whatever Kubernetes that defaulted to. Now v0.33.0 with `node_image` pinned by digest to v1.36.4, matching the k3s the ISO bakes.

## The guard

`.github/scripts/chart-pod-posture.py` asserts on the **rendered manifests**, not the templates — a `with` guard on the wrong values path renders nothing and reads fine in the template (the #917 lesson). It caught the unranked CNPG operator Deployment while being written.

Deliberate priority-0 decisions are recorded as `--allow-no-priority` at the call site rather than left implicit, so a *new* workload still fails the gate.

## Review round

`/code-review` found five, all valid, all fixed in `3d14989c`:

1. **MetalLB was the gap this change created.** Speaker and controller stayed BestEffort at priority 0 while everything around them moved — so the kubelet would now reclaim the VIP's ARP responder *first*. Nothing could see it: `charts-render-check` named the other two charts explicitly, so `spatiumddi-metallb` had **never been rendered on a PR**. It is in the gate now in three shapes, which immediately surfaced the same problem one level deeper in frr-k8s.
2. **The firstboot guard proved the wrong thing.** `[ -f "$CHART_TGZ" ]` shows the tarball exists; the class comes from its *release*. A failed `spatium-bootstrap` left every control-plane Deployment accepted and unable to create a pod — pre-#983 that failure still left a working UI to diagnose the supervisor with. Added `release_control_manifest`, which asks the live cluster and strips the reference when the class is absent.
3. **The gate never saw a CNPG `Cluster` under `--require-priority`.** A wrong values path there would have shipped green with Postgres at priority 0. Fixed and verified by deleting the block and watching the gate fail.
4. **`priorityClasses.create: false`** with the non-empty defaults refuses every appliance pod. Was a comment; now a `fail` naming each key still set.
5. **`""` inherited instead of clearing.** The keys now ship unset (null); `""` means no class for that workload even when the chart-wide key is set.

## Verification

Local, repeatable: `make charts-lint` (all gates, 3 charts, 10 renders), 265 appliance tests, shell + YAML syntax on every touched file. The three-state override semantics were checked end to end against real renders, and both new gates were exercised with negative controls.

**Not verified — needs an appliance, and nothing here is behind a toggle.** In rough order of what would hurt most if wrong:

- `RuntimeDefault` against the real workloads: Kea DORA over relay and L2, BIND with DoT/DoH (#50), GoBGP (#566), node-exporter, and pcap / nmap / mtr from the api pod.
- **The MetalLB speaker specifically** — it holds the VIP, and it is the one pod where a wrong seccomp verdict costs reachability rather than a feature. `RuntimeDefault` permits `socket(AF_PACKET, …)` for a container holding `CAP_NET_RAW`, which the speaker has (`drop: ALL`, `add: NET_RAW`) — the capability, not the profile, gates the raw socket. Reasoned, not run.
- Eviction ordering: a memory-pressure drill (`stress-ng --vm` in a throwaway pod), confirming the observability pod goes before BIND.
- Which workloads actually warn under PSA, so the "a warning from anything else is the signal" claim in APPLIANCE.md is true rather than aspirational.
- `release_control_manifest`'s degraded path on a real box (break `spatium-bootstrap`, confirm the UI still comes up unranked and the next boot restores the ranking).

Refs #983 — **deliberately not `Closes`.** Phase 1 is everything in this PR;
the issue stays open for Phase 2 (`hostUsers: false`, `nodes/stats` in place
of the `nodes/proxy` grant, PSI metrics, `topologySpreadConstraints`), which
the issue itself gates on the 1.36 ISO having soaked on a real 3-node
cluster. Closing it here would lose that tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
