### PR TITLE
fix(dhcp): #980 name the packet loss, and fix the Kea default that causes it

### DIFF
--- a/.github/scripts/ci-backend-must-run.txt
+++ b/.github/scripts/ci-backend-must-run.txt
@@ -26,6 +26,17 @@ appliance/mkosi.extra/usr/local/bin/
 # test_appliance_firewall_render.py imports the renderer by path.
 agent/supervisor/spatium_supervisor/
 
+# test_dhcp_packet_loss.py (#980) pins the agent's metric column names
+# against the ingest model's fields. That model does not forbid extra keys —
+# deliberately, so a newer agent posting a field an older control plane has
+# never heard of loses the field rather than having the whole sample 422'd
+# mid-upgrade — which means a TYPO is equally silent: the column would stay
+# NULL forever and every surface would report "loss not measured" on a fleet
+# that is measuring fine. agent/ is denied wholesale, so without this
+# carve-out the one edit that can break the boundary would not run the test
+# guarding it.
+agent/dhcp/spatium_dhcp_agent/metrics.py
+
 # test_openapi_export.py runs the release-asset exporter (#903) and pins
 # that its output still goes through app.openapi()'s wrapper.
 scripts/export_openapi.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,90 @@ the formatter handles the rest.
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- **A DHCP server short of CPU loses packets silently, and nothing
+  in the product said so (#980).** Kea answers 100 % of what it
+  reads; when its receive thread is late the kernel discards the
+  datagram first, so every server-side signal stays green — health
+  check, heartbeat, free addresses, and Kea's own
+  `pkt4-receive-drop`, which measured **0** through a run that lost
+  9,700 datagrams to buffer overflow. The only symptom was clients
+  taking several 4-second retransmit rounds to get an address, which
+  from the server looks like somebody else's problem. Two per-bucket
+  counters now name it: `socket_drop`, the kernel's per-socket
+  `sk_drops` read from `/proc/net/udp` by the agent, and
+  `receive_drop`, Kea's own. Both surface on the server's Stats tab
+  (a dashed *DROPPED* line and a red `N dropped` chip) and drive the
+  new default-on **`dhcp_packets_dropped`** alert rule.
+
+  **NULL is not zero.** An agent older than this change, or one that
+  cannot read `/proc/net/udp`, reports neither counter; the columns
+  stay NULL, the UI says *loss not measured*, and the alert skips
+  such a server rather than vouching for it. A wall of green zeros
+  from an un-upgraded fleet is the exact false reassurance the issue
+  was about.
+
+  **The issue's two proposed mitigations do not work, and a third
+  nobody proposed does.** A larger `packet-queue-size` is inert — 64
+  → 2048 changed neither throughput nor drops, because that queue
+  sits behind the receive thread. A larger receive buffer trades the
+  drops for latency (#952 measured a 34 s DORA p50 against 1.5 s).
+  What works is **`multi-threading.thread-pool-size`**, which Kea
+  sizes from `hardware_concurrency()` — the *machine's* CPU count,
+  ignoring the container's cgroup share. Verified: a container
+  limited to 0.20 CPU starts ten workers, which then compete inside
+  that cgroup with the one thread draining the socket. Packets
+  served at 12,000 relayed pkt/s (kea-dhcp4 3.0.3, memfile, median
+  of 4 runs):
+
+  | cgroup CPU | pool = 1 | pool = 2 | pool = 4 (= "auto" on 4 vCPU) |
+  |---|---|---|---|
+  | 0.25 | 19,381 | 11,119 | 6,723 |
+  | 4.0 (no quota) | 93,717 | 73,089 | 55,957 |
+
+  Monotonic in both shapes, so `kea_thread_pool_size` now defaults to
+  **1** and every existing group picks it up on upgrade (one Kea
+  config-reload, no restart); `0` restores Kea's auto-sizing. It is a
+  *resize*, deliberately not `enable-multi-threading: false` — with
+  MT off one thread must both receive and process, measuring 15,170
+  socket drops in a run where a pool of one measured none, and it
+  also flips host-reservation lookup order. Kea's HA hook keeps its
+  own `http-client-threads` / `http-listener-threads`, so a failover
+  pair's peer traffic is not serialised behind the single worker.
+
+  A second group setting, **`kea_packet_logging`**, defaults to
+  **true** — exactly today's behaviour. Kea writes four INFO lines
+  per transaction to two appenders, one of them flushed; turning
+  this off raises only the `kea-dhcpN.packets` child to WARN for
+  1.30x more packets served, at the cost of the two codes carrying
+  the source address and receiving interface. Opt-in rather than
+  default because it removes something an operator can see, the same
+  call #637 made for the lease cache. `kea-dhcpN.dhcpN` is never
+  silenced despite looking like the same noise: at INFO it also
+  carries `DHCP4_OPEN_SOCKETS_FAILED`, `DHCP4_CONFIG_COMPLETE`,
+  `DHCP4_STARTED` and `DHCP4_MULTI_THREADING_INFO` — the line that
+  confirms the pool size took effect.
+
+  **Found on the way:** the metrics ingest endpoint *substituted*
+  rather than accumulated when a bucket already existed. The agent
+  floors `bucket_at` to the minute while its own interval is 60 s ±
+  3 s of jitter, so a tick early in a minute followed by a 57-59 s
+  gap put two genuinely different deltas in one bucket — about one
+  bucket in forty, silently discarding a poll since #195. It
+  accumulates now, which for a loss counter is the difference
+  between reporting the bad minute and losing it.
+
+### Migrations
+
+- `c93f1a72e408` — `dhcp_metric_sample.receive_drop` /
+  `.socket_drop` (both nullable: NULL means unmeasured) and
+  `dhcp_server_group.kea_thread_pool_size` / `.kea_packet_logging`.
+
+---
+
 ## 2026.09.04-1 — 2026-09-04
 
 **The appliance sizing release.** Two days of measured load against a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,16 +35,30 @@ the formatter handles the rest.
   from the server looks like somebody else's problem. Two per-bucket
   counters now name it: `socket_drop`, the kernel's per-socket
   `sk_drops` read from `/proc/net/udp` by the agent, and
-  `receive_drop`, Kea's own. Both surface on the server's Stats tab
-  (a dashed *DROPPED* line and a red `N dropped` chip) and drive the
-  new default-on **`dhcp_packets_dropped`** alert rule.
+  `receive_drop`, Kea's own. Both are reported, but only
+  `socket_drop` is treated as loss: the *DROPPED* line, the red
+  `N dropped` chip on the server's Stats tab and the new default-on
+  **`dhcp_packets_dropped`** alert rule all read it alone.
+  `pkt4-receive-drop` counts packets Kea read and discarded **on
+  purpose** as well as by accident — verified, a client matching a
+  `DROP` client-class increments it once per packet, and a `DROP`
+  class is exactly what the shipped DHCP MAC blocklist renders (Kea's
+  HA hook drops out-of-scope queries in hot-standby the same way), so
+  a rule counting it would fire permanently and never auto-resolve on
+  two ordinary working configurations. It is surfaced beside the
+  other, labelled as context rather than fault.
 
   **NULL is not zero.** An agent older than this change, or one that
-  cannot read `/proc/net/udp`, reports neither counter; the columns
-  stay NULL, the UI says *loss not measured*, and the alert skips
+  cannot read `/proc/net/udp`, reports no `socket_drop`; the column
+  stays NULL, the UI says *loss not measured*, and the alert skips
   such a server rather than vouching for it. A wall of green zeros
   from an un-upgraded fleet is the exact false reassurance the issue
-  was about.
+  was about. Every "was this measured?" test keys on `socket_drop`
+  alone — `receive_drop` always arrives from an upgraded agent, so
+  testing the pair would read an unmeasurable server as
+  measured-and-clean — and a *partial* procfs read discards the whole
+  sample, because a missing inode returning later would charge its
+  entire lifetime of drops to one bucket.
 
   **The issue's two proposed mitigations do not work, and a third
   nobody proposed does.** A larger `packet-queue-size` is inert — 64
@@ -70,9 +84,12 @@ the formatter handles the rest.
   *resize*, deliberately not `enable-multi-threading: false` — with
   MT off one thread must both receive and process, measuring 15,170
   socket drops in a run where a pool of one measured none, and it
-  also flips host-reservation lookup order. Kea's HA hook keeps its
-  own `http-client-threads` / `http-listener-threads`, so a failover
-  pair's peer traffic is not serialised behind the single worker.
+  also flips host-reservation lookup order. Kea's HA hook does *not*
+  keep independent HTTP pools — `http-listener-threads` /
+  `http-client-threads` default to 0, which Kea reads as "same as
+  `thread-pool-size`" (counted: pool=1 gave 8 OS threads, pool=8 gave
+  29, three pools of N) — so the agent pins both to 4 and this
+  setting moves only the packet-worker pool.
 
   A second group setting, **`kea_packet_logging`**, defaults to
   **true** — exactly today's behaviour. Kea writes four INFO lines
@@ -86,6 +103,12 @@ the formatter handles the rest.
   carries `DHCP4_OPEN_SOCKETS_FAILED`, `DHCP4_CONFIG_COMPLETE`,
   `DHCP4_STARTED` and `DHCP4_MULTI_THREADING_INFO` — the line that
   confirms the pool size took effect.
+
+  Turning packet logging off appends a `kea-dhcpN.packets` child
+  logger at WARN with **no appenders of its own** — verified that a
+  child configured with only a severity inherits the parent's, so
+  giving it a copy would put a second `RollingFileAppender` on one
+  path with independent rotation state.
 
   **Found on the way:** the metrics ingest endpoint *substituted*
   rather than accumulated when a bucket already existed. The agent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1648,11 +1648,15 @@ suggestion, free-space treemap.
   it counts packets Kea *read* and discarded, and this loss is the kernel
   discarding them first. The number that moves is the per-socket `sk_drops`
   in `/proc/net/udp`, the same event as the `Udp RcvbufErrors` the reporter
-  saw. Both are now per-bucket columns on `dhcp_metric_sample`, a dashed
-  DROPPED line + chip on the Stats tab, and the default-on
-  `dhcp_packets_dropped` rule. **NULL means unmeasured** in every surface —
-  an agent too old to report is skipped by the alert, not vouched for, since
-  a wall of green zeros is the false reassurance being fixed.
+  saw. Both are per-bucket columns on `dhcp_metric_sample`, but only
+  `socket_drop` is treated as loss — the DROPPED line, the chip and the
+  default-on `dhcp_packets_dropped` rule all read it alone. **`pkt4-receive-drop`
+  counts deliberate drops too**: verified, a `DROP` client-class match
+  increments it, and a `DROP` class is exactly what the shipped MAC blocklist
+  renders, so a rule counting it would fire permanently on a working install.
+  **NULL means unmeasured** in every surface, keyed on `socket_drop` alone —
+  `receive_drop` always arrives from an upgraded agent, so testing the pair
+  would read an unmeasurable server as measured-and-clean.
   **Its two mitigations are dead ends.** `packet-queue-size` 64 → 2048 (32x)
   changed neither throughput nor drops: that queue sits *behind* the receive
   thread. A bigger receive buffer was already known to trade drops for a 34 s
@@ -1667,8 +1671,11 @@ suggestion, free-space treemap.
   and existing groups pick it up on upgrade. Deliberately a *resize*, not
   `enable-multi-threading: false`: MT-off makes one thread both receive and
   process (15,170 socket drops where pool 1 had none) and flips
-  host-reservation lookup order. Kea's HA hook keeps its own HTTP thread
-  pools, so a failover pair is unaffected.
+  host-reservation lookup order. **Kea's HA hook does NOT keep independent
+  HTTP pools** — `http-listener-threads` / `http-client-threads` default to 0,
+  which Kea reads as "same as `thread-pool-size`" (counted: pool=1 → 8 OS
+  threads, pool=8 → 29, three pools of N), so the agent pins both to 4 rather
+  than let a packet-path fix silently serialise HA peer traffic.
   Second knob `kea_packet_logging` (default **true** = today's behaviour) is
   worth 1.30x when turned off, and is opt-in because it removes two log codes
   an operator can see — the #637 lease-cache call. `kea-dhcpN.dhcpN` is never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1638,6 +1638,54 @@ suggestion, free-space treemap.
   itself, which needs `rndc tsig-list` (or the effective `named.conf` plus
   includes) from an affected node to say what named actually loaded.
 
+- ✅ [**Kea drops relayed DHCP requests before it reads them under CPU pressure**](https://github.com/spatiumddi/spatiumddi/issues/980)
+  — a QA report whose *observation* was exact and whose three proposed fixes
+  were all wrong, in ways only measurement could show. Reproduced against a
+  live kea-dhcp4 3.0.3 rather than reasoned about.
+  **The counter the issue asked us to report does not move.** It proposed
+  surfacing `pkt4-receive-drop`; measured, a run that lost **9,700** datagrams
+  to receive-buffer overflow reported it as **0** for the whole duration —
+  it counts packets Kea *read* and discarded, and this loss is the kernel
+  discarding them first. The number that moves is the per-socket `sk_drops`
+  in `/proc/net/udp`, the same event as the `Udp RcvbufErrors` the reporter
+  saw. Both are now per-bucket columns on `dhcp_metric_sample`, a dashed
+  DROPPED line + chip on the Stats tab, and the default-on
+  `dhcp_packets_dropped` rule. **NULL means unmeasured** in every surface —
+  an agent too old to report is skipped by the alert, not vouched for, since
+  a wall of green zeros is the false reassurance being fixed.
+  **Its two mitigations are dead ends.** `packet-queue-size` 64 → 2048 (32x)
+  changed neither throughput nor drops: that queue sits *behind* the receive
+  thread. A bigger receive buffer was already known to trade drops for a 34 s
+  DORA p50 (#952).
+  **What works is the knob nobody named.** Kea sizes its packet-worker pool
+  from `hardware_concurrency()` — the MACHINE's CPU count, ignoring the
+  cgroup share — so a container limited to 0.20 CPU starts **ten** workers
+  that compete, inside that cgroup, with the one thread draining the socket.
+  Packets served at 12,000 relayed pkt/s, median of 4: at 0.25 CPU 19,381
+  (pool 1) / 11,119 (2) / 6,723 (4); with 4 CPUs and no quota 93,717 /
+  73,089 / 55,957. Monotonic, so `kea_thread_pool_size` defaults to **1**
+  and existing groups pick it up on upgrade. Deliberately a *resize*, not
+  `enable-multi-threading: false`: MT-off makes one thread both receive and
+  process (15,170 socket drops where pool 1 had none) and flips
+  host-reservation lookup order. Kea's HA hook keeps its own HTTP thread
+  pools, so a failover pair is unaffected.
+  Second knob `kea_packet_logging` (default **true** = today's behaviour) is
+  worth 1.30x when turned off, and is opt-in because it removes two log codes
+  an operator can see — the #637 lease-cache call. `kea-dhcpN.dhcpN` is never
+  silenced despite looking like the same noise: it also carries
+  `DHCP4_OPEN_SOCKETS_FAILED` and the line reporting whether the pool size
+  took effect. Pairs with the #983 PSI alert, which names the cause where
+  this names the effect.
+  **Found on the way:** the metrics ingest *substituted* on a bucket
+  collision instead of accumulating, silently discarding roughly one poll in
+  forty since #195 — the agent floors `bucket_at` to the minute while its
+  interval is 60 s ± 3 s. Migration `c93f1a72e408`. No new MCP tool
+  (explicit decision per non-negotiable #13 — `find_dhcp_server_stats`
+  answers exactly this question and gained a `packet_loss` block; a
+  `propose_*` for the pool size is the broad-blast-radius shape that
+  guidance says to keep off the copilot) and not a feature module (#14 — it
+  extends an existing resource).
+
 - ✅ [**celery-beat reported unhealthy forever after a slot upgrade**](https://github.com/spatiumddi/spatiumddi/issues/925)
   — shipped `2026.09.04-1`. The rollup was right that something was broken and wrong about what.
   **Beat only *schedules* `beat_tick`; a worker executes it**, so the

--- a/agent/dhcp/spatium_dhcp_agent/metrics.py
+++ b/agent/dhcp/spatium_dhcp_agent/metrics.py
@@ -28,6 +28,26 @@ without a schema migration.
     pkt4-decline-received                 pkt6-decline-received        → decline
     pkt4-release-received                 pkt6-release-received        → release
     pkt4-inform-received                  pkt6-information-request-received → inform
+    pkt4-receive-drop                     pkt6-receive-drop            → receive_drop
+
+Two *loss* signals ride alongside those, added for issue #980, and they
+name different failures:
+
+* ``receive_drop`` — packets Kea read off the socket and then discarded
+  (unparseable, matched the ``DROP`` class, no subnet selected).
+* ``socket_drop`` — packets the kernel dropped because Kea's receive
+  buffer was full, so Kea never saw them at all. Read from
+  ``/proc/net/udp`` by :mod:`.socket_drops`, not from Kea.
+
+The distinction is the point. Measured against kea-dhcp4 3.0.3 on
+2026-09-06, a run that lost 9,700 datagrams to buffer overflow reported
+``pkt4-receive-drop = 0`` throughout: a server starved of CPU answers
+100 % of what it reads, and every Kea-sourced counter agrees it is
+healthy. Only ``socket_drop`` moves.
+
+Both are ``None`` — not 0 — when they could not be measured, so an agent
+that cannot read them, or one older than this change, is reported as
+UNKNOWN rather than as a server with no loss.
 """
 
 from __future__ import annotations
@@ -42,6 +62,7 @@ import structlog
 
 from .config import AgentConfig
 from .kea_ctrl import KeaCtrlError, send_command
+from .socket_drops import SocketDropCounter
 
 log = structlog.get_logger(__name__)
 
@@ -67,6 +88,8 @@ _STAT_MAP = {
     "pkt6-decline-received": "decline",
     "pkt6-release-received": "release",
     "pkt6-information-request-received": "inform",
+    "pkt4-receive-drop": "receive_drop",
+    "pkt6-receive-drop": "receive_drop",
 }
 
 # Column names — the unique set of values from ``_STAT_MAP``, used by
@@ -121,6 +144,9 @@ class MetricsPoller:
         # Previous snapshot. None on first tick — the first post-boot
         # bucket is absorbed (no baseline to diff against).
         self._prev: dict[str, int] | None = None
+        # #980 — kernel-side loss, sampled in lockstep with the Kea
+        # counters so both deltas always cover the same interval.
+        self._socket = SocketDropCounter()
 
     def stop(self) -> None:
         self._stop.set()
@@ -163,12 +189,18 @@ class MetricsPoller:
             return None
         return delta
 
-    def _report(self, bucket_at: datetime, delta: dict[str, int]) -> None:
+    def _report(
+        self, bucket_at: datetime, delta: dict[str, int], socket_drop: int | None
+    ) -> None:
         try:
             with self._client() as c:
                 resp = c.post(
                     "/api/v1/dhcp/agents/metrics",
-                    json={"bucket_at": bucket_at.isoformat(), **delta},
+                    json={
+                        "bucket_at": bucket_at.isoformat(),
+                        "socket_drop": socket_drop,
+                        **delta,
+                    },
                     headers={"Authorization": f"Bearer {self.token_ref[0]}"},
                 )
             if resp.status_code not in (200, 204):
@@ -181,6 +213,14 @@ class MetricsPoller:
             current = self._poll_kea()
             if current is not None:
                 delta = self._compute_delta(current)
+                # Sampled unconditionally so its baseline advances in step
+                # with the Kea one: a bucket that is dropped (agent start,
+                # Kea restart) drops BOTH deltas, and the pair that is
+                # reported always covers the same interval. Advancing only
+                # one of the two would smear an interval's kernel drops
+                # into a bucket whose Kea counters exclude them, and the
+                # first comparison anyone makes is drops against DISCOVERs.
+                socket_drop = self._socket.sample()
                 if delta is not None:
                     # Bucket timestamp is "now, rounded to the poll
                     # interval" — the server path dedupes on
@@ -188,7 +228,7 @@ class MetricsPoller:
                     # the next interval won't double-count.
                     now = datetime.now(UTC).replace(microsecond=0)
                     bucket = now.replace(second=(now.second // 60) * 60)
-                    self._report(bucket, delta)
+                    self._report(bucket, delta, socket_drop)
             # 60s base + small jitter so paired peers don't hit the
             # control plane in lockstep.
             interval = 60.0 + random.uniform(-3, 3)

--- a/agent/dhcp/spatium_dhcp_agent/render_kea.py
+++ b/agent/dhcp/spatium_dhcp_agent/render_kea.py
@@ -885,6 +885,11 @@ def _resolve_peer_url(url: str) -> str:
         return url
 
 
+# #980 — see the ``multi-threading`` block in _ha_hook for why the HA hook's
+# HTTP pools are pinned rather than left to follow the packet-worker pool.
+_HA_HTTP_THREADS = 4
+
+
 def _ha_hook(failover: dict[str, Any]) -> dict[str, Any]:
     """Render the ``libdhcp_ha.so`` hook entry from a failover payload.
 
@@ -904,6 +909,31 @@ def _ha_hook(failover: dict[str, Any]) -> dict[str, Any]:
         for p in failover["peers"]
     ]
     relationship = {
+        # #980 — pin the HA hook's OWN thread pools.
+        #
+        # ``http-listener-threads`` / ``http-client-threads`` default to 0,
+        # which Kea reads as "same as the core ``thread-pool-size``" — NOT as
+        # an independent auto-size. Verified by counting OS threads on
+        # kea-dhcp4 3.0.3 with the HA hook loaded: pool=1 gave 8 threads and
+        # pool=8 gave 29, a delta of 21 for a pool delta of 7, i.e. three
+        # pools of N. So #980's drop of the packet-worker pool to 1 would
+        # also have taken HA's peer HTTP concurrency to 1, serialising lease
+        # updates to the partner — an unmeasured side effect on a code path
+        # #980 never tested, in exactly the device-rush conditions it is
+        # about.
+        #
+        # 4 is a decoupling constant, not a tuned one: the point is that the
+        # packet-path fix must not silently change HA's concurrency, and the
+        # HA threads do short LAN HTTP POSTs that never contend for the
+        # receive thread the pool size exists to protect. With this block the
+        # same measurement gives 14 threads at pool=1 and 21 at pool=8 — a
+        # delta of exactly the core pool.
+        "multi-threading": {
+            "enable-multi-threading": True,
+            "http-dedicated-listener": True,
+            "http-listener-threads": _HA_HTTP_THREADS,
+            "http-client-threads": _HA_HTTP_THREADS,
+        },
         "this-server-name": failover["this_server_name"],
         "mode": failover["mode"],
         "heartbeat-delay": int(failover.get("heartbeat_delay_ms", 10000)),
@@ -928,11 +958,9 @@ def _log_outputs(daemon: str) -> list[dict[str, Any]]:
         the Logs UI's "DHCP Activity" tab. Kea rotates the file in-process
         via ``maxsize`` / ``maxver`` so we don't need external logrotate.
 
-    Shared rather than repeated because the #980 ``.packets`` override has to
-    name the SAME appenders — log4cplus gives a logger configured by name no
-    inherited appenders, so a mismatch here would not raise that child's
-    level, it would send its WARNs and ERRORs to a different file or to
-    nowhere.
+    Shared by the Dhcp4 and Dhcp6 root loggers so the path is defined once.
+    The #980 ``.packets`` override deliberately does NOT use this — it
+    inherits instead, so there is only ever one appender per file.
     """
     return [
         {"output": "stdout"},
@@ -965,17 +993,22 @@ def _quiet_packet_logger(daemon: str, server: dict[str, Any]) -> list[dict[str, 
 
     Absent from the bundle means True — an older control plane's bundle must
     keep the logging its operator can see today.
+
+    **No ``output_options``, deliberately.** A child logger configured with
+    only a severity inherits the parent's appenders — verified against
+    kea-dhcp4 3.0.3: with the child at DEBUG and no outputs of its own, every
+    ``DHCP4_PACKET_RECEIVED`` still reached both stdout and the shipped file,
+    and at WARN none did while the parent's INFO lines kept flowing. Giving
+    it a copy of the parent's appenders also works, but puts a SECOND
+    RollingFileAppender on ``/var/log/kea/<daemon>.log`` with its own
+    independent rotation state: at the 50 MB threshold one appender renames
+    the file while the other still holds the old descriptor, so lines land in
+    the rotated copy and the next rotation clobbers it. Inheriting avoids
+    that for free.
     """
     if server.get("kea_packet_logging", True):
         return []
-    return [
-        {
-            "name": f"{daemon}.packets",
-            # Same appenders as the parent — see _log_outputs.
-            "output_options": _log_outputs(daemon),
-            "severity": "WARN",
-        }
-    ]
+    return [{"name": f"{daemon}.packets", "severity": "WARN"}]
 
 
 def _multi_threading(server: dict[str, Any]) -> dict[str, Any]:

--- a/agent/dhcp/spatium_dhcp_agent/render_kea.py
+++ b/agent/dhcp/spatium_dhcp_agent/render_kea.py
@@ -918,6 +918,104 @@ def _ha_hook(failover: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _log_outputs(daemon: str) -> list[dict[str, Any]]:
+    """The two appenders every Kea logger in this config writes to.
+
+    Two outputs by design:
+      * stdout — picked up by ``docker logs`` for the existing operator
+        workflow.
+      * file — tailed by ``LogShipper`` and shipped to the control plane for
+        the Logs UI's "DHCP Activity" tab. Kea rotates the file in-process
+        via ``maxsize`` / ``maxver`` so we don't need external logrotate.
+
+    Shared rather than repeated because the #980 ``.packets`` override has to
+    name the SAME appenders — log4cplus gives a logger configured by name no
+    inherited appenders, so a mismatch here would not raise that child's
+    level, it would send its WARNs and ERRORs to a different file or to
+    nowhere.
+    """
+    return [
+        {"output": "stdout"},
+        {
+            "output": f"/var/log/kea/{daemon}.log",
+            "maxsize": 50_000_000,
+            "maxver": 5,
+            "flush": True,
+        },
+    ]
+
+
+def _quiet_packet_logger(daemon: str, server: dict[str, Any]) -> list[dict[str, Any]]:
+    """The ``kea-dhcpN.packets`` override, or nothing (#980).
+
+    Kea writes four INFO lines per transaction. Two of them —
+    ``DHCP4_PACKET_RECEIVED`` and ``DHCP4_PACKET_SEND``, both from the
+    ``.packets`` child logger — restate a transaction the ``.dhcp4`` and
+    ``.leases`` lines already record, adding the source address and the
+    receiving interface. Raising just that child to WARN measured 1.30x more
+    packets served on a CPU-constrained node (24,997-26,077 against
+    19,026-20,403 at 0.25 CPU and 12,000 offered pkt/s).
+
+    Only that one child. ``kea-dhcpN.dhcpN`` is the obvious-looking second
+    candidate and it also carries ``DHCP4_OPEN_SOCKETS_FAILED`` — a genuine
+    failure Kea logs at INFO — plus ``DHCP4_CONFIG_COMPLETE``,
+    ``DHCP4_STARTED`` and ``DHCP4_MULTI_THREADING_INFO``, which is the line
+    that reports whether the #980 pool size took effect. Silencing it would
+    trade a diagnosis for a throughput number.
+
+    Absent from the bundle means True — an older control plane's bundle must
+    keep the logging its operator can see today.
+    """
+    if server.get("kea_packet_logging", True):
+        return []
+    return [
+        {
+            "name": f"{daemon}.packets",
+            # Same appenders as the parent — see _log_outputs.
+            "output_options": _log_outputs(daemon),
+            "severity": "WARN",
+        }
+    ]
+
+
+def _multi_threading(server: dict[str, Any]) -> dict[str, Any]:
+    """Render Kea's ``multi-threading`` block from the bundle (#980).
+
+    Kea leaves ``thread-pool-size`` at 0, meaning "one worker per CPU the
+    machine reports" — ``hardware_concurrency()``, which knows nothing about
+    the cgroup quota or weight the container is actually held to. Those
+    workers then compete, inside that one cgroup, with the single thread that
+    has to drain the receive socket, and when it is late the kernel drops
+    datagrams before Kea can see them. That loss is invisible to every
+    counter Kea keeps: measured on kea-dhcp4 3.0.3, a run that lost 9,700
+    datagrams that way reported ``pkt4-receive-drop`` 0 throughout.
+
+    Fewer workers measured strictly better at every CPU allocation tried
+    (12,000 relayed pkt/s, memfile, median of 4; packets served): at 0.25
+    CPU 19,381 for one worker against 11,119 for two and 6,723 for four; with
+    four CPUs and no quota, 93,717 / 73,089 / 55,957. Hence the control
+    plane's default of 1.
+
+    ``enable-multi-threading`` stays **true** even at a pool of one, so this
+    is a resize and not a mode change: the receive thread remains separate
+    from the worker (with MT off, one thread must do both, which measured
+    15,170 socket drops in a run where a pool of one measured none), and
+    host-reservation lookup order and the disabling of ``dhcp-queue-control``
+    are unchanged.
+
+    A bundle from a control plane older than #980 carries no value; 1 is
+    assumed rather than Kea's 0, because "the field is absent" and "the
+    operator asked for auto-sizing" must not render the same way — the whole
+    point is that auto is the wrong answer here. An explicit 0 IS honoured
+    and hands sizing back to Kea.
+    """
+    size = server.get("kea_thread_pool_size")
+    return {
+        "enable-multi-threading": True,
+        "thread-pool-size": 1 if size is None else int(size),
+    }
+
+
 def render(
     bundle: dict[str, Any],
     *,
@@ -988,6 +1086,9 @@ def render(
         # 0.25, which would silently suppress the memfile writes that drive
         # lease-events → DDNS + the IPAM lease mirror. See _apply_lease_cache.
         "cache-threshold": float(server.get("lease_cache_threshold") or 0.0),
+        # #980 — see _multi_threading. Rendered on every bundle, so the ETag
+        # already covers it via the "server" block it reads from.
+        "multi-threading": _multi_threading(server),
         "renew-timer": 900,
         "rebind-timer": 1800,
         "hooks-libraries": [
@@ -996,25 +1097,13 @@ def render(
         "loggers": [
             {
                 "name": "kea-dhcp4",
-                # Two outputs by design:
-                #   * stdout — picked up by `docker logs` for the
-                #     existing operator workflow.
-                #   * file — tailed by ``LogShipper`` and shipped to
-                #     the control plane for the Logs UI's "DHCP
-                #     Activity" tab. Kea rotates the file in-process
-                #     via ``maxsize`` / ``maxver`` so we don't need
-                #     external logrotate.
-                "output_options": [
-                    {"output": "stdout"},
-                    {
-                        "output": "/var/log/kea/kea-dhcp4.log",
-                        "maxsize": 50_000_000,
-                        "maxver": 5,
-                        "flush": True,
-                    },
-                ],
+                "output_options": _log_outputs("kea-dhcp4"),
                 "severity": "INFO",
-            }
+            },
+            # #980 — appended, not merged into the parent: log4cplus resolves
+            # the most specific logger name, so this raises ONLY the two
+            # per-packet codes and leaves everything else at INFO.
+            *_quiet_packet_logger("kea-dhcp4", server),
         ],
     }
 
@@ -1184,6 +1273,11 @@ def render(
         ),
         # #637 — see the Dhcp4 block. Same group-wide lease-cache default.
         "cache-threshold": float(server.get("lease_cache_threshold") or 0.0),
+        # #980 — same pool size as Dhcp4. kea-dhcp6 is a separate process with
+        # its own pool, and it shares the node's CPU with kea-dhcp4, so
+        # leaving it on auto would put back most of the threads Dhcp4 just
+        # dropped.
+        "multi-threading": _multi_threading(server),
         "renew-timer": 900,
         "rebind-timer": 1800,
         "hooks-libraries": [
@@ -1193,17 +1287,11 @@ def render(
         "loggers": [
             {
                 "name": "kea-dhcp6",
-                "output_options": [
-                    {"output": "stdout"},
-                    {
-                        "output": "/var/log/kea/kea-dhcp6.log",
-                        "maxsize": 50_000_000,
-                        "maxver": 5,
-                        "flush": True,
-                    },
-                ],
+                "output_options": _log_outputs("kea-dhcp6"),
                 "severity": "INFO",
-            }
+            },
+            # #980 — see the Dhcp4 block.
+            *_quiet_packet_logger("kea-dhcp6", server),
         ],
     }
     # #637 — see the Dhcp4 block. Optional, so set conditionally.

--- a/agent/dhcp/spatium_dhcp_agent/socket_drops.py
+++ b/agent/dhcp/spatium_dhcp_agent/socket_drops.py
@@ -84,10 +84,11 @@ def read_socket_drops(
 ) -> dict[str, int] | None:
     """Snapshot ``{inode: sk_drops}`` for every DHCP-port UDP socket.
 
-    Returns ``None`` — never ``{}`` — when the counter cannot be read at
-    all, so a caller can report UNKNOWN rather than a zero that reads as
-    "no loss". ``{}`` is a real answer: procfs was readable and no DHCP
-    socket is currently open (Kea starting, or bound raw-only).
+    Returns ``None`` — never ``{}`` — when the counter cannot be read, so a
+    caller can report UNKNOWN rather than a zero that reads as "no loss".
+    A *partial* read is also ``None``: see the OSError branch below.
+    ``{}`` is a real answer: procfs was readable and no DHCP socket is
+    currently open (Kea starting, or bound raw-only).
     """
     merged: dict[str, int] = {}
     readable = False
@@ -96,11 +97,21 @@ def read_socket_drops(
             with open(path, encoding="ascii", errors="replace") as fh:
                 text = fh.read()
         except FileNotFoundError:
-            # No IPv6 stack, or not Linux. Not an error on its own.
+            # No IPv6 stack, or not Linux. Not an error on its own: an
+            # absent file has no sockets to account for, so the remaining
+            # answer is still complete.
             continue
         except OSError as e:
+            # A file that EXISTS and could not be read is different. Its
+            # sockets are unaccounted for, and returning the rest as a valid
+            # snapshot is worse than returning nothing: the missing inodes
+            # drop out of the baseline, and when the next read succeeds they
+            # come back as new sockets whose whole-lifetime sk_drops is
+            # attributed to that one bucket. On a socket that has been up for
+            # days that is a fabricated spike large enough to trip the
+            # alert. Fail the whole sample instead.
             log.debug("socket_drops_unreadable", path=path, error=str(e))
-            continue
+            return None
         readable = True
         merged.update(_parse_proc_udp(text, ports))
     return merged if readable else None
@@ -120,13 +131,24 @@ class SocketDropCounter:
         self._prev: dict[str, int] | None = None
 
     def sample(self) -> int | None:
-        """Drops since the previous call, or ``None`` if not measurable.
+        """Drops since the previous call, or ``None`` if not measurable."""
+        return self.sample_from(_PROC_UDP)
+
+    def sample_from(
+        self, paths: tuple[str, ...], ports: frozenset[int] = DHCP_PORTS
+    ) -> int | None:
+        """Drops since the previous call, reading ``paths``.
 
         The first call after start returns ``None``: with no baseline, the
         counters standing on the sockets are however much was lost before
         the agent came up, which belongs to no bucket in particular.
+
+        ``paths`` is a parameter only so the tests can drive this exact
+        method over fixture files. Production calls :meth:`sample`, which
+        supplies the real procfs paths — the tests must not reimplement the
+        arithmetic below, or they assert on a copy of it.
         """
-        current = read_socket_drops()
+        current = read_socket_drops(paths, ports)
         if current is None:
             self._prev = None
             return None

--- a/agent/dhcp/spatium_dhcp_agent/socket_drops.py
+++ b/agent/dhcp/spatium_dhcp_agent/socket_drops.py
@@ -1,0 +1,148 @@
+"""Per-socket kernel receive-drop counters for the DHCP listen ports (#980).
+
+Kea answers every packet it manages to read. When a burst arrives faster
+than its receive thread is scheduled, the loss happens one layer down — the
+kernel finds the socket's receive buffer full and drops the datagram before
+``recvmsg()`` ever sees it. Nothing inside Kea observes that, so every
+product surface reports a healthy server while clients retransmit.
+
+**``pkt4-receive-drop`` is not this number.** Measured against kea-dhcp4
+3.0.3 on 2026-09-06: a run that lost 9,700 datagrams to socket-buffer
+overflow left ``pkt4-receive-drop`` at exactly 0, because that counter
+covers packets Kea *read* and then discarded (unparseable, DROP class, no
+subnet). Both are worth reporting and they name different failures — this
+module supplies the one that moves when a node is out of CPU.
+
+The kernel exposes it per socket as the last column of ``/proc/net/udp``
+(``sk_drops``), which is the same event that increments the node-wide
+``Udp: RcvbufErrors`` in ``/proc/net/snmp``. We read the per-socket form
+deliberately: the node-wide counter is shared with every other UDP consumer
+in the network namespace — and the DHCP pod runs with host networking — so
+it cannot say the loss was ours.
+
+Only sockets bound to a DHCP service port are counted (67 for DHCPv4, 547
+for DHCPv6). The AF_PACKET socket Kea opens for ``dhcp-socket-type: raw``
+is *not* visible here — ``/proc/net/packet`` carries no drop column, and
+reading its statistics needs ``PACKET_STATISTICS`` on the socket itself,
+which only the owning process can do. That is a real blind spot for
+directly-attached broadcast traffic; relayed traffic, which is unicast and
+therefore arrives on the UDP fallback socket, is fully covered.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+# DHCPv4 server port and DHCPv6 server port. ``/proc/net/udp`` prints the
+# local port in hex, so these are compared post-parse rather than as text.
+DHCP_PORTS = frozenset({67, 547})
+
+_PROC_UDP = ("/proc/net/udp", "/proc/net/udp6")
+
+
+def _parse_proc_udp(text: str, ports: frozenset[int] = DHCP_PORTS) -> dict[str, int]:
+    """One ``/proc/net/udp`` body -> ``{inode: sk_drops}`` for DHCP ports.
+
+    Row layout (both the v4 and v6 files), whitespace-separated::
+
+        sl local_address rem_address st tx:rx tr:when retrnsmt uid
+        timeout inode ref pointer drops
+
+    ``local_address`` is ``<hex-addr>:<hex-port>``; ``drops`` is last.
+    Keying by inode rather than by address means a socket that Kea closes
+    and reopens on reconfiguration reads as a *new* counter starting at
+    zero instead of as a counter that went backwards.
+
+    ``ports`` is a parameter only so the tests can point it at an ephemeral
+    port: binding 67 needs privilege, and a fixture cannot prove the field
+    indices below are the ones this kernel actually uses. Production always
+    passes the default.
+    """
+    out: dict[str, int] = {}
+    for line in text.splitlines()[1:]:  # [0] is the column header
+        fields = line.split()
+        if len(fields) < 13:
+            continue
+        local = fields[1]
+        if ":" not in local:
+            continue
+        try:
+            port = int(local.rsplit(":", 1)[1], 16)
+            drops = int(fields[-1])
+        except ValueError:
+            continue
+        if port not in ports:
+            continue
+        out[fields[9]] = drops
+    return out
+
+
+def read_socket_drops(
+    paths: tuple[str, ...] = _PROC_UDP, ports: frozenset[int] = DHCP_PORTS
+) -> dict[str, int] | None:
+    """Snapshot ``{inode: sk_drops}`` for every DHCP-port UDP socket.
+
+    Returns ``None`` — never ``{}`` — when the counter cannot be read at
+    all, so a caller can report UNKNOWN rather than a zero that reads as
+    "no loss". ``{}`` is a real answer: procfs was readable and no DHCP
+    socket is currently open (Kea starting, or bound raw-only).
+    """
+    merged: dict[str, int] = {}
+    readable = False
+    for path in paths:
+        try:
+            with open(path, encoding="ascii", errors="replace") as fh:
+                text = fh.read()
+        except FileNotFoundError:
+            # No IPv6 stack, or not Linux. Not an error on its own.
+            continue
+        except OSError as e:
+            log.debug("socket_drops_unreadable", path=path, error=str(e))
+            continue
+        readable = True
+        merged.update(_parse_proc_udp(text, ports))
+    return merged if readable else None
+
+
+class SocketDropCounter:
+    """Turns per-socket monotonic ``sk_drops`` into a per-bucket delta.
+
+    Each socket's counter is monotonic for the life of *that* socket and
+    disappears with it, so the aggregate is summed per inode rather than in
+    total: a socket that goes away must not make the fleet-wide sum fall
+    (which would read as a counter reset), and a socket that appears
+    contributes its own count from zero.
+    """
+
+    def __init__(self) -> None:
+        self._prev: dict[str, int] | None = None
+
+    def sample(self) -> int | None:
+        """Drops since the previous call, or ``None`` if not measurable.
+
+        The first call after start returns ``None``: with no baseline, the
+        counters standing on the sockets are however much was lost before
+        the agent came up, which belongs to no bucket in particular.
+        """
+        current = read_socket_drops()
+        if current is None:
+            self._prev = None
+            return None
+        prev = self._prev
+        self._prev = current
+        if prev is None:
+            return None
+        total = 0
+        for inode, value in current.items():
+            baseline = prev.get(inode, 0)
+            # max() guards a same-inode counter that appears to fall. It
+            # cannot happen for sk_drops, but an inode number reused by a
+            # different socket inside one interval would look exactly like
+            # that, and a negative contribution is never the right answer.
+            total += max(0, value - baseline)
+        return total
+
+
+__all__ = ["DHCP_PORTS", "SocketDropCounter", "read_socket_drops"]

--- a/agent/dhcp/tests/test_metrics.py
+++ b/agent/dhcp/tests/test_metrics.py
@@ -1,15 +1,19 @@
 """Tests for the Kea metrics poller.
 
-Covers the three interesting behaviors:
+Covers the interesting behaviors:
   • first tick after startup establishes a baseline, doesn't report;
   • second tick with a positive delta gets reported upstream;
-  • counter-reset (Kea restart) is detected and the bucket is dropped.
+  • counter-reset (Kea restart) is detected and the bucket is dropped;
+  • the #980 loss counters ride the same delta, and ``socket_drop`` — which
+    comes from procfs rather than from Kea — stays in lockstep with them.
 
 We test ``_parse_snapshot`` + ``_compute_delta`` directly so the HTTP
 client stays out of the test path.
 """
 
 from __future__ import annotations
+
+from datetime import UTC, datetime
 
 from spatium_dhcp_agent.config import AgentConfig
 from spatium_dhcp_agent.metrics import MetricsPoller, _parse_snapshot
@@ -45,6 +49,9 @@ def test_parse_snapshot_picks_expected_columns():
         "decline": 0,
         "release": 2,
         "inform": 0,
+        # #980 — absent from this response, so 0. The column exists either
+        # way; a Kea too old to publish it is not a Kea that dropped nothing.
+        "receive_drop": 0,
     }
 
 
@@ -130,6 +137,7 @@ def test_second_tick_emits_delta(tmp_path):
         "decline": 0,
         "release": 1,
         "inform": 0,
+        "receive_drop": 0,
     }
 
 
@@ -183,4 +191,119 @@ def test_counter_reset_drops_bucket(tmp_path):
         "decline": 0,
         "release": 0,
         "inform": 0,
+        "receive_drop": 0,
     }
+
+
+# ── #980: the loss counters ─────────────────────────────────────────────────
+
+
+def test_receive_drop_folds_both_address_families():
+    """v4 and v6 are separate daemons sharing one row, like every other
+    column here — so their drop counters sum rather than one overwriting
+    the other."""
+    resp = _snapshot({"pkt4-receive-drop": 4, "pkt6-receive-drop": 3})
+    assert _parse_snapshot(resp)["receive_drop"] == 7
+
+
+class _FakeResponse:
+    status_code = 200
+
+
+class _FakeClient:
+    """Stands in for httpx.Client and records the JSON body actually posted."""
+
+    def __init__(self, sink: list):
+        self._sink = sink
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def post(self, url, json=None, headers=None):
+        self._sink.append(json)
+        return _FakeResponse()
+
+
+def _posted_body(tmp_path, monkeypatch, socket_drop):
+    """Run the REAL ``_report`` and return the body it put on the wire."""
+    p = _poller(tmp_path)
+    sink: list = []
+    monkeypatch.setattr(p, "_client", lambda: _FakeClient(sink))
+    p._report(datetime(2026, 9, 6, 12, 0, tzinfo=UTC), {"discover": 3}, socket_drop)
+    assert len(sink) == 1
+    return sink[0]
+
+
+def test_wire_body_carries_socket_drop_zero_as_a_value(tmp_path, monkeypatch):
+    """Zero is a measurement and has to appear in the payload as 0.
+
+    The server stores an omitted field as NULL, and NULL means "nobody
+    looked" — so a working agent that measured no loss must not be filed
+    under the same label as an agent that cannot measure at all. Asserts on
+    the posted body rather than on a stubbed ``_report``, or the test would
+    pass for a ``_report`` that silently dropped the field.
+    """
+    body = _posted_body(tmp_path, monkeypatch, 0)
+    assert "socket_drop" in body
+    assert body["socket_drop"] == 0
+    assert body["discover"] == 3
+
+
+def test_wire_body_carries_none_when_unmeasurable(tmp_path, monkeypatch):
+    """The other half: unknown travels as an explicit null, not as 0 and not
+    by omission (omission would be indistinguishable, but being explicit is
+    what makes an older control plane's 422 loud rather than silent)."""
+    body = _posted_body(tmp_path, monkeypatch, None)
+    assert "socket_drop" in body
+    assert body["socket_drop"] is None
+
+
+def test_one_run_iteration_samples_both_counters_together(tmp_path, monkeypatch):
+    """Drive the REAL ``run()`` loop for two ticks.
+
+    Both baselines must advance on the same ticks: a bucket that is thrown
+    away (agent start, Kea restart) throws away both deltas, and a bucket
+    that is reported carries two numbers covering the same interval. If only
+    one advanced, "drops against DISCOVERs" — the first comparison anyone
+    makes — would span different windows.
+    """
+    p = _poller(tmp_path)
+    sink: list = []
+    monkeypatch.setattr(p, "_client", lambda: _FakeClient(sink))
+
+    kea = iter([{"discover": 0}, {"discover": 7}])
+    monkeypatch.setattr(p, "_poll_kea", lambda: next(kea, None))
+
+    samples = iter([11, 22])
+    sock_calls: list = []
+
+    def _sample():
+        v = next(samples, None)
+        sock_calls.append(v)
+        return v
+
+    monkeypatch.setattr(p._socket, "sample", _sample)
+    # Stop after the second tick rather than sleeping 60 s.
+    real_wait = p._stop.wait
+    ticks = {"n": 0}
+
+    def _wait(timeout=None):
+        ticks["n"] += 1
+        if ticks["n"] >= 2:
+            p._stop.set()
+        return real_wait(0)
+
+    monkeypatch.setattr(p._stop, "wait", _wait)
+
+    p.run()
+
+    # Two ticks -> two socket samples; only the second tick had a Kea
+    # baseline, so exactly one bucket was posted, carrying that tick's
+    # socket sample and not the first one.
+    assert sock_calls == [11, 22]
+    assert len(sink) == 1
+    assert sink[0]["discover"] == 7
+    assert sink[0]["socket_drop"] == 22

--- a/agent/dhcp/tests/test_render_kea_packet_path.py
+++ b/agent/dhcp/tests/test_render_kea_packet_path.py
@@ -1,0 +1,152 @@
+"""#980 — the two Kea packet-path settings, in both daemon blocks.
+
+Both are rendered rather than left to Kea's defaults, and both defaults were
+chosen from measurement against kea-dhcp4 3.0.3 (see
+``DHCPServerGroup.kea_thread_pool_size`` for the numbers). What these tests
+protect is the wiring: a value that is stored, shipped and then not rendered
+is a silent no-op, which is the failure class #430 / #734 / #899 each found
+one instance of.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from spatium_dhcp_agent.render_kea import render
+
+
+def _bundle(**server_extra) -> dict:
+    server = {"name": "dhcp1", "interfaces": ["eth0"]}
+    server.update(server_extra)
+    return {
+        "server": server,
+        "global_options": {"lease_time": 3600},
+        "scopes": [
+            {
+                "subnet_cidr": "192.0.2.0/24",
+                "lease_time": 3600,
+                "pools": [
+                    {
+                        "start_ip": "192.0.2.100",
+                        "end_ip": "192.0.2.200",
+                        "pool_type": "dynamic",
+                    }
+                ],
+                "options": {},
+            },
+            {
+                "subnet_cidr": "2001:db8::/64",
+                "address_family": "ipv6",
+                "v6_address_mode": "stateful",
+                "lease_time": 3600,
+                "pools": [
+                    {
+                        "start_ip": "2001:db8::100",
+                        "end_ip": "2001:db8::200",
+                        "pool_type": "dynamic",
+                    }
+                ],
+                "options": {},
+            },
+        ],
+    }
+
+
+# ── thread-pool-size ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("daemon", ["Dhcp4", "Dhcp6"])
+def test_thread_pool_size_is_rendered_from_the_bundle(daemon):
+    out = render(_bundle(kea_thread_pool_size=3))[daemon]
+    assert out["multi-threading"]["thread-pool-size"] == 3
+
+
+@pytest.mark.parametrize("daemon", ["Dhcp4", "Dhcp6"])
+def test_multi_threading_stays_enabled_at_a_pool_of_one(daemon):
+    """A pool of one is a resize, NOT ``enable-multi-threading: false``.
+
+    With MT off, one thread must both receive and process; measured, that
+    was 15,170 socket drops in a run where a pool of one had none. It also
+    changes host-reservation lookup order and re-enables
+    ``dhcp-queue-control``. Rendering it by accident would trade a
+    throughput win for a semantics change nobody asked for.
+    """
+    out = render(_bundle(kea_thread_pool_size=1))[daemon]
+    assert out["multi-threading"]["enable-multi-threading"] is True
+
+
+@pytest.mark.parametrize("daemon", ["Dhcp4", "Dhcp6"])
+def test_zero_is_passed_through_as_keas_auto_sizing(daemon):
+    """0 is a real value — the operator opting back into Kea's own sizing —
+    and must not be coalesced to the default it exists to escape."""
+    out = render(_bundle(kea_thread_pool_size=0))[daemon]
+    assert out["multi-threading"]["thread-pool-size"] == 0
+
+
+@pytest.mark.parametrize("daemon", ["Dhcp4", "Dhcp6"])
+def test_a_bundle_from_an_older_control_plane_gets_one_not_auto(daemon):
+    """Absent means 1, not 0. "The field is missing" and "the operator asked
+    for auto" must not render the same way: auto is the behaviour this
+    setting exists to replace."""
+    out = render(_bundle())[daemon]
+    assert out["multi-threading"]["thread-pool-size"] == 1
+
+
+# ── per-packet logging ──────────────────────────────────────────────────────
+
+
+def _loggers(out, name):
+    return [lg for lg in out["loggers"] if lg["name"] == name]
+
+
+@pytest.mark.parametrize(
+    ("daemon", "root"), [("Dhcp4", "kea-dhcp4"), ("Dhcp6", "kea-dhcp6")]
+)
+def test_packet_logging_on_by_default_leaves_the_child_alone(daemon, root):
+    """Default must be byte-identical to what shipped before #980: no
+    override at all, so the child inherits the parent's INFO."""
+    out = render(_bundle())[daemon]
+    assert _loggers(out, f"{root}.packets") == []
+    assert _loggers(out, root)[0]["severity"] == "INFO"
+
+
+@pytest.mark.parametrize(
+    ("daemon", "root"), [("Dhcp4", "kea-dhcp4"), ("Dhcp6", "kea-dhcp6")]
+)
+def test_disabling_packet_logging_raises_only_that_child(daemon, root):
+    out = render(_bundle(kea_packet_logging=False))[daemon]
+    quiet = _loggers(out, f"{root}.packets")
+    assert len(quiet) == 1
+    assert quiet[0]["severity"] == "WARN"
+    # The parent stays at INFO, or this would silence the lease lines the
+    # Logs tab is built on.
+    assert _loggers(out, root)[0]["severity"] == "INFO"
+
+
+@pytest.mark.parametrize(
+    ("daemon", "root"), [("Dhcp4", "kea-dhcp4"), ("Dhcp6", "kea-dhcp6")]
+)
+def test_the_daemon_child_logger_is_never_silenced(daemon, root):
+    """``kea-dhcpN.dhcpN`` looks like the same kind of noise and is not.
+
+    At INFO it carries ``DHCP4_OPEN_SOCKETS_FAILED`` — a real failure Kea
+    logs at INFO — plus ``DHCP4_CONFIG_COMPLETE``, ``DHCP4_STARTED`` and
+    ``DHCP4_MULTI_THREADING_INFO``, the last being the only line that
+    reports whether the pool size above actually took effect. Verified
+    against kea-dhcp4 3.0.3: silencing it loses all four.
+    """
+    out = render(_bundle(kea_packet_logging=False))[daemon]
+    assert _loggers(out, f"{root}.{daemon.lower()}") == []
+
+
+@pytest.mark.parametrize(
+    ("daemon", "root"), [("Dhcp4", "kea-dhcp4"), ("Dhcp6", "kea-dhcp6")]
+)
+def test_the_quiet_child_keeps_the_parents_appenders(daemon, root):
+    """log4cplus does not inherit appenders into a logger configured by
+    name, so a child with no ``output_options`` sends its WARNs and ERRORs
+    nowhere at all — which would be a silencing, not a level change."""
+    out = render(_bundle(kea_packet_logging=False))[daemon]
+    quiet = _loggers(out, f"{root}.packets")[0]
+    outputs = {o["output"] for o in quiet["output_options"]}
+    assert outputs == {"stdout", f"/var/log/kea/{root}.log"}

--- a/agent/dhcp/tests/test_render_kea_packet_path.py
+++ b/agent/dhcp/tests/test_render_kea_packet_path.py
@@ -142,11 +142,63 @@ def test_the_daemon_child_logger_is_never_silenced(daemon, root):
 @pytest.mark.parametrize(
     ("daemon", "root"), [("Dhcp4", "kea-dhcp4"), ("Dhcp6", "kea-dhcp6")]
 )
-def test_the_quiet_child_keeps_the_parents_appenders(daemon, root):
-    """log4cplus does not inherit appenders into a logger configured by
-    name, so a child with no ``output_options`` sends its WARNs and ERRORs
-    nowhere at all — which would be a silencing, not a level change."""
+def test_the_quiet_child_declares_no_appenders_of_its_own(daemon, root):
+    """The child must INHERIT the parent's appenders, not copy them.
+
+    Verified against kea-dhcp4 3.0.3: a child configured with only a
+    severity still reaches both stdout and the shipped file, so its WARNs
+    and ERRORs are not lost. Copying the parent's ``output_options`` also
+    works, but puts a second RollingFileAppender on the same path with its
+    own rotation state — at 50 MB one renames the file while the other holds
+    the old descriptor.
+    """
     out = render(_bundle(kea_packet_logging=False))[daemon]
     quiet = _loggers(out, f"{root}.packets")[0]
-    outputs = {o["output"] for o in quiet["output_options"]}
-    assert outputs == {"stdout", f"/var/log/kea/{root}.log"}
+    assert "output_options" not in quiet
+    # Exactly one appender set per file, on the parent.
+    parent = _loggers(out, root)[0]
+    assert {o["output"] for o in parent["output_options"]} == {
+        "stdout",
+        f"/var/log/kea/{root}.log",
+    }
+
+
+# ── the HA hook's own thread pools (#980 review finding) ────────────────────
+
+
+def _ha_bundle(**server_extra) -> dict:
+    b = _bundle(**server_extra)
+    b["failover"] = {
+        "this_server_name": "a",
+        "mode": "hot-standby",
+        "peers": [
+            {"name": "a", "url": "http://10.0.0.1:8000/", "role": "primary"},
+            {"name": "b", "url": "http://10.0.0.2:8000/", "role": "standby"},
+        ],
+    }
+    return b
+
+
+def _ha_relationship(out):
+    hook = [h for h in out["hooks-libraries"] if "ha.so" in h["library"]][0]
+    return hook["parameters"]["high-availability"][0]
+
+
+def test_ha_http_threads_do_not_follow_the_packet_pool():
+    """Kea reads ``http-listener-threads: 0`` as "same as thread-pool-size",
+    not as an independent auto-size — measured by counting OS threads: with
+    the HA hook loaded, pool=1 gave 8 threads and pool=8 gave 29, three pools
+    of N. Left alone, #980's pool of 1 would have serialised HA peer traffic
+    as a side effect. They are pinned instead."""
+    rel = _ha_relationship(render(_ha_bundle(kea_thread_pool_size=1))["Dhcp4"])
+    mt = rel["multi-threading"]
+    assert mt["http-listener-threads"] > 1
+    assert mt["http-client-threads"] > 1
+    assert mt["enable-multi-threading"] is True
+    assert mt["http-dedicated-listener"] is True
+
+
+def test_ha_http_threads_are_the_same_whatever_the_packet_pool():
+    one = _ha_relationship(render(_ha_bundle(kea_thread_pool_size=1))["Dhcp4"])
+    many = _ha_relationship(render(_ha_bundle(kea_thread_pool_size=16))["Dhcp4"])
+    assert one["multi-threading"] == many["multi-threading"]

--- a/agent/dhcp/tests/test_socket_drops.py
+++ b/agent/dhcp/tests/test_socket_drops.py
@@ -137,57 +137,109 @@ def test_dhcp_ports_are_the_server_ports():
 
 
 # ── delta accumulation ──────────────────────────────────────────────────────
+#
+# These drive the REAL ``SocketDropCounter.sample()`` by pointing it at
+# fixture files on disk. An earlier version of this file subclassed it and
+# reimplemented ``sample()``, which meant the five tests below asserted on a
+# copy of the logic and would have passed with the production method
+# arbitrarily broken.
 
 
-class _Counter(SocketDropCounter):
-    """SocketDropCounter driven from a scripted list of snapshots."""
-
-    def __init__(self, snapshots):
-        super().__init__()
-        self._snapshots = list(snapshots)
-
-    def sample(self):
-        snap = self._snapshots.pop(0)
-        prev = self._prev
-        if snap is None:
-            self._prev = None
-            return None
-        self._prev = snap
-        if prev is None:
-            return None
-        return sum(max(0, v - prev.get(k, 0)) for k, v in snap.items())
+def _write_proc(tmp_path, name, rows):
+    """Write a /proc/net/udp-shaped file and return its path."""
+    path = tmp_path / name
+    path.write_text(_proc(*rows))
+    return str(path)
 
 
-def test_first_sample_has_no_baseline():
-    c = _Counter([{"1": 40}])
-    assert c.sample() is None
+def _counter_over(tmp_path, snapshots):
+    """A real SocketDropCounter reading a file this helper rewrites per tick.
+
+    ``read_socket_drops`` opens the path on every call, so rewriting the file
+    between ``sample()`` calls is exactly what a changing kernel table looks
+    like to it.
+    """
+    path = tmp_path / "udp"
+    counter = SocketDropCounter()
+
+    def tick(rows):
+        # rows=None models procfs becoming unreadable: point the counter at a
+        # path that does not exist.
+        if rows is None:
+            return counter.sample_from(("/nonexistent/net/udp",))
+        path.write_text(_proc(*rows))
+        return counter.sample_from((str(path),))
+
+    return [tick(r) for r in snapshots]
 
 
-def test_delta_is_per_socket():
-    c = _Counter([{"1": 40}, {"1": 47}])
-    c.sample()
-    assert c.sample() == 7
+def test_first_sample_has_no_baseline(tmp_path):
+    (out,) = _counter_over(tmp_path, [[_row("0043", "1", 40)]])
+    assert out is None
 
 
-def test_a_socket_disappearing_does_not_read_as_negative():
+def test_delta_is_per_socket(tmp_path):
+    out = _counter_over(
+        tmp_path, [[_row("0043", "1", 40)], [_row("0043", "1", 47)]]
+    )
+    assert out == [None, 7]
+
+
+def test_a_socket_disappearing_does_not_read_as_negative(tmp_path):
     """Kea closes and reopens its sockets on reconfiguration. Summing the
     totals would show the fleet-wide count falling, which looks exactly like
     a counter reset; summing per inode gives the right answer of 0."""
-    c = _Counter([{"1": 500, "2": 500}, {"2": 500}])
-    c.sample()
-    assert c.sample() == 0
+    out = _counter_over(
+        tmp_path,
+        [
+            [_row("0043", "1", 500), _row("0223", "2", 500)],
+            [_row("0223", "2", 500)],
+        ],
+    )
+    assert out == [None, 0]
 
 
-def test_a_new_socket_contributes_from_zero():
-    c = _Counter([{"1": 500}, {"1": 500, "2": 12}])
-    c.sample()
-    assert c.sample() == 12
+def test_a_new_socket_contributes_from_zero(tmp_path):
+    out = _counter_over(
+        tmp_path,
+        [
+            [_row("0043", "1", 500)],
+            [_row("0043", "1", 500), _row("0223", "2", 12)],
+        ],
+    )
+    assert out == [None, 12]
 
 
-def test_unreadable_procfs_clears_the_baseline():
+def test_unreadable_procfs_clears_the_baseline(tmp_path):
     """If a sample cannot be taken, the next one must not diff against a
     stale baseline and report a bucket's worth of drops as one spike."""
-    c = _Counter([{"1": 10}, None, {"1": 900}])
-    c.sample()
-    assert c.sample() is None
-    assert c.sample() is None
+    out = _counter_over(
+        tmp_path, [[_row("0043", "1", 10)], None, [_row("0043", "1", 900)]]
+    )
+    assert out == [None, None, None]
+
+
+def test_a_partial_read_is_not_a_sample(tmp_path):
+    """One of the two procfs files unreadable must fail the WHOLE sample.
+
+    Returning the half that read as a valid snapshot drops the missing
+    inodes out of the baseline; when the next read succeeds they come back
+    as brand-new sockets and their entire lifetime ``sk_drops`` is charged
+    to that one bucket — a fabricated spike, on a rule whose floor is one
+    packet.
+    """
+    v4 = _write_proc(tmp_path, "udp", [_row("0043", "1", 5)])
+    v6 = _write_proc(tmp_path, "udp6", [_row("0223", "2", 5000)])
+
+    both = read_socket_drops(paths=(v4, v6))
+    assert both == {"1": 5, "2": 5000}
+
+    # v6 present but unreadable (a directory stands in for EISDIR — any
+    # OSError that is not FileNotFoundError takes the same branch).
+    unreadable = tmp_path / "unreadable"
+    unreadable.mkdir()
+    assert read_socket_drops(paths=(v4, str(unreadable))) is None
+
+    # A genuinely absent file is different and stays a valid partial answer:
+    # no IPv6 stack means no v6 sockets to miss.
+    assert read_socket_drops(paths=(v4, str(tmp_path / "gone"))) == {"1": 5}

--- a/agent/dhcp/tests/test_socket_drops.py
+++ b/agent/dhcp/tests/test_socket_drops.py
@@ -1,0 +1,193 @@
+"""Per-socket kernel drop counters (#980).
+
+The parser reads field indices out of ``/proc/net/udp``. A fixture cannot
+prove those indices are right — it can only prove they match the fixture —
+so the load-bearing test here binds a **real socket**, overruns its receive
+buffer, and checks that the number the parser returns is the number the
+kernel just counted. The fixture tests cover the shapes a real kernel will
+not produce on demand (a socket vanishing, an inode reused, procfs absent).
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+
+import pytest
+
+from spatium_dhcp_agent.socket_drops import (
+    DHCP_PORTS,
+    SocketDropCounter,
+    _parse_proc_udp,
+    read_socket_drops,
+)
+
+# One header line plus rows, exactly as the kernel formats them.
+_HEADER = (
+    "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when "
+    "retrnsmt   uid  timeout inode ref pointer drops"
+)
+
+
+def _row(port_hex: str, inode: str, drops: int) -> str:
+    return (
+        f"  181: 00000000:{port_hex} 00000000:0000 07 00000000:00000000 "
+        f"00:00000000 00000000     0        0 {inode} 2 0000000000000000 {drops}"
+    )
+
+
+def _proc(*rows: str) -> str:
+    return "\n".join([_HEADER, *rows]) + "\n"
+
+
+# ── the real-kernel test ────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or not os.path.exists("/proc/net/udp"),
+    reason="/proc/net/udp is Linux-only",
+)
+def test_parser_reads_the_real_sk_drops_column():
+    """Bind a socket, make the kernel drop into it, read the count back.
+
+    This is the only test that can catch a wrong field index, and the only
+    one that would notice a future kernel changing the row layout.
+
+    Deliberately an ephemeral port rather than 67: binding a privileged port
+    would need root, and the point of the check is the column offsets, which
+    do not depend on which port the socket is on.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sender = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+        inode = str(os.stat(f"/proc/self/fd/{sock.fileno()}").st_ino)
+        ports = frozenset({port})
+
+        before = read_socket_drops(ports=ports)
+        assert before is not None
+        assert inode in before, (
+            "parser did not find a socket that is definitely bound — the "
+            "local_address or inode field index is wrong"
+        )
+        assert before[inode] == 0
+
+        # Smallest buffer the kernel will take, then overrun it. Nothing
+        # reads from the socket, so the queue fills and every later datagram
+        # is dropped with sk_drops incremented.
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 1024)
+        for _ in range(200):
+            try:
+                sender.sendto(b"x" * 1400, ("127.0.0.1", port))
+            except OSError:  # ENOBUFS on the send side; not what we measure
+                pass
+
+        after = read_socket_drops(ports=ports)
+        assert after is not None
+        assert after[inode] > 0, (
+            "the kernel dropped datagrams but the parser reported none — the "
+            "drops field index is wrong"
+        )
+    finally:
+        sock.close()
+        sender.close()
+
+
+# ── parsing ─────────────────────────────────────────────────────────────────
+
+
+def test_only_dhcp_ports_are_counted():
+    text = _proc(
+        _row("0043", "111", 7),  # 67  — DHCPv4 server
+        _row("0223", "222", 3),  # 547 — DHCPv6 server
+        _row("0044", "333", 99),  # 68  — a client port, not ours
+        _row("0035", "444", 99),  # 53  — DNS on a host-networked node
+    )
+    assert _parse_proc_udp(text) == {"111": 7, "222": 3}
+
+
+def test_malformed_rows_are_skipped_not_fatal():
+    """procfs is a kernel interface, but the agent must not die on a short
+    read or a row it does not understand — the counter is diagnostics, and
+    taking the metrics poller down with it would cost more than it reports."""
+    text = _proc(
+        "  1: garbage",
+        _row("0043", "111", 5),
+        "  2: 00000000:ZZZZ 00000000:0000 07 x x x x x x x x x",
+    )
+    assert _parse_proc_udp(text) == {"111": 5}
+
+
+def test_missing_procfs_reports_unknown_not_zero():
+    """The distinction the whole feature rests on: None means nobody looked."""
+    assert read_socket_drops(paths=("/nonexistent/net/udp",)) is None
+
+
+def test_present_but_no_dhcp_socket_is_zero_not_unknown():
+    """An empty answer from a readable procfs is a real measurement: Kea is
+    starting, or bound raw-only. Reporting it as unknown would hide a working
+    agent behind the same label as a broken one."""
+    assert read_socket_drops(paths=("/proc/net/udp",), ports=frozenset({1})) == {}
+
+
+def test_dhcp_ports_are_the_server_ports():
+    assert DHCP_PORTS == frozenset({67, 547})
+
+
+# ── delta accumulation ──────────────────────────────────────────────────────
+
+
+class _Counter(SocketDropCounter):
+    """SocketDropCounter driven from a scripted list of snapshots."""
+
+    def __init__(self, snapshots):
+        super().__init__()
+        self._snapshots = list(snapshots)
+
+    def sample(self):
+        snap = self._snapshots.pop(0)
+        prev = self._prev
+        if snap is None:
+            self._prev = None
+            return None
+        self._prev = snap
+        if prev is None:
+            return None
+        return sum(max(0, v - prev.get(k, 0)) for k, v in snap.items())
+
+
+def test_first_sample_has_no_baseline():
+    c = _Counter([{"1": 40}])
+    assert c.sample() is None
+
+
+def test_delta_is_per_socket():
+    c = _Counter([{"1": 40}, {"1": 47}])
+    c.sample()
+    assert c.sample() == 7
+
+
+def test_a_socket_disappearing_does_not_read_as_negative():
+    """Kea closes and reopens its sockets on reconfiguration. Summing the
+    totals would show the fleet-wide count falling, which looks exactly like
+    a counter reset; summing per inode gives the right answer of 0."""
+    c = _Counter([{"1": 500, "2": 500}, {"2": 500}])
+    c.sample()
+    assert c.sample() == 0
+
+
+def test_a_new_socket_contributes_from_zero():
+    c = _Counter([{"1": 500}, {"1": 500, "2": 12}])
+    c.sample()
+    assert c.sample() == 12
+
+
+def test_unreadable_procfs_clears_the_baseline():
+    """If a sample cannot be taken, the next one must not diff against a
+    stale baseline and report a bucket's worth of drops as one spike."""
+    c = _Counter([{"1": 10}, None, {"1": 900}])
+    c.sample()
+    assert c.sample() is None
+    assert c.sample() is None

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -425,6 +425,10 @@ backend/alembic/versions/c8e3a7f10b54_ai_usage_observability.py:drop_column:77
 backend/alembic/versions/c8e3a7f10b54_ai_usage_observability.py:drop_column:78
 backend/alembic/versions/c8e4f7a91d36_session_viewer.py:drop_column:65
 backend/alembic/versions/c8e4f7a91d36_session_viewer.py:drop_column:66
+backend/alembic/versions/c93f1a72e408_dhcp_drop_metrics_and_thread_pool.py:drop_column:84
+backend/alembic/versions/c93f1a72e408_dhcp_drop_metrics_and_thread_pool.py:drop_column:85
+backend/alembic/versions/c93f1a72e408_dhcp_drop_metrics_and_thread_pool.py:drop_column:86
+backend/alembic/versions/c93f1a72e408_dhcp_drop_metrics_and_thread_pool.py:drop_column:87
 backend/alembic/versions/c9a1f4e07b52_dhcp_scope_dns_track_dynamic_leases.py:drop_column:39
 backend/alembic/versions/c9a1f7e0b234_dns_zone_masters.py:drop_column:43
 backend/alembic/versions/c9a2f61e740b_wol_run_verify_params.py:drop_column:59

--- a/backend/alembic/versions/c93f1a72e408_dhcp_drop_metrics_and_thread_pool.py
+++ b/backend/alembic/versions/c93f1a72e408_dhcp_drop_metrics_and_thread_pool.py
@@ -1,0 +1,87 @@
+"""#980 — per-bucket DHCP loss counters + two Kea packet-path knobs.
+
+Two columns on ``dhcp_metric_sample`` and two on ``dhcp_server_group``.
+
+``receive_drop`` / ``socket_drop`` are deliberately NULLABLE with no
+server_default. They are not "zero until measured": zero means the agent
+looked and found no loss, and NULL means nobody looked — an agent older
+than this change, or one whose runtime cannot read ``/proc/net/udp``. A
+default of 0 would paint the entire pre-upgrade history, and every
+not-yet-upgraded agent, as a server that has never dropped a packet, which
+is the exact false-reassurance this issue is about.
+
+``kea_thread_pool_size`` defaults to 1 and IS written to existing rows,
+because leaving Kea's own default in place is the bug. Kea sizes its
+packet-processing pool from ``hardware_concurrency()`` — the node's CPU
+count — with no regard for the cgroup share it actually holds, so on a
+4 vCPU appliance it starts 4 workers that compete with the one thread
+that has to drain the receive socket. Measured against kea-dhcp4 3.0.3
+(memfile backend, relayed unicast) on 2026-09-06, offered 12,000 pkt/s:
+
+    cgroup CPU   pool=1 served      pool=2         pool=4 (= "auto" here)
+    0.25         18.4k-22.5k        9.6k-11.6k     6.5k-7.1k
+    4.0 (none)   79.5k-95.6k        75.8k-77.5k    44.5k
+
+Every DHCP group therefore re-renders once on upgrade and its Kea
+config-reloads. ``0`` restores Kea's auto-sizing for an operator who
+measures otherwise.
+
+``kea_packet_logging`` defaults to **true**, which is exactly today's
+behaviour, because turning it off removes two log codes an operator can
+currently see (``DHCP4_PACKET_RECEIVED`` / ``DHCP4_PACKET_SEND``, carrying
+the source address and interface). It is worth 1.30x on the same rig —
+24,997-26,077 packets served against 19,026-20,403 — so it is offered as a
+lever for a site at the knee rather than taken away from everyone. Same
+reasoning as #637's lease cache, which also preserves observable behaviour
+and lets the operator opt into the throughput.
+
+Revision ID: c93f1a72e408
+Revises: d4a9e37b2c15
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c93f1a72e408"
+down_revision: str | None = "d4a9e37b2c15"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "dhcp_metric_sample",
+        sa.Column("receive_drop", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "dhcp_metric_sample",
+        sa.Column("socket_drop", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "dhcp_server_group",
+        sa.Column(
+            "kea_thread_pool_size",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+    )
+    op.add_column(
+        "dhcp_server_group",
+        sa.Column(
+            "kea_packet_logging",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("dhcp_server_group", "kea_packet_logging")
+    op.drop_column("dhcp_server_group", "kea_thread_pool_size")
+    op.drop_column("dhcp_metric_sample", "socket_drop")
+    op.drop_column("dhcp_metric_sample", "receive_drop")

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -568,6 +568,12 @@ async def agent_config_longpoll(
                             # falls back to these when the scope value is null.
                             "lease_cache_threshold": bundle.lease_cache_threshold,
                             "lease_cache_max_age": bundle.lease_cache_max_age,
+                            # #980 — Kea's packet-worker pool. Serialized here
+                            # as well as folded into the ETag; those are
+                            # separate steps and skipping this one is the #430
+                            # silent no-op the lease-cache keys above call out.
+                            "kea_thread_pool_size": bundle.kea_thread_pool_size,
+                            "kea_packet_logging": bundle.kea_packet_logging,
                         },
                         "scopes": [
                             {
@@ -1377,6 +1383,12 @@ class DHCPMetricReport(BaseModel):
     decline: int = 0
     release: int = 0
     inform: int = 0
+    # #980 — loss counters. ``None`` (the default, and what an agent older
+    # than #980 sends by omission) means NOT MEASURED and is stored as NULL;
+    # 0 means measured and no loss. They must not collapse together, or an
+    # un-upgraded fleet reads as a fleet that has never dropped a packet.
+    receive_drop: int | None = None
+    socket_drop: int | None = None
 
 
 @router.post("/metrics")
@@ -1385,7 +1397,25 @@ async def agent_metrics(
     db: DB,
     auth: tuple[DHCPServer, dict[str, Any]] = Depends(_auth_agent),
 ) -> dict[str, str]:
-    """Ingest one sample row. Idempotent on ``(server_id, bucket_at)``."""
+    """Ingest one sample row, accumulating into ``(server_id, bucket_at)``.
+
+    A second report for a bucket that already exists is ADDED to it rather
+    than replacing it, because these are counter *deltas* over disjoint
+    intervals and two of them landing in one bucket are two things that both
+    happened. Replacing was the original behaviour and it silently discarded
+    a poll: the agent floors ``bucket_at`` to the minute while its own
+    interval is 60 s ± 3 s of jitter, so a tick early in a minute followed by
+    a 57-59 s gap puts two genuinely different deltas in the same bucket —
+    roughly one bucket in forty. Harmless-looking on a traffic chart, and
+    exactly wrong for the #980 loss counters, where the discarded minute is
+    the one an operator is looking for.
+
+    The trade is that a client-side retry of an identical body would now
+    double-count. Nothing retries today (``MetricsPoller._report`` logs a
+    failed POST and moves on), and under-reporting loss is the worse of the
+    two failure modes; a retry added later needs an idempotency key rather
+    than a last-write-wins overwrite that loses a poll in normal operation.
+    """
     server, _ = auth
     values = {
         "discover": max(0, body.discover),
@@ -1397,12 +1427,30 @@ async def agent_metrics(
         "release": max(0, body.release),
         "inform": max(0, body.inform),
     }
+    # #980 — nullable, so kept out of ``values``: None must be stored as NULL
+    # (not measured) and must not be clamped to 0 by the max() above.
+    nullable_values = {
+        "receive_drop": None if body.receive_drop is None else max(0, body.receive_drop),
+        "socket_drop": None if body.socket_drop is None else max(0, body.socket_drop),
+    }
     existing = await db.get(DHCPMetricSample, (server.id, body.bucket_at))
     if existing is None:
-        db.add(DHCPMetricSample(server_id=server.id, bucket_at=body.bucket_at, **values))
+        db.add(
+            DHCPMetricSample(
+                server_id=server.id, bucket_at=body.bucket_at, **values, **nullable_values
+            )
+        )
     else:
         for k, v in values.items():
-            setattr(existing, k, v)
+            setattr(existing, k, getattr(existing, k, 0) + v)
+        for k, v in nullable_values.items():
+            prior = getattr(existing, k, None)
+            # UNKNOWN + n = n: one poll failing to measure does not erase
+            # what its neighbour in the same bucket did measure. Only two
+            # unmeasured polls leave the bucket unmeasured.
+            if v is None:
+                continue
+            setattr(existing, k, v if prior is None else prior + v)
     await db.commit()
     return {"status": "ok"}
 

--- a/backend/app/api/v1/dhcp/server_groups.py
+++ b/backend/app/api/v1/dhcp/server_groups.py
@@ -60,6 +60,16 @@ class GroupCreate(BaseModel):
     # do not simply inherit it.
     lease_cache_threshold: float = Field(default=0.0, ge=0.0, le=1.0)
     lease_cache_max_age: int | None = Field(default=None, ge=1)
+    # #980 — Kea packet-worker pool size. 1 (the default) measured 1.7x-2.9x
+    # more packets served than Kea's own auto-sizing on every CPU allocation
+    # tested; ``0`` hands sizing back to Kea (one worker per HOST cpu,
+    # regardless of the container's cgroup share). Capped at 64 because this
+    # is a pool-size knob, not a free-form integer, and a four-digit value is
+    # a typo that renders a config Kea accepts and then thrashes on.
+    kea_thread_pool_size: int = Field(default=1, ge=0, le=64)
+    # #980 — True (default) keeps today's per-packet log detail. False
+    # silences DHCP4_PACKET_RECEIVED / _SEND for ~1.30x more packets served.
+    kea_packet_logging: bool = True
 
     @field_validator("mode")
     @classmethod
@@ -88,6 +98,8 @@ class GroupUpdate(BaseModel):
     auto_failover: bool | None = None
     lease_cache_threshold: float | None = Field(default=None, ge=0.0, le=1.0)
     lease_cache_max_age: int | None = Field(default=None, ge=1)
+    kea_thread_pool_size: int | None = Field(default=None, ge=0, le=64)
+    kea_packet_logging: bool | None = None
 
     @field_validator("mode")
     @classmethod
@@ -128,6 +140,8 @@ class GroupResponse(BaseModel):
     auto_failover: bool
     lease_cache_threshold: float
     lease_cache_max_age: int | None
+    kea_thread_pool_size: int
+    kea_packet_logging: bool
     # Computed: count of Kea servers currently in the group. ≥ 2 means
     # the group renders the libdhcp_ha.so hook on every peer.
     kea_member_count: int = 0
@@ -155,6 +169,8 @@ def _group_to_response(g: DHCPServerGroup) -> GroupResponse:
         auto_failover=g.auto_failover,
         lease_cache_threshold=g.lease_cache_threshold,
         lease_cache_max_age=g.lease_cache_max_age,
+        kea_thread_pool_size=g.kea_thread_pool_size,
+        kea_packet_logging=g.kea_packet_logging,
         kea_member_count=len(kea),
         servers=[
             ServerSummary(
@@ -224,9 +240,10 @@ async def update_group(
     }
     for k, v in changes.items():
         setattr(g, k, v)
-    # HA tuning (mode / heartbeat / delays / auto-failover) and the Kea
-    # socket mode (#365) all render into every member's bundle, so wake the
-    # group channel — the bundle ETag shifts and agents re-render promptly.
+    # HA tuning (mode / heartbeat / delays / auto-failover), the Kea socket
+    # mode (#365) and the packet-worker pool size (#980) all render into
+    # every member's bundle, so wake the group channel — the bundle ETag
+    # shifts and agents re-render promptly.
     collect_wake(dhcp_group_channel(g.id))
     write_audit(
         db,

--- a/backend/app/api/v1/dhcp/servers.py
+++ b/backend/app/api/v1/dhcp/servers.py
@@ -1485,10 +1485,14 @@ async def delete_lease(server_id: uuid.UUID, lease_id: uuid.UUID, db: DB, user: 
 
 
 class DHCPRateBucket(BaseModel):
-    """One time bucket of DHCP message-type counts (#195).
+    """One time bucket of DHCP message-type counts (#195) and loss (#980).
 
-    Exactly the 7 contract keys — ``inform`` is summed in the DB but
-    dropped here to match the pinned issue contract.
+    The 7 message-type keys are the pinned #195 contract — ``inform`` is
+    summed in the DB but dropped here to match it. The two loss counters
+    were added by #980 and are ``None``, never 0, when no sample in the
+    bucket reported them: an agent older than #980 measures neither, and a
+    bucket of zeroes from such an agent is the false "nothing was lost" this
+    endpoint exists to stop showing.
     """
 
     ts: datetime
@@ -1499,6 +1503,12 @@ class DHCPRateBucket(BaseModel):
     nak: int
     decline: int
     release: int
+    # Packets Kea read and discarded (unparseable, DROP class, no subnet).
+    receive_drop: int | None = None
+    # Packets the kernel dropped before Kea could read them, because its
+    # receive buffer was full. The one that moves when a node is short of
+    # CPU; ``receive_drop`` stays at 0 through exactly that failure.
+    socket_drop: int | None = None
 
 
 class DHCPServerStatsResponse(BaseModel):
@@ -1563,6 +1573,11 @@ async def get_server_stats(
             func.coalesce(func.sum(DHCPMetricSample.nak), 0).label("nak"),
             func.coalesce(func.sum(DHCPMetricSample.decline), 0).label("decline"),
             func.coalesce(func.sum(DHCPMetricSample.release), 0).label("release"),
+            # #980 — deliberately NOT coalesced. SUM over an all-NULL group
+            # is NULL, which is the answer: nothing in this bucket measured
+            # loss. A partially-measured bucket sums the samples that did.
+            func.sum(DHCPMetricSample.receive_drop).label("receive_drop"),
+            func.sum(DHCPMetricSample.socket_drop).label("socket_drop"),
         )
         .where(DHCPMetricSample.server_id == server_id)
         .where(DHCPMetricSample.bucket_at >= since)
@@ -1580,6 +1595,9 @@ async def get_server_stats(
             nak=int(r.nak or 0),
             decline=int(r.decline or 0),
             release=int(r.release or 0),
+            # ``is None`` rather than ``or``: 0 is a real, measured value.
+            receive_drop=None if r.receive_drop is None else int(r.receive_drop),
+            socket_drop=None if r.socket_drop is None else int(r.socket_drop),
         )
         for r in rows
     ]

--- a/backend/app/api/v1/dhcp/servers.py
+++ b/backend/app/api/v1/dhcp/servers.py
@@ -1363,11 +1363,17 @@ async def get_server_rendered_config(
 ) -> DHCPRenderedConfigResponse:
     """Render this server's current ConfigBundle through its driver.
 
-    For Kea this returns the ``Dhcp4`` / ``Dhcp6`` JSON the agent
-    would apply on its next reload — useful for operators to preview
-    what's in flight without SSHing into the agent. Read-only drivers
-    (``windows_dhcp``) return an empty ``config`` payload since there's
-    no rendered config to show; the UI tab handles that case.
+    A **preview** of what is in flight — the subnets, pools, classes,
+    options and group tunables the agent will apply — not a copy of the
+    file it writes. The driver-side render deliberately omits the daemon
+    plumbing the agent adds (control socket, hooks, timers, expired-lease
+    processing, the full logger block) and does not parse as a Kea config
+    on its own. Useful for checking a setting took without SSHing into the
+    agent; not for diffing against ``kea-dhcp4.conf``.
+
+    Read-only drivers (``windows_dhcp``) return an empty ``config``
+    payload since there's no rendered config to show; the UI tab handles
+    that case.
     """
     server = await db.get(DHCPServer, server_id)
     if server is None:

--- a/backend/app/api/v1/metrics/router.py
+++ b/backend/app/api/v1/metrics/router.py
@@ -108,6 +108,15 @@ class DHCPTimePoint(BaseModel):
     decline: int
     release: int
     inform: int
+    #: #980 — packets lost, and where. ``receive_drop`` is Kea's own
+    #: ``pkt4/6-receive-drop`` (read, then discarded); ``socket_drop`` is the
+    #: kernel dropping datagrams Kea never got to read, which is what a
+    #: CPU-starved node does while every Kea counter still reports health.
+    #: ``None`` means no sample in this point measured it — an agent older
+    #: than #980, or one that cannot read ``/proc/net/udp`` — and must be
+    #: rendered as unknown, not as zero.
+    receive_drop: int | None = None
+    socket_drop: int | None = None
 
 
 class DHCPTimeseries(BaseModel):
@@ -211,6 +220,11 @@ async def dhcp_timeseries(
         func.sum(DHCPMetricSample.decline).label("decline"),
         func.sum(DHCPMetricSample.release).label("release"),
         func.sum(DHCPMetricSample.inform).label("inform"),
+        # #980 — SUM over an all-NULL group is NULL, which is the correct
+        # answer here (nothing measured) and the reason these are not
+        # coalesced like the counters above.
+        func.sum(DHCPMetricSample.receive_drop).label("receive_drop"),
+        func.sum(DHCPMetricSample.socket_drop).label("socket_drop"),
     ).where(DHCPMetricSample.bucket_at >= since)
     if server_id is not None:
         stmt = stmt.where(DHCPMetricSample.server_id == server_id)
@@ -229,6 +243,10 @@ async def dhcp_timeseries(
             decline=int(row.decline or 0),
             release=int(row.release or 0),
             inform=int(row.inform or 0),
+            # ``is None`` rather than ``or``: 0 is measured, and means the
+            # opposite of unmeasured.
+            receive_drop=None if row.receive_drop is None else int(row.receive_drop),
+            socket_drop=None if row.socket_drop is None else int(row.socket_drop),
         )
         for row in rows
     ]

--- a/backend/app/drivers/dhcp/base.py
+++ b/backend/app/drivers/dhcp/base.py
@@ -305,6 +305,18 @@ class ConfigBundle:
     # lease-events → DDNS + the IPAM lease mirror. ``cache-max-age`` None = uncapped.
     lease_cache_threshold: float = 0.0
     lease_cache_max_age: int | None = None
+    # #980 — Kea ``multi-threading.thread-pool-size``, from
+    # ``DHCPServerGroup.kea_thread_pool_size``. 0 = Kea's own auto-sizing
+    # (one worker per host CPU, ignoring the cgroup share), which measured
+    # 2.9x worse than a single worker on a CPU-constrained node. Defaults to
+    # 1 here as well as in the column so a bundle built without a group is
+    # not silently handed the auto behaviour this exists to replace.
+    kea_thread_pool_size: int = 1
+    # #980 — render ``kea-dhcp4.packets`` / ``kea-dhcp6.packets`` at INFO
+    # (True, today's behaviour) or WARN (False, ~1.30x more packets served,
+    # at the cost of the two per-packet log codes that carry the source
+    # address and interface). See DHCPServerGroup.kea_packet_logging.
+    kea_packet_logging: bool = True
     # IPv6 Router-Advertisement config (issue #524) — one entry per
     # RA-enabled IPv6 subnet the server's group serves. ``radvd_conf`` is
     # the pre-rendered radvd.conf text the agent writes verbatim; the
@@ -330,6 +342,8 @@ class ConfigBundle:
             "dhcp_socket_type": self.dhcp_socket_type,
             "lease_cache_threshold": self.lease_cache_threshold,
             "lease_cache_max_age": self.lease_cache_max_age,
+            "kea_thread_pool_size": self.kea_thread_pool_size,
+            "kea_packet_logging": self.kea_packet_logging,
             "ra_configs": [asdict(r) for r in self.ra_configs],
             "radvd_conf": self.radvd_conf,
         }

--- a/backend/app/drivers/dhcp/kea.py
+++ b/backend/app/drivers/dhcp/kea.py
@@ -499,6 +499,14 @@ class KeaDriver(DHCPDriver):
                 # #637 — group-wide Kea lease cache, rendered explicitly because
                 # Kea 3.0 flipped the default from off to 0.25.
                 "cache-threshold": bundle.lease_cache_threshold,
+                # #980 — rendered explicitly because Kea's own default sizes
+                # the packet-worker pool from the machine's CPU count, not
+                # from the cgroup share the container holds. See
+                # ``DHCPServerGroup.kea_thread_pool_size`` for the numbers.
+                "multi-threading": {
+                    "enable-multi-threading": True,
+                    "thread-pool-size": bundle.kea_thread_pool_size,
+                },
                 # Issue #365 — ``raw`` (group socket_mode "direct") receives
                 # broadcast DISCOVERs from directly-attached clients; ``udp``
                 # is relay-only. v6 below has no socket-type concept.
@@ -541,6 +549,12 @@ class KeaDriver(DHCPDriver):
                 "host-reservation-identifiers": ["duid", "hw-address"],
                 # #637 — see the Dhcp4 block.
                 "cache-threshold": bundle.lease_cache_threshold,
+                # #980 — see the Dhcp4 block. Separate process, separate pool,
+                # same node's CPU.
+                "multi-threading": {
+                    "enable-multi-threading": True,
+                    "thread-pool-size": bundle.kea_thread_pool_size,
+                },
                 "lease-database": {
                     "type": "memfile",
                     "persist": True,

--- a/backend/app/drivers/dhcp/kea.py
+++ b/backend/app/drivers/dhcp/kea.py
@@ -479,6 +479,26 @@ def _render_pxe_class(p: PXEClassDef) -> dict[str, Any]:
     return d
 
 
+def _packet_logging_override(bundle: ConfigBundle, daemon: str) -> dict[str, Any]:
+    """The ``kea-dhcpN.packets`` severity override, for the preview (#980).
+
+    Returns ``{}`` when packet logging is on, so the rendered preview is
+    unchanged for the default.
+
+    Only the override, not a full ``loggers`` block: this render is a
+    *preview*, not the file the agent writes. It already omits the control
+    socket, hooks, timers and expired-lease processing — and does not parse
+    as a Kea config at all — so duplicating the agent's appender paths here
+    would add a third copy of them to drift, for no gain. What belongs in
+    the preview is the group tunables an operator just set, which is the
+    same rule ``dhcp_socket_type`` (#365) and ``cache-threshold`` (#637)
+    already follow.
+    """
+    if bundle.kea_packet_logging:
+        return {}
+    return {"loggers": [{"name": f"{daemon}.packets", "severity": "WARN"}]}
+
+
 class KeaDriver(DHCPDriver):
     """Kea DHCPv4 driver — emits a ``Dhcp4`` JSON config structure."""
 
@@ -530,6 +550,7 @@ class KeaDriver(DHCPDriver):
                 # match, so declaration order is precedence.
                 + [_render_device_policy_class(p) for p in bundle.device_policy_classes],
                 "option-data": _render_option_data(bundle.options.options, address_family="ipv4"),
+                **_packet_logging_override(bundle, "kea-dhcp4"),
             }
             # #856 — ship definitions for any non-standard option emitted above.
             option_defs = _collect_option_defs(out["Dhcp4"])
@@ -565,6 +586,7 @@ class KeaDriver(DHCPDriver):
                     _render_client_class(c, address_family="ipv6") for c in bundle.client_classes
                 ],
                 "option-data": _render_option_data(bundle.options.options, address_family="ipv6"),
+                **_packet_logging_override(bundle, "kea-dhcp6"),
             }
         # #637 — group-wide ``cache-max-age`` is optional (None = uncapped, Kea's
         # own default), so it is applied conditionally rather than in the literals.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -512,6 +512,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         await seed_node_pressure_alert_rule()
     except Exception as exc:  # noqa: BLE001
         logger.debug("node_pressure_alert_rule_seed_skipped", reason=str(exc))
+    # DHCP packet-loss alert rule — singleton, ENABLED by default (issue
+    # #980). Reads counters every Kea agent reports unconditionally; a server
+    # whose agent is too old to report them is skipped, not alarmed on, so
+    # enabling it everywhere is silent until it is real. Idempotent.
+    try:
+        from app.services.alerts import (  # noqa: PLC0415
+            seed_dhcp_packets_dropped_alert_rule,
+        )
+
+        await seed_dhcp_packets_dropped_alert_rule()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("dhcp_packets_dropped_alert_rule_seed_skipped", reason=str(exc))
     # DNS query-anomaly alert rules — NXDOMAIN-spike + query-rate-spike,
     # singletons, DISABLED by default (issue #371). Discoverable in the
     # Alerts UI; fire only on agent-based BIND9 installs with metric data.

--- a/backend/app/models/dhcp.py
+++ b/backend/app/models/dhcp.py
@@ -126,6 +126,67 @@ class DHCPServerGroup(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
     lease_cache_max_age: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
+    # #980 — Kea ``multi-threading.thread-pool-size``, rendered explicitly
+    # instead of left at Kea's own default of 0 ("auto").
+    #
+    # "Auto" means ``std::thread::hardware_concurrency()``: the number of CPUs
+    # on the MACHINE, with no regard for the cgroup share the container
+    # actually holds. On a 4 vCPU appliance Kea therefore starts four packet
+    # workers that compete, inside one cgroup, with the single thread whose
+    # only job is to drain the receive socket — and when that thread is late,
+    # the kernel drops datagrams Kea never learns about. Fewer workers get the
+    # receiver scheduled sooner; measured against kea-dhcp4 3.0.3 with the
+    # memfile backend at 12,000 relayed pkt/s (median of 4 runs, packets
+    # served):
+    #
+    #     cgroup CPU    pool=1     pool=2     pool=4 (what "auto" gives here)
+    #     0.25          19,381     11,119      6,723
+    #     4.0 (none)    93,717     73,089     55,957
+    #
+    # Monotonic in both shapes, so 1 is the default. It is a *pool* size, not
+    # a thread count: MT stays enabled, so the receive thread is still
+    # separate and every multi-threaded semantic (host-reservation lookup
+    # order, ``dhcp-queue-control`` staying disabled) is unchanged — which is
+    # why this rather than ``enable-multi-threading: false``, whose single
+    # thread must both receive and process and measured 15,170 socket drops
+    # in a run where pool=1 measured 0. Kea's HA hook keeps its own
+    # ``http-client-threads`` / ``http-listener-threads``, unaffected by this
+    # value, so a failover pair's peer traffic is not serialised behind the
+    # one worker.
+    #
+    # ``0`` restores Kea's auto-sizing for an operator who measures otherwise.
+    kea_thread_pool_size: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default=sa_text("1")
+    )
+
+    # #980 — per-packet logging, and whether it is worth its cost here.
+    #
+    # At severity INFO, Kea writes FOUR lines per transaction, to two
+    # appenders, one of them flushed: ``DHCP4_QUERY_LABEL`` and
+    # ``DHCP4_LEASE_ALLOC``/``_OFFER`` (from ``kea-dhcp4.dhcp4`` and
+    # ``kea-dhcp4.leases``), plus ``DHCP4_PACKET_RECEIVED`` and
+    # ``DHCP4_PACKET_SEND`` (from ``kea-dhcp4.packets``). Only the last two
+    # are switched off here, and only they: measured on the same rig as
+    # ``kea_thread_pool_size``, silencing that one child logger took packets
+    # served from 19,026-20,403 to 24,997-26,077 — 1.30x — for lines whose
+    # information is largely carried by the two that remain.
+    #
+    # ``kea-dhcp4.dhcp4`` is deliberately NOT part of this. It looks like the
+    # other noisy one, and silencing it also loses ``DHCP4_OPEN_SOCKETS_FAILED``
+    # (a real failure Kea logs at INFO), ``DHCP4_CONFIG_COMPLETE``,
+    # ``DHCP4_STARTED`` and ``DHCP4_MULTI_THREADING_INFO`` — the last of which
+    # is the line that reports the pool size above actually took effect.
+    #
+    # Defaults to True: OFF is a change an operator can SEE, since those two
+    # codes carry the source address and receiving interface and no other line
+    # does. Preserving observable behaviour and offering the throughput as an
+    # opt-in is the same call #637 made for the lease cache. The #980 loss
+    # counters are what tell an operator whether they are at the knee where
+    # this is worth reaching for.
+    kea_packet_logging: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+
     # Eager-load `servers` by default. The API's group list endpoint
     # reads this relationship to compute `kea_member_count` + roll up
     # the members, and it runs in an async session where an accidental

--- a/backend/app/models/dhcp.py
+++ b/backend/app/models/dhcp.py
@@ -149,10 +149,15 @@ class DHCPServerGroup(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # order, ``dhcp-queue-control`` staying disabled) is unchanged — which is
     # why this rather than ``enable-multi-threading: false``, whose single
     # thread must both receive and process and measured 15,170 socket drops
-    # in a run where pool=1 measured 0. Kea's HA hook keeps its own
-    # ``http-client-threads`` / ``http-listener-threads``, unaffected by this
-    # value, so a failover pair's peer traffic is not serialised behind the
-    # one worker.
+    # in a run where pool=1 measured 0.
+    #
+    # Kea's HA hook does NOT keep independent HTTP pools by default:
+    # ``http-listener-threads`` / ``http-client-threads`` default to 0, which
+    # Kea reads as "same as thread-pool-size". Verified by counting OS
+    # threads with the HA hook loaded — pool=1 gave 8 and pool=8 gave 29, a
+    # delta of 21 for a pool delta of 7, i.e. three pools of N. So the agent
+    # pins them (``_HA_HTTP_THREADS`` in ``render_kea.py``) and this setting
+    # moves only the packet-worker pool.
     #
     # ``0`` restores Kea's auto-sizing for an operator who measures otherwise.
     kea_thread_pool_size: Mapped[int] = mapped_column(

--- a/backend/app/models/metrics.py
+++ b/backend/app/models/metrics.py
@@ -63,5 +63,24 @@ class DHCPMetricSample(Base):
     release: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
     inform: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
 
+    # #980 — the two loss counters, and the reason they are NULLABLE where
+    # every column above is NOT NULL DEFAULT 0.
+    #
+    # ``receive_drop`` is Kea's own ``pkt4/6-receive-drop``: packets it read
+    # and then discarded. ``socket_drop`` is the kernel's per-socket
+    # ``sk_drops`` on UDP/67 + UDP/547 — packets Kea never saw because its
+    # receive buffer was full. They are not interchangeable, and the second
+    # is the one that moves when a node is short of CPU: measured against
+    # kea-dhcp4 3.0.3, a run that lost 9,700 datagrams to buffer overflow
+    # left ``pkt4-receive-drop`` at 0 for its whole duration.
+    #
+    # NULL means UNMEASURED, and only NULL can mean that. An agent older
+    # than #980 reports neither field, and 0 from such an agent would read
+    # as "this server has dropped nothing" — the precise false reassurance
+    # the issue was filed about. Every reader must render NULL as unknown
+    # rather than folding it to zero.
+    receive_drop: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    socket_drop: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
 
 __all__ = ["DNSMetricSample", "DHCPMetricSample"]

--- a/backend/app/services/ai/tools/dhcp.py
+++ b/backend/app/services/ai/tools/dhcp.py
@@ -927,8 +927,13 @@ async def find_dhcp_server_stats(
             "release": int(totals_row.release or 0),
         },
         # #980. Kept out of ``totals`` deliberately: those are messages
-        # handled, these are messages lost, and folding them into one dict
-        # invites a model to add them up.
+        # handled, these are messages not handled, and folding them into one
+        # dict invites a model to add them up.
+        #
+        # ``measured`` keys on socket_drop ALONE. receive_drop always arrives
+        # from a #980 agent, so testing the pair would report a server whose
+        # kernel-side loss is unmeasurable as measured-and-clean — the exact
+        # false reassurance the counters exist to remove.
         "packet_loss": {
             "socket_drop": (
                 None if totals_row.socket_drop is None else int(totals_row.socket_drop)
@@ -936,7 +941,11 @@ async def find_dhcp_server_stats(
             "receive_drop": (
                 None if totals_row.receive_drop is None else int(totals_row.receive_drop)
             ),
-            "measured": totals_row.socket_drop is not None or totals_row.receive_drop is not None,
+            "measured": totals_row.socket_drop is not None,
+            "note": (
+                "socket_drop is lost traffic; receive_drop also counts deliberate "
+                "drops (blocklisted MAC, HA out-of-scope) and is not by itself a fault"
+            ),
         },
     }
 

--- a/backend/app/services/ai/tools/dhcp.py
+++ b/backend/app/services/ai/tools/dhcp.py
@@ -853,7 +853,14 @@ class FindDHCPServerStatsArgs(BaseModel):
     description=(
         "Summarize a DHCP server's recent traffic: active lease count and "
         "per-message-type totals (discover/offer/request/ack/nak/decline/"
-        "release) over a 1h/6h/24h/7d window. Use for 'how busy is server X?'."
+        "release) over a 1h/6h/24h/7d window, plus packets LOST over that "
+        "window. Use for 'how busy is server X?' and 'is server X dropping "
+        "packets?'. socket_drop counts packets the kernel dropped before the "
+        "server could read them (its receive buffer filled — the node is "
+        "short of CPU); receive_drop counts packets the server read and then "
+        "discarded. Either may be null, meaning the agent did not measure it "
+        "(too old, or cannot read /proc/net/udp) — null is NOT zero, and must "
+        "not be reported as 'no packets were dropped'."
     ),
     args_model=FindDHCPServerStatsArgs,
     category="dhcp",
@@ -894,6 +901,11 @@ async def find_dhcp_server_stats(
                 func.coalesce(func.sum(DHCPMetricSample.nak), 0).label("nak"),
                 func.coalesce(func.sum(DHCPMetricSample.decline), 0).label("decline"),
                 func.coalesce(func.sum(DHCPMetricSample.release), 0).label("release"),
+                # #980 — not coalesced: SUM over an all-NULL group is NULL,
+                # which means "not measured" and must reach the model as
+                # null rather than as a zero it would summarise as healthy.
+                func.sum(DHCPMetricSample.receive_drop).label("receive_drop"),
+                func.sum(DHCPMetricSample.socket_drop).label("socket_drop"),
             )
             .where(DHCPMetricSample.server_id == sid)
             .where(DHCPMetricSample.bucket_at >= since)
@@ -913,6 +925,18 @@ async def find_dhcp_server_stats(
             "nak": int(totals_row.nak or 0),
             "decline": int(totals_row.decline or 0),
             "release": int(totals_row.release or 0),
+        },
+        # #980. Kept out of ``totals`` deliberately: those are messages
+        # handled, these are messages lost, and folding them into one dict
+        # invites a model to add them up.
+        "packet_loss": {
+            "socket_drop": (
+                None if totals_row.socket_drop is None else int(totals_row.socket_drop)
+            ),
+            "receive_drop": (
+                None if totals_row.receive_drop is None else int(totals_row.receive_drop)
+            ),
+            "measured": totals_row.socket_drop is not None or totals_row.receive_drop is not None,
         },
     }
 

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -291,6 +291,16 @@ RULE_TYPE_DNS_RATE_LIMIT_DROPPING = "dns_rate_limit_dropping"
 # is the counter this rule reads. Measured on kea-dhcp4 3.0.3: a run that
 # lost 9,700 datagrams that way left ``pkt4-receive-drop`` at 0 and every
 # other signal green.
+#
+# It fires on ``socket_drop`` ONLY, never on ``receive_drop``, even though
+# both are reported. ``pkt4-receive-drop`` counts packets Kea read and threw
+# away *on purpose* as well as by accident: verified against kea-dhcp4 3.0.3,
+# a client matching a ``DROP`` client-class — which is exactly what the
+# shipped DHCP MAC blocklist renders — increments it once per blocked packet.
+# Kea's HA hook drops out-of-scope queries in ``hot-standby`` the same way.
+# So a rule that counted it would fire permanently, and never auto-resolve,
+# on two ordinary correctly-working configurations. Deliberate policy drops
+# are not loss.
 RULE_TYPE_DHCP_PACKETS_DROPPED = "dhcp_packets_dropped"
 
 # Active IP reconciliation hygiene alerts — issue #369. Subject = ip_address.
@@ -518,11 +528,14 @@ _DNS_RATE_LIMIT_DROP_MIN_DEFAULT = 100
 #
 # The floor is 1 — ANY confirmed loss fires. That is deliberate and unlike
 # the RRL rule's 100: RRL dropping a few responses is the feature working as
-# designed, whereas a DHCP datagram dropped before the server read it is
-# never intended behaviour and always costs a client a full retransmit round
-# (4 s and up). The floor is still an operator knob (``min_free_addresses``,
-# reused as a raw count like the other DHCP rules) for a site that would
-# rather hear about it only past a threshold.
+# designed, whereas a DHCP datagram the kernel discarded before the server
+# could read it is never intended behaviour and always costs a client a full
+# retransmit round (4 s and up). A floor of 1 is only safe because the rule
+# reads ``socket_drop`` alone — see the rule-type comment for why
+# ``receive_drop`` would make it fire forever on a working MAC blocklist.
+# The floor is still an operator knob (``min_free_addresses``, reused as a
+# raw count like the other DHCP rules) for a site that would rather hear
+# about it only past a threshold.
 _DHCP_PACKET_LOSS_WINDOW = timedelta(minutes=15)
 _DHCP_PACKET_LOSS_MIN_DEFAULT = 1
 
@@ -1725,24 +1738,28 @@ async def _matching_dhcp_packets_dropped_subjects(
     db: AsyncSession,
     rule: AlertRule,
 ) -> list[tuple[str, str, str]]:
-    """DHCP servers that lost packets over the trailing window (issue #980).
+    """DHCP servers the kernel dropped packets for over the window (#980).
 
-    Two independent losses, reported separately because they mean different
-    things and are fixed in different places:
+    Fires on ``socket_drop`` alone: packets discarded because Kea's receive
+    buffer was full, so Kea never read them. That is unambiguous loss nobody
+    asked for, which is why a floor of one packet is reasonable.
 
-    * ``socket_drop`` — the kernel dropped the datagram because Kea's receive
-      buffer was full, so Kea never read it. The node is short of CPU, or
-      Kea's own worker threads are crowding out its receive thread. This is
-      the one that moves under load and the one nothing else can see.
-    * ``receive_drop`` — Kea read the packet and threw it away (unparseable,
-      matched a ``DROP`` class, no subnet selected). Usually a configuration
-      or client problem, not a capacity one.
+    **``receive_drop`` is deliberately not part of the test**, though the
+    message reports it when present. Kea's ``pkt4-receive-drop`` counts
+    packets it read and discarded *on purpose* as well as by accident —
+    verified against kea-dhcp4 3.0.3, a client matching a ``DROP``
+    client-class increments it once per packet, and a ``DROP`` class is
+    exactly what the shipped DHCP MAC blocklist renders. Kea's HA hook drops
+    out-of-scope queries in ``hot-standby`` the same way. Counting it would
+    make this rule fire permanently, and never auto-resolve, on two ordinary
+    working configurations.
 
     NULL is not zero. A server whose agent predates #980, or cannot read
-    ``/proc/net/udp``, reports neither counter, and ``SUM`` over its rows is
-    NULL — such a server is skipped rather than treated as loss-free, which
-    is the whole point of keeping the columns nullable. It also cannot be
-    alerted on; the Stats tab renders it as "not measured" instead.
+    ``/proc/net/udp``, reports no ``socket_drop`` at all; ``SUM`` over its
+    rows is NULL and the server is skipped rather than treated as loss-free.
+    Note this is tested on ``socket_drop`` specifically and not on the pair:
+    ``receive_drop`` always arrives from a #980 agent, so a combined test
+    would read an unmeasurable server as measured-and-clean.
 
     Open-while-true: auto-resolves once a window passes with no loss.
     """
@@ -1767,16 +1784,14 @@ async def _matching_dhcp_packets_dropped_subjects(
     if not rows:
         return []
 
-    hits: dict[uuid.UUID, tuple[int | None, int | None, int]] = {}
+    hits: dict[uuid.UUID, tuple[int, int | None, int]] = {}
     for r in rows:
-        # ``is None`` throughout: an unmeasured counter must not clear the
-        # floor by being coalesced to 0, and must not be *reported* as 0
-        # either.
-        sock = None if r.sock is None else int(r.sock)
-        recv = None if r.recv is None else int(r.recv)
-        total = (sock or 0) + (recv or 0)
-        if total >= floor and total > 0:
-            hits[r.server_id] = (sock, recv, int(r.disc or 0))
+        if r.sock is None:
+            continue  # unmeasured — skipped, not vouched for
+        sock = int(r.sock)
+        if sock < floor or sock <= 0:
+            continue
+        hits[r.server_id] = (sock, None if r.recv is None else int(r.recv), int(r.disc or 0))
     if not hits:
         return []
 
@@ -1791,24 +1806,23 @@ async def _matching_dhcp_packets_dropped_subjects(
     matches: list[tuple[str, str, str]] = []
     for sid, (sock, recv, disc) in hits.items():
         name = names.get(sid) or str(sid)
-        parts: list[str] = []
-        if sock:
-            parts.append(
-                f"{sock} dropped by the kernel before the server could read them "
-                "(receive buffer full — the node is short of CPU, or Kea's worker "
-                "threads are crowding out its receive thread)"
-            )
-        if recv:
-            parts.append(
-                f"{recv} read and then discarded by Kea (unparseable, no subnet, or a DROP class)"
-            )
         message = (
-            f"DHCP server {name} lost packets in the last {win_min} min: "
-            + "; ".join(parts)
-            + f". It answered {disc} DISCOVER(s) over the same window, so every "
+            f"DHCP server {name} lost {sock} packet(s) in the last {win_min} min: "
+            "the kernel discarded them because the server's receive buffer was "
+            "full, so it never read them. Usually means the node is short of "
+            f"CPU. It answered {disc} DISCOVER(s) over the same window, so every "
             "server-side counter reads healthy — the loss is upstream of them and "
             "costs each affected client a full retransmit round."
         )
+        if recv:
+            # Reported, never alerted on: this number legitimately includes
+            # MAC-blocklist and HA out-of-scope drops.
+            message += (
+                f" Separately, {recv} packet(s) were read and then discarded by "
+                "Kea — that figure also counts deliberate drops (a blocklisted "
+                "MAC, or an HA standby declining an out-of-scope query) and is "
+                "not necessarily a fault."
+            )
         matches.append((str(sid), name, message))
     return matches
 
@@ -4039,8 +4053,14 @@ async def seed_dhcp_packets_dropped_alert_rule() -> None:
     because they need an optional subsystem (agent-based BIND9) before they
     can say anything; this one reads a counter every Kea agent reports
     unconditionally, needs no configuration, and cannot false-fire — a
-    non-zero drop count is not an inference from a threshold, it is the
+    non-zero ``socket_drop`` is not an inference from a threshold, it is the
     kernel saying it threw a packet away.
+
+    "Cannot false-fire" is only true because the evaluator reads
+    ``socket_drop`` alone. Counting ``receive_drop`` as well would make a
+    default-on rule fire permanently on any install using the DHCP MAC
+    blocklist, since Kea counts a ``DROP``-class match there — the kind of
+    alarm that trains operators to ignore the feed.
 
     It also cannot be found by an operator who does not already suspect it.
     A server dropping packets in its socket buffer is reachable, heartbeats
@@ -4070,15 +4090,16 @@ async def seed_dhcp_packets_dropped_alert_rule() -> None:
             AlertRule(
                 name=_DHCP_PACKETS_DROPPED_RULE_NAME,
                 description=(
-                    "Fires when a DHCP server lost packets over the last 15 minutes — "
-                    "either dropped by the kernel because the server's receive buffer "
-                    "filled before it could read them, or read and then discarded by "
-                    "Kea. The first kind is invisible to every other signal: the "
-                    "server stays reachable and healthy and answers 100% of what "
-                    "reaches it, while clients wait out retransmit rounds. Usually "
-                    "means the node is short of CPU. Auto-resolves once a window "
-                    "passes with no loss. Set the rule's minimum-count threshold to "
-                    "alert only past a number of packets."
+                    "Fires when the kernel discarded DHCP packets before the server "
+                    "could read them — its receive buffer filled, usually because the "
+                    "node is short of CPU. Invisible to every other signal: the server "
+                    "stays reachable and healthy and answers 100% of what reaches it, "
+                    "while clients wait out retransmit rounds. Does NOT fire on packets "
+                    "Kea read and discarded, because that figure also counts deliberate "
+                    "drops (a blocklisted MAC, an HA standby declining an out-of-scope "
+                    "query); those are reported alongside but are not faults. "
+                    "Auto-resolves once a window passes with no loss. Set the rule's "
+                    "minimum-count threshold to alert only past a number of packets."
                 ),
                 rule_type=RULE_TYPE_DHCP_PACKETS_DROPPED,
                 severity="warning",

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -54,7 +54,7 @@ from app.models.dhcp import (
 from app.models.dns import DNSServer, DNSZone
 from app.models.domain import Domain
 from app.models.ipam import IPAddress, IPBlock, IpMacHistory, Subnet
-from app.models.metrics import DNSMetricSample
+from app.models.metrics import DHCPMetricSample, DNSMetricSample
 from app.models.network_service import NetworkService, NetworkServiceResource
 from app.models.overlay import OverlayNetwork
 from app.models.ownership import Site
@@ -280,6 +280,19 @@ RULE_TYPE_DNS_QUERY_RATE_SPIKE = "dns_query_rate_spike"
 # clears the floor, auto-resolves when the flood subsides.
 RULE_TYPE_DNS_RATE_LIMIT_DROPPING = "dns_rate_limit_dropping"
 
+# A DHCP server losing packets it never got to read (#980). Subject =
+# dhcp_server. Open-while-true, same shape as the RRL rule above.
+#
+# This is deliberately NOT folded into ``dhcp_pool_exhaustion`` or any
+# reachability check, because it is invisible to both: the server is up,
+# heartbeating, has free addresses, and answers 100 % of the packets that
+# reach it. The loss is in the kernel's socket buffer, on a node whose CPU
+# the receive thread is not getting in time, and the only place it appears
+# is the counter this rule reads. Measured on kea-dhcp4 3.0.3: a run that
+# lost 9,700 datagrams that way left ``pkt4-receive-drop`` at 0 and every
+# other signal green.
+RULE_TYPE_DHCP_PACKETS_DROPPED = "dhcp_packets_dropped"
+
 # Active IP reconciliation hygiene alerts — issue #369. Subject = ip_address.
 # Reuse the on-the-wire liveness signal (IPAddress.last_seen_at) the discovery
 # sweep + SNMP poll already write + the ip_mac_history observation log; no new
@@ -498,6 +511,20 @@ _DNS_QUERY_RATE_MIN_DEFAULT = 1000  # absolute query floor over the window
 # is shedding a flood, i.e. likely under attack. Below it, a few drops from
 # an over-eager client are just noise.
 _DNS_RATE_LIMIT_DROP_MIN_DEFAULT = 100
+
+# DHCP packet-loss evaluation window + floor (#980). Same 15 min as the DNS
+# anomaly rules, for the same reason: long enough to smooth one noisy bucket,
+# short enough to page inside a quarter hour.
+#
+# The floor is 1 — ANY confirmed loss fires. That is deliberate and unlike
+# the RRL rule's 100: RRL dropping a few responses is the feature working as
+# designed, whereas a DHCP datagram dropped before the server read it is
+# never intended behaviour and always costs a client a full retransmit round
+# (4 s and up). The floor is still an operator knob (``min_free_addresses``,
+# reused as a raw count like the other DHCP rules) for a site that would
+# rather hear about it only past a threshold.
+_DHCP_PACKET_LOSS_WINDOW = timedelta(minutes=15)
+_DHCP_PACKET_LOSS_MIN_DEFAULT = 1
 
 # Issue #285 Phase 2d — how long a control-plane-rendered firewall hash may
 # go un-applied (ok-status) before it's "stalled". Comfortably larger than
@@ -1689,6 +1716,98 @@ async def _matching_dns_rate_limit_dropping_subjects(
             f"responses in the last {win_min} min ({slipped} slipped/truncated); "
             f"the server is shedding a query flood (floor {floor}). Investigate a "
             "possible amplification attempt or misbehaving client."
+        )
+        matches.append((str(sid), name, message))
+    return matches
+
+
+async def _matching_dhcp_packets_dropped_subjects(
+    db: AsyncSession,
+    rule: AlertRule,
+) -> list[tuple[str, str, str]]:
+    """DHCP servers that lost packets over the trailing window (issue #980).
+
+    Two independent losses, reported separately because they mean different
+    things and are fixed in different places:
+
+    * ``socket_drop`` — the kernel dropped the datagram because Kea's receive
+      buffer was full, so Kea never read it. The node is short of CPU, or
+      Kea's own worker threads are crowding out its receive thread. This is
+      the one that moves under load and the one nothing else can see.
+    * ``receive_drop`` — Kea read the packet and threw it away (unparseable,
+      matched a ``DROP`` class, no subnet selected). Usually a configuration
+      or client problem, not a capacity one.
+
+    NULL is not zero. A server whose agent predates #980, or cannot read
+    ``/proc/net/udp``, reports neither counter, and ``SUM`` over its rows is
+    NULL — such a server is skipped rather than treated as loss-free, which
+    is the whole point of keeping the columns nullable. It also cannot be
+    alerted on; the Stats tab renders it as "not measured" instead.
+
+    Open-while-true: auto-resolves once a window passes with no loss.
+    """
+    floor = (
+        rule.min_free_addresses
+        if rule.min_free_addresses is not None
+        else _DHCP_PACKET_LOSS_MIN_DEFAULT
+    )
+    since = datetime.now(UTC) - _DHCP_PACKET_LOSS_WINDOW
+    rows = (
+        await db.execute(
+            select(
+                DHCPMetricSample.server_id,
+                func.sum(DHCPMetricSample.socket_drop).label("sock"),
+                func.sum(DHCPMetricSample.receive_drop).label("recv"),
+                func.sum(DHCPMetricSample.discover).label("disc"),
+            )
+            .where(DHCPMetricSample.bucket_at >= since)
+            .group_by(DHCPMetricSample.server_id)
+        )
+    ).all()
+    if not rows:
+        return []
+
+    hits: dict[uuid.UUID, tuple[int | None, int | None, int]] = {}
+    for r in rows:
+        # ``is None`` throughout: an unmeasured counter must not clear the
+        # floor by being coalesced to 0, and must not be *reported* as 0
+        # either.
+        sock = None if r.sock is None else int(r.sock)
+        recv = None if r.recv is None else int(r.recv)
+        total = (sock or 0) + (recv or 0)
+        if total >= floor and total > 0:
+            hits[r.server_id] = (sock, recv, int(r.disc or 0))
+    if not hits:
+        return []
+
+    name_rows = (
+        await db.execute(
+            select(DHCPServer.id, DHCPServer.name).where(DHCPServer.id.in_(list(hits.keys())))
+        )
+    ).all()
+    names: dict[uuid.UUID, str] = {row[0]: row[1] for row in name_rows}
+
+    win_min = int(_DHCP_PACKET_LOSS_WINDOW.total_seconds() // 60)
+    matches: list[tuple[str, str, str]] = []
+    for sid, (sock, recv, disc) in hits.items():
+        name = names.get(sid) or str(sid)
+        parts: list[str] = []
+        if sock:
+            parts.append(
+                f"{sock} dropped by the kernel before the server could read them "
+                "(receive buffer full — the node is short of CPU, or Kea's worker "
+                "threads are crowding out its receive thread)"
+            )
+        if recv:
+            parts.append(
+                f"{recv} read and then discarded by Kea (unparseable, no subnet, or a DROP class)"
+            )
+        message = (
+            f"DHCP server {name} lost packets in the last {win_min} min: "
+            + "; ".join(parts)
+            + f". It answered {disc} DISCOVER(s) over the same window, so every "
+            "server-side counter reads healthy — the loss is upstream of them and "
+            "costs each affected client a full retransmit round."
         )
         matches.append((str(sid), name, message))
     return matches
@@ -3909,6 +4028,69 @@ async def seed_agent_config_rejected_alert_rule() -> None:
         await session.commit()
 
 
+_DHCP_PACKETS_DROPPED_RULE_NAME = "DHCP packets dropped"
+
+
+async def seed_dhcp_packets_dropped_alert_rule() -> None:
+    """Seed the #980 rule, ENABLED by default.
+
+    On by default for the same reason as ``agent_config_rejected``, and not
+    for the reason the DNS-anomaly rules are seeded off. Those are off
+    because they need an optional subsystem (agent-based BIND9) before they
+    can say anything; this one reads a counter every Kea agent reports
+    unconditionally, needs no configuration, and cannot false-fire — a
+    non-zero drop count is not an inference from a threshold, it is the
+    kernel saying it threw a packet away.
+
+    It also cannot be found by an operator who does not already suspect it.
+    A server dropping packets in its socket buffer is reachable, heartbeats
+    normally, passes its health check, has free addresses, and answers 100 %
+    of what it reads; the only symptom is clients taking multiple retransmit
+    rounds to get an address, which looks like a client-side or network
+    problem from here. Seeding this off would mean the alarm arrives only
+    after somebody has already diagnosed the thing it exists to diagnose.
+
+    Servers whose agent cannot report the counters are skipped by the
+    evaluator, not alarmed on — see
+    :func:`_matching_dhcp_packets_dropped_subjects`.
+
+    Keyed on ``name``; an operator who disables or renames it is never
+    overridden.
+    """
+    from app.db import AsyncSessionLocal  # noqa: PLC0415
+    from app.models.alerts import AlertRule  # noqa: PLC0415
+
+    async with AsyncSessionLocal() as session:
+        existing = await session.scalar(
+            select(AlertRule).where(AlertRule.name == _DHCP_PACKETS_DROPPED_RULE_NAME)
+        )
+        if existing is not None:
+            return
+        session.add(
+            AlertRule(
+                name=_DHCP_PACKETS_DROPPED_RULE_NAME,
+                description=(
+                    "Fires when a DHCP server lost packets over the last 15 minutes — "
+                    "either dropped by the kernel because the server's receive buffer "
+                    "filled before it could read them, or read and then discarded by "
+                    "Kea. The first kind is invisible to every other signal: the "
+                    "server stays reachable and healthy and answers 100% of what "
+                    "reaches it, while clients wait out retransmit rounds. Usually "
+                    "means the node is short of CPU. Auto-resolves once a window "
+                    "passes with no loss. Set the rule's minimum-count threshold to "
+                    "alert only past a number of packets."
+                ),
+                rule_type=RULE_TYPE_DHCP_PACKETS_DROPPED,
+                severity="warning",
+                enabled=True,
+                notify_syslog=True,
+                notify_webhook=True,
+                notify_smtp=False,
+            )
+        )
+        await session.commit()
+
+
 _DNS_NXDOMAIN_SPIKE_RULE_NAME = "DNS NXDOMAIN spike"
 _DNS_QUERY_RATE_SPIKE_RULE_NAME = "DNS query-rate spike"
 
@@ -4930,6 +5112,10 @@ async def evaluate_all(db: AsyncSession) -> dict[str, int]:
                 base = await _matching_dns_query_rate_spike_subjects(db, rule)
                 matches = [(sid, disp, msg, None) for sid, disp, msg in base]
                 subject_type = "dns_server"
+            elif rule.rule_type == RULE_TYPE_DHCP_PACKETS_DROPPED:
+                base = await _matching_dhcp_packets_dropped_subjects(db, rule)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in base]
+                subject_type = "dhcp_server"
             elif rule.rule_type == RULE_TYPE_DNS_RATE_LIMIT_DROPPING:
                 base = await _matching_dns_rate_limit_dropping_subjects(db, rule)
                 matches = [(sid, disp, msg, None) for sid, disp, msg in base]

--- a/backend/app/services/dhcp/config_bundle.py
+++ b/backend/app/services/dhcp/config_bundle.py
@@ -384,6 +384,15 @@ async def build_config_bundle(db: AsyncSession, server: DHCPServer) -> ConfigBun
     lease_cache_threshold = 0.0 if _group_threshold is None else float(_group_threshold)
     lease_cache_max_age = getattr(group, "lease_cache_max_age", None) if group else None
 
+    # #980 — Kea packet-worker pool size. ``is None`` rather than ``or``: 0 is
+    # a real value here (it means "let Kea auto-size"), so a truthiness
+    # coalesce would silently rewrite the one setting an operator uses to opt
+    # back out of this change into the default they were opting out of.
+    _pool = getattr(group, "kea_thread_pool_size", None) if group else None
+    kea_thread_pool_size = 1 if _pool is None else int(_pool)
+    _pktlog = getattr(group, "kea_packet_logging", None) if group else None
+    kea_packet_logging = True if _pktlog is None else bool(_pktlog)
+
     bundle = ConfigBundle(
         server_id=str(server.id),
         server_name=server.name,
@@ -401,6 +410,8 @@ async def build_config_bundle(db: AsyncSession, server: DHCPServer) -> ConfigBun
         dhcp_socket_type=dhcp_socket_type,
         lease_cache_threshold=lease_cache_threshold,
         lease_cache_max_age=lease_cache_max_age,
+        kea_thread_pool_size=kea_thread_pool_size,
+        kea_packet_logging=kea_packet_logging,
         ra_configs=tuple(ra_configs),
         radvd_conf=radvd_conf,
     )

--- a/backend/app/services/influxdb/collect.py
+++ b/backend/app/services/influxdb/collect.py
@@ -155,7 +155,11 @@ async def collect_dns_points(
 async def collect_dhcp_points(
     db: AsyncSession, watermark: datetime | None
 ) -> tuple[list[Point], datetime | None]:
-    """DHCP message-count deltas — same two-query shape as the DNS side."""
+    """DHCP message-count deltas — same two-query shape as the DNS side.
+
+    Carries the #980 loss counters too. They are the only reason a field can
+    be absent from a point here: everything else is NOT NULL.
+    """
 
     def _point(sample: Any, server_name: str | None) -> Point:
         return Point(
@@ -170,6 +174,21 @@ async def collect_dhcp_points(
                 "decline": int(sample.decline),
                 "release": int(sample.release),
                 "inform": int(sample.inform),
+                # #980 — loss, not traffic. Omitted (not zero-filled) when
+                # NULL: the agent did not measure it, and line protocol has
+                # no null, so writing 0 would assert "no packets were lost"
+                # on a server nobody looked at. An absent field leaves a gap
+                # in the series, which is the honest rendering.
+                **(
+                    {"socket_drop": int(sample.socket_drop)}
+                    if sample.socket_drop is not None
+                    else {}
+                ),
+                **(
+                    {"receive_drop": int(sample.receive_drop)}
+                    if sample.receive_drop is not None
+                    else {}
+                ),
             },
             timestamp=_epoch(sample.bucket_at),
         )

--- a/backend/tests/test_ci_backend_relevant.py
+++ b/backend/tests/test_ci_backend_relevant.py
@@ -50,6 +50,7 @@ _KNOWN_REPO_ROOT_READS: dict[str, str] = {
     "test_openapi_export.py": "scripts/export_openapi.py",
     "test_outbound_hosts_documented.py": "docs/PRIVACY.md",
     "test_zone_name_scope.py": "scripts/refresh_iana_tlds.py",
+    "test_dhcp_packet_loss.py": "agent/dhcp/spatium_dhcp_agent/metrics.py",
 }
 
 # ``parents[2]`` from backend/tests/x.py is the repo root; anything at that

--- a/backend/tests/test_dhcp_packet_loss.py
+++ b/backend/tests/test_dhcp_packet_loss.py
@@ -87,6 +87,22 @@ def test_thread_pool_size_shifts_the_etag() -> None:
     )
 
 
+def test_packet_logging_shows_in_the_rendered_preview() -> None:
+    """The preview is what an operator checks a setting against.
+
+    It already omits most daemon plumbing and does not parse as a Kea
+    config, but it does carry the group tunables — ``dhcp_socket_type``
+    (#365) and ``cache-threshold`` (#637) are both there — so a #980 knob
+    that was invisible would have the operator seeing one of the two
+    settings they just changed.
+    """
+    on = json.loads(KeaDriver().render_config(_bundle(kea_packet_logging=True)))
+    assert "loggers" not in on["Dhcp4"], "default must render exactly as before"
+
+    off = json.loads(KeaDriver().render_config(_bundle(kea_packet_logging=False)))
+    assert off["Dhcp4"]["loggers"] == [{"name": "kea-dhcp4.packets", "severity": "WARN"}]
+
+
 def test_packet_logging_shifts_the_etag() -> None:
     assert (
         _bundle(kea_packet_logging=True).compute_etag()

--- a/backend/tests/test_dhcp_packet_loss.py
+++ b/backend/tests/test_dhcp_packet_loss.py
@@ -222,7 +222,7 @@ async def test_alert_fires_on_measured_socket_loss(db_session: AsyncSession) -> 
     srv = await _server_with_samples(db_session, [{"socket_drop": 12, "receive_drop": 0}])
     matches = await _matching_dhcp_packets_dropped_subjects(db_session, _rule())
     assert [m[0] for m in matches] == [str(srv.id)]
-    assert "12 dropped by the kernel" in matches[0][2]
+    assert "lost 12 packet(s)" in matches[0][2]
 
 
 async def test_alert_is_silent_when_loss_was_measured_as_zero(
@@ -242,14 +242,46 @@ async def test_alert_is_silent_when_loss_was_never_measured(
     assert await _matching_dhcp_packets_dropped_subjects(db_session, _rule()) == []
 
 
-async def test_alert_separates_the_two_kinds_of_loss(db_session: AsyncSession) -> None:
-    """They are fixed in different places — one is capacity, the other is
-    configuration — so the message must not merge them into one number."""
+async def test_alert_never_fires_on_receive_drop_alone(
+    db_session: AsyncSession,
+) -> None:
+    """THE REGRESSION THIS RULE MUST NOT HAVE.
+
+    ``pkt4-receive-drop`` counts packets Kea read and discarded ON PURPOSE as
+    well as by accident. Verified against kea-dhcp4 3.0.3: a client matching
+    a ``DROP`` client-class increments it once per blocked packet, and a
+    ``DROP`` class is exactly what the shipped DHCP MAC blocklist renders;
+    the HA hook drops out-of-scope queries in hot-standby the same way.
+
+    A default-on rule that counted it would therefore fire permanently, and
+    never auto-resolve, on two ordinary correctly-working configurations.
+    """
+    await _server_with_samples(db_session, [{"socket_drop": 0, "receive_drop": 5000}])
+    assert await _matching_dhcp_packets_dropped_subjects(db_session, _rule()) == []
+
+
+async def test_alert_is_silent_when_only_socket_drop_is_unmeasured(
+    db_session: AsyncSession,
+) -> None:
+    """The subtle half: ``receive_drop`` always arrives from a #980 agent, so
+    a server whose procfs is unreadable has receive_drop set and socket_drop
+    NULL. Testing the pair for "was this measured?" would call that
+    measured-and-clean; it must read as unmeasured."""
+    await _server_with_samples(db_session, [{"receive_drop": 3}])
+    assert await _matching_dhcp_packets_dropped_subjects(db_session, _rule()) == []
+
+
+async def test_alert_reports_receive_drop_as_context_when_it_fires(
+    db_session: AsyncSession,
+) -> None:
+    """It is not the trigger, but it is worth telling the operator about —
+    labelled as possibly-deliberate rather than as lost traffic."""
     await _server_with_samples(db_session, [{"socket_drop": 7, "receive_drop": 3}])
     matches = await _matching_dhcp_packets_dropped_subjects(db_session, _rule())
     msg = matches[0][2]
-    assert "7 dropped by the kernel" in msg
-    assert "3 read and then discarded" in msg
+    assert "lost 7 packet(s)" in msg
+    assert "3 packet(s) were read and then discarded" in msg
+    assert "deliberate drops" in msg
 
 
 async def test_alert_floor_is_honoured(db_session: AsyncSession) -> None:

--- a/backend/tests/test_dhcp_packet_loss.py
+++ b/backend/tests/test_dhcp_packet_loss.py
@@ -1,0 +1,470 @@
+"""#980 — DHCP packet-loss metrics and the two Kea packet-path settings.
+
+Three things under test, and what each would look like if it broke:
+
+* the bundle plumbing for ``kea_thread_pool_size`` / ``kea_packet_logging``
+  — a value stored and shipped but never rendered is a silent no-op, and a
+  value not folded into the ETag never reaches a running agent at all;
+* the ingest path's NULL-vs-0 discipline — an agent too old to measure loss
+  must be UNKNOWN, because 0 reads as "this server has dropped nothing",
+  which is the false reassurance the issue was filed about;
+* the alert evaluator, which must fire on measured loss and stay silent on
+  unmeasured — not the other way round.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.drivers.dhcp.base import ConfigBundle, PoolDef, ScopeDef, ServerOptionsDef
+from app.drivers.dhcp.kea import KeaDriver
+from app.models.alerts import AlertRule
+from app.models.auth import User
+from app.models.dhcp import DHCPServer, DHCPServerGroup
+from app.models.metrics import DHCPMetricSample
+from app.services.alerts import (
+    RULE_TYPE_DHCP_PACKETS_DROPPED,
+    _matching_dhcp_packets_dropped_subjects,
+)
+from app.services.dhcp.config_bundle import build_config_bundle
+
+CIDR = "10.98.0.0/24"
+
+
+def _bundle(**kw) -> ConfigBundle:
+    return ConfigBundle(
+        server_id="00000000-0000-0000-0000-000000000980",
+        server_name="kea-980",
+        driver="kea",
+        roles=(),
+        options=ServerOptionsDef(options={}, lease_time=3600),
+        scopes=(
+            ScopeDef(
+                subnet_cidr=CIDR,
+                pools=(PoolDef(start_ip="10.98.0.100", end_ip="10.98.0.200"),),
+            ),
+        ),
+        client_classes=(),
+        generated_at=datetime.now(UTC),
+        **kw,
+    )
+
+
+# ── driver render + ETag ────────────────────────────────────────────────
+
+
+def test_thread_pool_size_is_rendered() -> None:
+    cfg = json.loads(KeaDriver().render_config(_bundle(kea_thread_pool_size=2)))
+    mt = cfg["Dhcp4"]["multi-threading"]
+    assert mt["thread-pool-size"] == 2
+    # A pool of N is a resize, not a mode change: with MT off one thread has
+    # to both receive and process, which measured 15,170 socket drops in a
+    # run where a pool of one had none.
+    assert mt["enable-multi-threading"] is True
+
+
+def test_bundle_defaults_to_one_worker_not_keas_auto() -> None:
+    """Kea's own default sizes the pool from the machine's CPU count with no
+    regard for the container's cgroup share — verified live: a container
+    limited to 0.20 CPU started ten workers. A bundle built without a group
+    must not inherit that."""
+    assert _bundle().kea_thread_pool_size == 1
+
+
+def test_thread_pool_size_shifts_the_etag() -> None:
+    """Not folded into the ETag means a change never wakes a long-polling
+    agent — the #430 silent no-op."""
+    assert (
+        _bundle(kea_thread_pool_size=1).compute_etag()
+        != _bundle(kea_thread_pool_size=4).compute_etag()
+    )
+
+
+def test_packet_logging_shifts_the_etag() -> None:
+    assert (
+        _bundle(kea_packet_logging=True).compute_etag()
+        != _bundle(kea_packet_logging=False).compute_etag()
+    )
+
+
+# ── build_config_bundle: group column → bundle ──────────────────────────
+
+
+async def _group_with_server(db: AsyncSession, **group_kw) -> DHCPServer:
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:8]}", **group_kw)
+    db.add(grp)
+    await db.flush()
+    srv = DHCPServer(
+        name=f"kea-{uuid.uuid4().hex[:6]}",
+        driver="kea",
+        host="127.0.0.1",
+        port=67,
+        server_group_id=grp.id,
+    )
+    db.add(srv)
+    await db.flush()
+    return srv
+
+
+async def test_group_pool_size_reaches_the_bundle(db_session: AsyncSession) -> None:
+    srv = await _group_with_server(db_session, kea_thread_pool_size=4)
+    bundle = await build_config_bundle(db_session, srv)
+    assert bundle.kea_thread_pool_size == 4
+
+
+async def test_group_zero_is_not_coalesced_to_the_default(
+    db_session: AsyncSession,
+) -> None:
+    """0 means "let Kea auto-size" — the one setting an operator uses to opt
+    OUT of this change. A truthiness coalesce would silently put them back
+    on the default they were escaping."""
+    srv = await _group_with_server(db_session, kea_thread_pool_size=0)
+    bundle = await build_config_bundle(db_session, srv)
+    assert bundle.kea_thread_pool_size == 0
+
+
+async def test_group_packet_logging_off_reaches_the_bundle(
+    db_session: AsyncSession,
+) -> None:
+    """False is falsy; the same coalesce hazard, in the other type."""
+    srv = await _group_with_server(db_session, kea_packet_logging=False)
+    bundle = await build_config_bundle(db_session, srv)
+    assert bundle.kea_packet_logging is False
+
+
+# ── group API round-trip ────────────────────────────────────────────────
+
+
+async def _superadmin(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def test_group_api_round_trips_the_packet_path_settings(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _superadmin(db_session)
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    r = await client.post(
+        "/api/v1/dhcp/server-groups", headers=h, json={"name": f"g-{uuid.uuid4().hex[:6]}"}
+    )
+    assert r.status_code == 201, r.text
+    gid = r.json()["id"]
+    assert r.json()["kea_thread_pool_size"] == 1
+    assert r.json()["kea_packet_logging"] is True
+
+    r = await client.put(
+        f"/api/v1/dhcp/server-groups/{gid}",
+        headers=h,
+        json={"kea_thread_pool_size": 0, "kea_packet_logging": False},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["kea_thread_pool_size"] == 0
+    assert r.json()["kea_packet_logging"] is False
+
+
+async def test_group_api_rejects_an_absurd_pool_size(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _superadmin(db_session)
+    await db_session.commit()
+    r = await client.post(
+        "/api/v1/dhcp/server-groups",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"name": f"g-{uuid.uuid4().hex[:6]}", "kea_thread_pool_size": 5000},
+    )
+    assert r.status_code == 422, r.text
+
+
+# ── the alert evaluator ─────────────────────────────────────────────────
+
+
+async def _server_with_samples(db: AsyncSession, rows: list[dict]) -> DHCPServer:
+    srv = await _group_with_server(db)
+    base = datetime.now(UTC) - timedelta(minutes=5)
+    for i, row in enumerate(rows):
+        db.add(
+            DHCPMetricSample(
+                server_id=srv.id,
+                bucket_at=base + timedelta(minutes=i),
+                discover=row.get("discover", 10),
+                **{k: v for k, v in row.items() if k != "discover"},
+            )
+        )
+    await db.flush()
+    return srv
+
+
+def _rule() -> AlertRule:
+    return AlertRule(
+        name="t", rule_type=RULE_TYPE_DHCP_PACKETS_DROPPED, severity="warning", enabled=True
+    )
+
+
+async def test_alert_fires_on_measured_socket_loss(db_session: AsyncSession) -> None:
+    srv = await _server_with_samples(db_session, [{"socket_drop": 12, "receive_drop": 0}])
+    matches = await _matching_dhcp_packets_dropped_subjects(db_session, _rule())
+    assert [m[0] for m in matches] == [str(srv.id)]
+    assert "12 dropped by the kernel" in matches[0][2]
+
+
+async def test_alert_is_silent_when_loss_was_measured_as_zero(
+    db_session: AsyncSession,
+) -> None:
+    await _server_with_samples(db_session, [{"socket_drop": 0, "receive_drop": 0}])
+    assert await _matching_dhcp_packets_dropped_subjects(db_session, _rule()) == []
+
+
+async def test_alert_is_silent_when_loss_was_never_measured(
+    db_session: AsyncSession,
+) -> None:
+    """An agent older than #980 reports neither counter. SUM over its rows is
+    NULL, and NULL must not be read as either loss or its absence — the
+    server is skipped, not alarmed on and not vouched for."""
+    await _server_with_samples(db_session, [{"discover": 500}])
+    assert await _matching_dhcp_packets_dropped_subjects(db_session, _rule()) == []
+
+
+async def test_alert_separates_the_two_kinds_of_loss(db_session: AsyncSession) -> None:
+    """They are fixed in different places — one is capacity, the other is
+    configuration — so the message must not merge them into one number."""
+    await _server_with_samples(db_session, [{"socket_drop": 7, "receive_drop": 3}])
+    matches = await _matching_dhcp_packets_dropped_subjects(db_session, _rule())
+    msg = matches[0][2]
+    assert "7 dropped by the kernel" in msg
+    assert "3 read and then discarded" in msg
+
+
+async def test_alert_floor_is_honoured(db_session: AsyncSession) -> None:
+    await _server_with_samples(db_session, [{"socket_drop": 5}])
+    rule = _rule()
+    rule.min_free_addresses = 100
+    assert await _matching_dhcp_packets_dropped_subjects(db_session, rule) == []
+    rule.min_free_addresses = 5
+    assert len(await _matching_dhcp_packets_dropped_subjects(db_session, rule)) == 1
+
+
+# ── the ingest path ─────────────────────────────────────────────────────
+#
+# Two behaviours, one of them a deliberate change to a shipped endpoint.
+#
+# NULL discipline: an agent that omits the loss fields (older than #980, or
+# unable to read procfs) must store NULL, and an agent that reports 0 must
+# store 0. Collapsing those makes an un-upgraded fleet read as a fleet with
+# no packet loss.
+#
+# Accumulation: a second report for an existing bucket is ADDED, not
+# substituted. The agent floors ``bucket_at`` to the minute while its own
+# interval is 60 s +/- 3 s of jitter, so a tick early in a minute followed by
+# a 57-59 s gap lands two genuinely different deltas in the same bucket.
+# Overwriting — the original behaviour — silently discarded one of them,
+# which for a loss counter discards exactly the minute being looked for.
+
+
+async def _committed_server(db: AsyncSession) -> DHCPServer:
+    """Create a server, commit, and hand back a LIVE instance.
+
+    ``commit()`` expires every attribute, so touching ``srv.id`` afterwards
+    triggers a lazy refresh outside the async greenlet and raises
+    MissingGreenlet. Re-getting after the commit rebinds it to the session.
+    """
+    srv = await _group_with_server(db)
+    sid = srv.id
+    await db.commit()
+    got = await db.get(DHCPServer, sid)
+    assert got is not None
+    return got
+
+
+async def _post_metric(client: AsyncClient, server: DHCPServer, **body):
+    from app.api.v1.dhcp.agents import _auth_agent
+    from app.main import app
+
+    app.dependency_overrides[_auth_agent] = lambda: (server, {})
+    try:
+        return await client.post("/api/v1/dhcp/agents/metrics", json=body)
+    finally:
+        app.dependency_overrides.pop(_auth_agent, None)
+
+
+async def _sample(db: AsyncSession, server_id, at) -> DHCPMetricSample:
+    """Read the row back with a fresh SELECT.
+
+    Not ``db.get`` after ``expire_all``: the endpoint commits in the app's
+    own session, so the test session's identity map holds a stale instance
+    and expiring it makes the next attribute access try to check out a
+    connection of its own.
+    """
+    row = (
+        await db.execute(
+            select(DHCPMetricSample)
+            .where(DHCPMetricSample.server_id == server_id)
+            .where(DHCPMetricSample.bucket_at == at)
+        )
+    ).scalar_one_or_none()
+    return row
+
+
+async def test_omitted_loss_fields_store_null_not_zero(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    srv = await _committed_server(db_session)
+    sid = srv.id
+    at = datetime(2026, 9, 6, 10, 0, tzinfo=UTC)
+
+    r = await _post_metric(client, srv, bucket_at=at.isoformat(), discover=5)
+    assert r.status_code == 200, r.text
+
+    row = await _sample(db_session, sid, at)
+    assert row is not None
+    assert row.discover == 5
+    assert row.socket_drop is None
+    assert row.receive_drop is None
+
+
+async def test_reported_zero_stores_zero(client: AsyncClient, db_session: AsyncSession) -> None:
+    """The other side of the same coin: a working agent that measured no loss
+    must be distinguishable from one that cannot measure."""
+    srv = await _committed_server(db_session)
+    sid = srv.id
+    at = datetime(2026, 9, 6, 10, 1, tzinfo=UTC)
+
+    r = await _post_metric(
+        client, srv, bucket_at=at.isoformat(), discover=5, socket_drop=0, receive_drop=0
+    )
+    assert r.status_code == 200, r.text
+
+    row = await _sample(db_session, sid, at)
+    assert row.socket_drop == 0
+    assert row.receive_drop == 0
+
+
+async def test_a_second_report_for_one_bucket_accumulates(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    srv = await _committed_server(db_session)
+    sid = srv.id
+    at = datetime(2026, 9, 6, 10, 2, tzinfo=UTC)
+
+    await _post_metric(client, srv, bucket_at=at.isoformat(), discover=5, socket_drop=2)
+    await _post_metric(client, srv, bucket_at=at.isoformat(), discover=7, socket_drop=3)
+
+    row = await _sample(db_session, sid, at)
+    assert row.discover == 12
+    assert row.socket_drop == 5
+
+
+async def test_an_unmeasured_second_poll_does_not_erase_a_measured_first(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """UNKNOWN + n = n. One poll failing to read procfs must not throw away
+    what its neighbour in the same bucket did measure."""
+    srv = await _committed_server(db_session)
+    sid = srv.id
+    at = datetime(2026, 9, 6, 10, 3, tzinfo=UTC)
+
+    await _post_metric(client, srv, bucket_at=at.isoformat(), discover=1, socket_drop=9)
+    await _post_metric(client, srv, bucket_at=at.isoformat(), discover=1)
+
+    row = await _sample(db_session, sid, at)
+    assert row.socket_drop == 9
+    assert row.discover == 2
+
+
+async def test_a_measured_second_poll_fills_an_unmeasured_first(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    srv = await _committed_server(db_session)
+    sid = srv.id
+    at = datetime(2026, 9, 6, 10, 4, tzinfo=UTC)
+
+    await _post_metric(client, srv, bucket_at=at.isoformat(), discover=1)
+    await _post_metric(client, srv, bucket_at=at.isoformat(), discover=1, socket_drop=4)
+
+    row = await _sample(db_session, sid, at)
+    assert row.socket_drop == 4
+
+
+async def test_two_unmeasured_polls_leave_the_bucket_unmeasured(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    srv = await _committed_server(db_session)
+    sid = srv.id
+    at = datetime(2026, 9, 6, 10, 5, tzinfo=UTC)
+
+    await _post_metric(client, srv, bucket_at=at.isoformat(), discover=1)
+    await _post_metric(client, srv, bucket_at=at.isoformat(), discover=1)
+
+    row = await _sample(db_session, sid, at)
+    assert row.socket_drop is None
+
+
+# ── the agent/server column-name boundary ───────────────────────────────
+
+
+def test_agent_metric_columns_match_the_ingest_model() -> None:
+    """The agent's column names must be exactly the ingest model's fields.
+
+    ``DHCPMetricReport`` does not set ``extra="forbid"`` — deliberately, so a
+    newer agent posting a field an older control plane has never heard of
+    loses that field rather than having the whole sample 422'd mid-upgrade.
+    The cost of that choice is that a *typo* is equally silent: the agent
+    would post ``socket_drops``, pydantic would drop it, the column would
+    stay NULL forever, and every surface would render "loss not measured" on
+    a fleet that is measuring perfectly well.
+
+    So the boundary is pinned here instead. Reads the agent source rather
+    than importing it: ``agent/dhcp`` is a separate distribution and is not
+    installed in the backend's environment.
+    """
+    import ast
+    from pathlib import Path
+
+    from app.api.v1.dhcp.agents import DHCPMetricReport
+
+    agent_src = (
+        Path(__file__).resolve().parents[2] / "agent" / "dhcp" / "spatium_dhcp_agent" / "metrics.py"
+    )
+    if not agent_src.exists():  # pragma: no cover - see docstring
+        import pytest
+
+        pytest.skip(f"agent source not present at {agent_src} (backend-only checkout)")
+
+    tree = ast.parse(agent_src.read_text())
+    stat_map: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "_STAT_MAP" for t in node.targets
+        ):
+            assert isinstance(node.value, ast.Dict)
+            for k, v in zip(node.value.keys, node.value.values, strict=True):
+                assert isinstance(k, ast.Constant) and isinstance(v, ast.Constant)
+                stat_map[k.value] = v.value
+    assert stat_map, "could not find _STAT_MAP in the agent source"
+
+    # Every column the agent computes a delta for must be a field the server
+    # stores. ``socket_drop`` is not in _STAT_MAP — it comes from procfs, not
+    # from Kea — so it is added here explicitly rather than being forgotten.
+    agent_columns = set(stat_map.values()) | {"socket_drop"}
+    model_fields = set(DHCPMetricReport.model_fields) - {"bucket_at"}
+    assert agent_columns == model_fields, (
+        f"agent sends {sorted(agent_columns - model_fields)} the server ignores; "
+        f"server expects {sorted(model_fields - agent_columns)} the agent never sends"
+    )

--- a/backend/tests/test_dhcp_wire_bundle_coverage.py
+++ b/backend/tests/test_dhcp_wire_bundle_coverage.py
@@ -50,6 +50,8 @@ SHIPPED: frozenset[str] = frozenset(
         "dhcp_socket_type",  # → inside the synthesized "server" block
         "lease_cache_threshold",  # → "server" block (group-wide default)
         "lease_cache_max_age",  # → "server" block
+        "kea_thread_pool_size",  # #980 → "server" block
+        "kea_packet_logging",  # #980 → "server" block
         "radvd_conf",
         "ra_configs",
     }

--- a/backend/tests/test_influxdb_export.py
+++ b/backend/tests/test_influxdb_export.py
@@ -610,3 +610,78 @@ async def test_scope_lease_gauge_counts_addresses_not_rows(
     points = await collect_dhcp_scope_lease_points(db_session, datetime.now(UTC))
     gauge = next(p for p in points if p.tags["scope_id"] == str(scope.id))
     assert gauge.fields["active_leases"] == 2  # not 3
+
+
+# ── #980 loss counters in the DHCP export ──────────────────────────
+
+
+async def _dhcp_sample(db: AsyncSession, bucket_at: datetime, **loss: int | None) -> uuid.UUID:
+    from app.models.dhcp import DHCPServer, DHCPServerGroup
+    from app.models.metrics import DHCPMetricSample
+
+    group = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(group)
+    await db.flush()
+    server = DHCPServer(
+        server_group_id=group.id,
+        name=f"kea {uuid.uuid4().hex[:4]}",
+        driver="kea",
+        host="10.0.0.67",
+        port=67,
+    )
+    db.add(server)
+    await db.flush()
+    db.add(
+        DHCPMetricSample(
+            server_id=server.id,
+            bucket_at=bucket_at,
+            discover=5,
+            offer=5,
+            request=5,
+            ack=5,
+            nak=0,
+            decline=0,
+            release=0,
+            inform=0,
+            **loss,
+        )
+    )
+    await db.flush()
+    return server.id
+
+
+@pytest.mark.asyncio
+async def test_dhcp_export_carries_the_loss_counters(db_session: AsyncSession) -> None:
+    """#980 — they were the only DHCPMetricSample columns the exporter missed."""
+    from app.services.influxdb.collect import collect_dhcp_points
+
+    base = datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=10)
+    await _dhcp_sample(db_session, base, socket_drop=12, receive_drop=3)
+
+    points, _ = await collect_dhcp_points(db_session, None)
+    assert len(points) == 1
+    assert points[0].fields["socket_drop"] == 12
+    assert points[0].fields["receive_drop"] == 3
+
+
+@pytest.mark.asyncio
+async def test_dhcp_export_omits_an_unmeasured_counter(db_session: AsyncSession) -> None:
+    """Line protocol has no null, so an unmeasured counter must be OMITTED.
+
+    Writing 0 would assert "no packets were lost" on a server nobody looked
+    at — the same false reassurance #980 exists to remove, published into the
+    operator's long-term metrics store where it outlives the agent upgrade
+    that would have corrected it. An absent field leaves a gap in the series,
+    which is the honest rendering.
+    """
+    from app.services.influxdb.collect import collect_dhcp_points
+
+    base = datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=10)
+    await _dhcp_sample(db_session, base, socket_drop=None, receive_drop=None)
+
+    points, _ = await collect_dhcp_points(db_session, None)
+    assert len(points) == 1
+    assert "socket_drop" not in points[0].fields
+    assert "receive_drop" not in points[0].fields
+    # The traffic counters are unaffected — the point is still emitted.
+    assert points[0].fields["discover"] == 5

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -209,19 +209,24 @@ async def test_invalid_window_rejected(client: AsyncClient, db_session: AsyncSes
 async def test_dhcp_agent_metrics_ingest_roundtrip(
     client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """POST → dedupe on (server_id, bucket_at) → read back via /timeseries.
+    """Direct insert → read back via /timeseries.
 
-    We skip the real agent auth path for brevity — the critical
-    invariant is that a repeat POST overwrites instead of duplicating.
+    This does NOT exercise the ingest handler — it writes rows straight to
+    the table — so it says nothing about what a repeat POST does. That
+    behaviour changed in #980 (a second report for an existing bucket is now
+    ADDED, not substituted, because the agent's minute-floored bucket and its
+    60 s +/- 3 s interval put two real deltas in one bucket about once in
+    forty) and is covered by the round-trip tests in
+    ``test_dhcp_packet_loss.py``. What this test pins is the read side:
+    one row per (server_id, bucket_at), surfaced by the timeseries endpoint.
     """
     _, token = await _make_user(db_session)
     server = await _make_dhcp_server(db_session)
     now = datetime.now(UTC).replace(second=0, microsecond=0)
 
-    # Insert directly (agent-auth happy-path is covered elsewhere):
-    # two writes to the same bucket with different values — the second
-    # must overwrite, not duplicate, so the read-back shows 7/5, not
-    # (3/2) + (7/5).
+    # Insert directly (the ingest handler is covered in
+    # test_dhcp_packet_loss.py): the primary key admits one row per
+    # (server_id, bucket_at), so the read-back shows that row's values.
     db_session.add(
         DHCPMetricSample(
             server_id=server.id,

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -616,23 +616,31 @@ bucket_at, discover, offer, request, ack, nak, decline, release,
 inform, receive_drop, socket_drop)`. Retention is enforced by the
 `prune_metric_samples` Celery task (daily, default 7 days).
 
-Two of those DHCP columns are *loss* rather than traffic, and they do not
-come from the same place (issue #980). `receive_drop` is Kea's own
-`pkt4/6-receive-drop` — packets it read and then discarded. `socket_drop`
-is the kernel's per-socket `sk_drops` from `/proc/net/udp`, read by the
-agent directly: packets discarded because Kea's receive buffer was full,
-so Kea never saw them and no counter it keeps can report them. On a node
-short of CPU only the second one moves, which is why both are carried
-rather than just the one the issue originally asked for. See
-[`DHCP.md` §4c](features/DHCP.md).
+Two of those DHCP columns are about packets *not* handled, and they do not
+come from the same place or mean the same thing (issue #980).
+`socket_drop` is the kernel's per-socket `sk_drops` from `/proc/net/udp`,
+read by the agent directly: packets discarded because Kea's receive buffer
+was full, so Kea never saw them and no counter it keeps can report them.
+On a node short of CPU only this one moves, and it is the one the alert
+and the dashboard treat as loss.
+
+`receive_drop` is Kea's own `pkt4/6-receive-drop` — packets it read and then
+discarded — and is **context, not a fault**: it counts deliberate drops too.
+Verified against kea-dhcp4 3.0.3, a client matching a `DROP` client-class
+increments it once per packet, and a `DROP` class is exactly what the shipped
+DHCP MAC blocklist renders. See [`DHCP.md` §4c](features/DHCP.md).
 
 **Both are nullable, and NULL means UNMEASURED.** An agent older than #980,
-or one whose runtime cannot read `/proc/net/udp`, reports neither. Readers
-must render that as unknown — a 0 would say "this server has dropped
+or one whose runtime cannot read `/proc/net/udp`, reports no `socket_drop`.
+Readers must render that as unknown — a 0 would say "this server has dropped
 nothing", which is exactly the false reassurance #980 was filed about. The
 ingest endpoint therefore stores an omitted field as NULL rather than
-clamping it, and the `dhcp_packets_dropped` alert skips such a server
-rather than vouching for it.
+clamping it, the `dhcp_packets_dropped` alert skips such a server rather than
+vouching for it, and every "was this measured?" test keys on `socket_drop`
+alone (`receive_drop` always arrives from a #980 agent, so testing the pair
+would read an unmeasurable server as measured-and-clean). The InfluxDB
+exporter omits the field entirely rather than writing 0, since line protocol
+has no null.
 
 One more thing worth knowing about this endpoint: a second report for a
 bucket that already exists is **added** to it, not substituted. The agent

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -613,8 +613,34 @@ The control plane stores deltas in two small tables —
 `dns_metric_sample(server_id, bucket_at, queries_total, noerror,
 nxdomain, servfail, recursion)` and `dhcp_metric_sample(server_id,
 bucket_at, discover, offer, request, ack, nak, decline, release,
-inform)`. Retention is enforced by the `prune_metric_samples`
-Celery task (daily, default 7 days).
+inform, receive_drop, socket_drop)`. Retention is enforced by the
+`prune_metric_samples` Celery task (daily, default 7 days).
+
+Two of those DHCP columns are *loss* rather than traffic, and they do not
+come from the same place (issue #980). `receive_drop` is Kea's own
+`pkt4/6-receive-drop` — packets it read and then discarded. `socket_drop`
+is the kernel's per-socket `sk_drops` from `/proc/net/udp`, read by the
+agent directly: packets discarded because Kea's receive buffer was full,
+so Kea never saw them and no counter it keeps can report them. On a node
+short of CPU only the second one moves, which is why both are carried
+rather than just the one the issue originally asked for. See
+[`DHCP.md` §4c](features/DHCP.md).
+
+**Both are nullable, and NULL means UNMEASURED.** An agent older than #980,
+or one whose runtime cannot read `/proc/net/udp`, reports neither. Readers
+must render that as unknown — a 0 would say "this server has dropped
+nothing", which is exactly the false reassurance #980 was filed about. The
+ingest endpoint therefore stores an omitted field as NULL rather than
+clamping it, and the `dhcp_packets_dropped` alert skips such a server
+rather than vouching for it.
+
+One more thing worth knowing about this endpoint: a second report for a
+bucket that already exists is **added** to it, not substituted. The agent
+floors `bucket_at` to the minute while its own interval is 60 s ± 3 s of
+jitter, so a tick early in a minute followed by a 57-59 s gap puts two
+genuinely different deltas in the same bucket — about one bucket in forty.
+Substituting (the pre-#980 behaviour) silently discarded a poll, which for
+a loss counter discards the minute somebody is looking for.
 
 The dashboard queries two read endpoints:
 

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -113,7 +113,24 @@ not the operator's:
   fourth CPU happens to be free for Kea — and why 3 vCPU sits at the knee.
   A larger socket receive buffer does not help: with 8 MiB of buffer the drops
   vanish but a DORA takes 34 s instead of 1.5 s, because Kea then answers
-  stale requests whole retransmit rounds late.
+  stale requests whole retransmit rounds late. Nor does a larger Kea
+  `packet-queue-size`: 64 → 2048 changed neither throughput nor drops, because
+  that queue sits behind the receive thread and the problem is the receive
+  thread not being scheduled.
+- Kea's own packet-worker pool is sized from the **machine's** CPU count, not
+  from the container's cgroup share, so on a 4 vCPU appliance it starts four
+  workers that compete with the one thread draining the receive socket
+  (spatiumddi#980). SpatiumDDI now renders `thread-pool-size: 1` explicitly:
+  measured at 12,000 relayed pkt/s, that served 19,381 packets against 6,723
+  for four workers at 0.25 CPU, and 93,717 against 55,957 with four CPUs and
+  no quota. It is a per-group setting; `0` restores Kea's auto-sizing.
+- **When a Kea server is short of CPU it loses packets silently.** Every
+  server-side counter stays green — it answers 100 % of what it reads, and
+  `pkt4-receive-drop` stays at 0 through the whole thing — because the loss is
+  the kernel discarding datagrams before Kea reads them. The per-bucket
+  `socket_drop` metric and the default-on `dhcp_packets_dropped` alert are the
+  only signals that name it; see
+  [`DHCP.md` §4c](../features/DHCP.md).
 
 Beyond that: **500k records in one group** is not a supported single-node
 size at any RAM tested (up to 10 GiB) — the api's bundle build for the
@@ -583,6 +600,12 @@ appliance dropping relayed DHCP under CPU pressure with every dashboard
 green — and it stayed green because utilisation cannot distinguish a node at
 70% CPU with a run queue behind one core from a node at 70% without one.
 Only the first drops traffic. Stall time is what separates them.
+
+PSI names the *cause*; the `socket_drop` metric added by #980 itself names
+the *effect*, per DHCP server rather than per node. They are worth reading
+together: PSI says the node is stalling, `socket_drop` says DHCP was what
+paid for it, and a node stalling with no DHCP loss is a node with headroom
+left. See [`DHCP.md` §4c](../features/DHCP.md).
 
 Surfaced in three places, all reading `avg300` (the kernel's own 5-minute
 rolling average, which is why "sustained" needs no state on our side — a

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -129,8 +129,10 @@ not the operator's:
   `pkt4-receive-drop` stays at 0 through the whole thing — because the loss is
   the kernel discarding datagrams before Kea reads them. The per-bucket
   `socket_drop` metric and the default-on `dhcp_packets_dropped` alert are the
-  only signals that name it; see
-  [`DHCP.md` §4c](../features/DHCP.md).
+  only signals that name it — and note it is `socket_drop` specifically:
+  Kea's own `pkt4-receive-drop` also counts deliberate drops (a blocklisted
+  MAC, an HA standby declining an out-of-scope query) and is not a fault
+  signal. See [`DHCP.md` §4c](../features/DHCP.md).
 
 Beyond that: **500k records in one group** is not a supported single-node
 size at any RAM tested (up to 10 GiB) — the api's bundle build for the

--- a/docs/drivers/DHCP_DRIVERS.md
+++ b/docs/drivers/DHCP_DRIVERS.md
@@ -157,19 +157,33 @@ Kea reads them. The default is `1`; `0` restores Kea's auto-sizing. Note that
 `enable-multi-threading` stays **true** — this is a resize, not a mode change,
 because MT-off makes one thread both receive and process (measured 15,170
 socket drops where a pool of one had none) and also flips host-reservation
-lookup order. Kea's HA hook keeps its own `http-client-threads` /
-`http-listener-threads` (`http-dedicated-listener: true`), unaffected by this
-value, so HA peer traffic is not serialised behind the single worker.
+lookup order.
+
+Kea's HA hook does **not** keep independent HTTP pools by default:
+`http-listener-threads` / `http-client-threads` default to `0`, which Kea
+reads as *"same as `thread-pool-size`"*, not as an independent auto-size.
+Measured by counting OS threads with the hook loaded — pool=1 gave 8 threads
+and pool=8 gave 29, a delta of 21 for a pool delta of 7, i.e. three pools of
+N. Left alone, the packet-path fix would have taken HA's peer HTTP
+concurrency to 1 as a side effect, so `_ha_hook` now renders an explicit
+`multi-threading` block pinning both to 4 (a decoupling constant, not a
+tuned one — the HA threads do short LAN POSTs and never contend for the
+receive thread). With it, the same measurement gives 14 threads at pool=1 and
+21 at pool=8: a delta of exactly the core pool.
 
 `kea_packet_logging` → when false, appends a `kea-dhcpN.packets` logger at
 `WARN`, silencing `DHCP4_PACKET_RECEIVED` / `DHCP4_PACKET_SEND`. Default
 true (today's behaviour); off is worth ~1.30x more packets served. The child
-carries the parent's `output_options` explicitly — log4cplus does not inherit
-appenders into a logger configured by name, so omitting them would send its
-WARNs and ERRORs nowhere instead of raising the level. `kea-dhcpN.dhcpN` is
-deliberately never silenced: at INFO it carries `DHCP4_OPEN_SOCKETS_FAILED`,
-`DHCP4_CONFIG_COMPLETE`, `DHCP4_STARTED` and `DHCP4_MULTI_THREADING_INFO`,
-the last being the line that confirms the pool size took effect.
+declares **no `output_options`** and inherits the parent's — verified against
+kea-dhcp4 3.0.3: at DEBUG with no outputs of its own every packet line still
+reached both stdout and the shipped file, and at WARN none did while the
+parent's INFO lines kept flowing. Copying the parent's appenders also works
+but puts a second `RollingFileAppender` on one path with its own rotation
+state, so at 50 MB one renames the file while the other holds the old
+descriptor. `kea-dhcpN.dhcpN` is deliberately never silenced: at INFO it
+carries `DHCP4_OPEN_SOCKETS_FAILED`, `DHCP4_CONFIG_COMPLETE`,
+`DHCP4_STARTED` and `DHCP4_MULTI_THREADING_INFO`, the last being the line
+that confirms the pool size took effect.
 
 Both are also rendered by the control-plane-side `KeaDriver.render_config`
 for parity. Full measurements: [`DHCP.md` §4c](../features/DHCP.md).

--- a/docs/drivers/DHCP_DRIVERS.md
+++ b/docs/drivers/DHCP_DRIVERS.md
@@ -121,7 +121,8 @@ The HTTP envelope returned by `GET /api/v1/dhcp/agents/config` is:
     "server_name": "…",
     "driver": "kea",
     "roles": [...],
-    "server": { "interfaces": ["*"], "dhcp_socket_type": "raw" },
+    "server": { "interfaces": ["*"], "dhcp_socket_type": "raw",
+                "kea_thread_pool_size": 1, "kea_packet_logging": true },
     "scopes": [
       {
         "subnet_cidr": "10.0.0.0/24",
@@ -142,6 +143,36 @@ The HTTP envelope returned by `GET /api/v1/dhcp/agents/config` is:
 Shipped 2026.04.21-2: `render_kea.py:_scope_to_subnet` maps each wire scope to a Kea `subnet4` entry — `subnet_cidr` → `subnet`, `pools[start_ip,end_ip,pool_type]` → `{"pool": "start - end"}` (only `dynamic` pools are emitted; `excluded` / `reserved` are IPAM bookkeeping and must **not** become Kea lease pools), `statics[ip_address,mac_address,hostname]` → `reservations[ip-address,hw-address,hostname]`. Client-class `match_expression` → Kea `test`. Subnet `id` is derived deterministically from the CIDR via truncated SHA-256, so a config reload never orphans active leases by renumbering subnets.
 
 **Socket type (issue #365).** The `server.dhcp_socket_type` field drives `Dhcp4.interfaces-config.dhcp-socket-type`. It is derived from the server group's `dhcp_socket_mode` in `services/dhcp/config_bundle.py` (`direct` → `raw`, `relay` → `udp`) and is part of `ConfigBundle.compute_etag()`, so flipping the mode shifts the ETag and the agent re-renders on its next long-poll. The default is `raw` (AF_PACKET) so Kea hears broadcast `DHCPDISCOVER`s from directly-attached clients; the agent's `render_kea.py` also falls back to `raw` when an older control plane omits the `server` block. `raw` needs `CAP_NET_RAW` (appliance DaemonSet + shipped compose Kea services grant it). DHCPv6 has no socket-type concept — the field applies to `Dhcp4` only.
+
+**Packet path (issue #980).** Two more `server` fields, both rendered
+explicitly rather than left to Kea's defaults, both folded into the ETag.
+
+`kea_thread_pool_size` → `Dhcp4`/`Dhcp6` `multi-threading.thread-pool-size`.
+Kea's own default is `0`, meaning one worker per CPU `hardware_concurrency()`
+reports — the *machine's* count, with no regard for the container's cgroup
+share. Verified against kea-dhcp4 3.0.3: a container limited to 0.20 CPU
+starts ten workers, which then compete inside that cgroup with the single
+thread draining the receive socket, and packets are lost in the kernel before
+Kea reads them. The default is `1`; `0` restores Kea's auto-sizing. Note that
+`enable-multi-threading` stays **true** — this is a resize, not a mode change,
+because MT-off makes one thread both receive and process (measured 15,170
+socket drops where a pool of one had none) and also flips host-reservation
+lookup order. Kea's HA hook keeps its own `http-client-threads` /
+`http-listener-threads` (`http-dedicated-listener: true`), unaffected by this
+value, so HA peer traffic is not serialised behind the single worker.
+
+`kea_packet_logging` → when false, appends a `kea-dhcpN.packets` logger at
+`WARN`, silencing `DHCP4_PACKET_RECEIVED` / `DHCP4_PACKET_SEND`. Default
+true (today's behaviour); off is worth ~1.30x more packets served. The child
+carries the parent's `output_options` explicitly — log4cplus does not inherit
+appenders into a logger configured by name, so omitting them would send its
+WARNs and ERRORs nowhere instead of raising the level. `kea-dhcpN.dhcpN` is
+deliberately never silenced: at INFO it carries `DHCP4_OPEN_SOCKETS_FAILED`,
+`DHCP4_CONFIG_COMPLETE`, `DHCP4_STARTED` and `DHCP4_MULTI_THREADING_INFO`,
+the last being the line that confirms the pool size took effect.
+
+Both are also rendered by the control-plane-side `KeaDriver.render_config`
+for parity. Full measurements: [`DHCP.md` §4c](../features/DHCP.md).
 
 ### HA coordination
 

--- a/docs/drivers/DHCP_DRIVERS.md
+++ b/docs/drivers/DHCP_DRIVERS.md
@@ -185,8 +185,16 @@ carries `DHCP4_OPEN_SOCKETS_FAILED`, `DHCP4_CONFIG_COMPLETE`,
 `DHCP4_STARTED` and `DHCP4_MULTI_THREADING_INFO`, the last being the line
 that confirms the pool size took effect.
 
-Both are also rendered by the control-plane-side `KeaDriver.render_config`
-for parity. Full measurements: [`DHCP.md` §4c](../features/DHCP.md).
+Both also appear in the control-plane-side `KeaDriver.render_config`, which
+backs the **Rendered config** tab. That render is a *preview*, not a copy of
+the file the agent writes — it omits the control socket, hooks, timers,
+expired-lease processing and the full logger block, and does not parse as a
+Kea config on its own. What it does carry is the group tunables an operator
+just set, which is the same rule `dhcp_socket_type` (#365) and
+`cache-threshold` (#637) already follow: `thread-pool-size` renders in full,
+and `kea_packet_logging` renders as the `kea-dhcpN.packets` severity
+override alone (nothing when it is on). Full measurements:
+[`DHCP.md` §4c](../features/DHCP.md).
 
 ### HA coordination
 

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -626,6 +626,119 @@ override).
 
 ---
 
+## 4c. Packets lost before Kea reads them (#980)
+
+A Kea server that is short of CPU does not slow down — it loses packets, in
+the kernel, before the server ever sees them. Everything Kea can tell you
+about itself stays green: it answers **100 % of what it reads**, its own
+`pkt4-receive-drop` stays at zero, its health check passes, it heartbeats
+normally and its pools have free addresses. The only symptom is clients
+taking several retransmit rounds (4 s apart, and up) to get an address,
+which from the server looks like somebody else's problem.
+
+Measured on a 4 vCPU appliance serving a relayed burst: at 1,200 devices /
+20 DORA per second, 32-48 % of first DISCOVERs had to be resent, while Kea
+reported having answered every packet it received.
+
+### Where the loss actually is, and where it isn't
+
+Three counters, and only one of them moves:
+
+| Counter | What it means | Moves here? |
+|---|---|---|
+| per-socket `sk_drops` (`/proc/net/udp`) | the kernel found the receive buffer full and discarded the datagram | **yes** |
+| `pkt4-receive-drop` / `pkt6-receive-drop` | Kea read the packet and discarded it (unparseable, `DROP` class, no subnet) | no |
+| `pkt4-discover-received` vs `pkt4-offer-sent` | Kea answering what it read | always equal |
+
+Verified against kea-dhcp4 3.0.3: a run that lost **9,700** datagrams to
+buffer overflow reported `pkt4-receive-drop = 0` for its entire duration.
+Both are now reported per 60 s bucket on `dhcp_metric_sample` as
+`socket_drop` and `receive_drop`; the server detail modal's **Stats** tab
+draws a dashed *DROPPED* line and a red `N dropped` chip, and the default-on
+**`dhcp_packets_dropped`** alert rule fires on any confirmed loss over a
+15-minute window (raise the rule's minimum-count threshold to alert only
+past a number of packets).
+
+> **`NULL` is not zero, anywhere in this chain.** An agent older than #980,
+> or one whose runtime cannot read `/proc/net/udp`, reports neither counter
+> and the column stays NULL. That renders as *loss not measured*, the alert
+> skips the server rather than vouching for it, and nothing folds it to 0 —
+> a wall of green zeros from an un-upgraded fleet is precisely the false
+> reassurance this section exists to remove.
+>
+> One real blind spot: the AF_PACKET socket Kea opens for
+> `dhcp-socket-type: raw` is not covered. `/proc/net/packet` carries no drop
+> column and its statistics can only be read by the process that owns the
+> socket. Relayed traffic is unicast and therefore arrives on the UDP
+> fallback socket, which is fully covered; directly-attached broadcast
+> traffic is not.
+
+### What actually helps
+
+Two things do not, and it is worth knowing why before reaching for them:
+
+* **A bigger socket receive buffer** removes the drops and replaces them with
+  latency. Measured under #952: with 8 MiB of buffer the drops vanish and a
+  DORA takes **34 s instead of 1.5 s**, because Kea then works through a
+  backlog answering requests whole retransmit rounds late.
+* **A bigger `packet-queue-size`** does nothing at all. 64 → 2048 (32x)
+  changed neither throughput nor drops; that queue sits *behind* the receive
+  thread, and the bottleneck is the receive thread not being scheduled.
+
+What helps is giving the receive thread the CPU. The chart already ships a
+500m CPU request on the Kea pod (#953 / #967 — see
+[`APPLIANCE.md`](../deployment/APPLIANCE.md)), whose `node_pressure` alert
+reads the kernel's PSI stall time and names the *cause* where `socket_drop`
+names the *effect*; a node stalling with no DHCP loss still has headroom.
+Two group settings tune the packet path itself:
+
+| Setting | Where | Default | Meaning |
+|---|---|---|---|
+| `kea_thread_pool_size` | `DHCPServerGroup` | `1` | Kea's `multi-threading.thread-pool-size`. `0` = let Kea auto-size. |
+| `kea_packet_logging` | `DHCPServerGroup` | `true` | Log every packet received and sent. |
+
+**`kea_thread_pool_size` is the important one, and its default changed.**
+Left to Kea, `thread-pool-size` is `0` — one worker per CPU that
+`hardware_concurrency()` reports, which is the *machine's* CPU count and
+knows nothing about the cgroup share the container is held to. Verified: a
+container limited to 0.20 CPU starts **ten** workers, which then compete,
+inside that one cgroup, with the single thread that has to drain the receive
+socket. Packets served on kea-dhcp4 3.0.3 (memfile, relayed unicast, 12,000
+pkt/s offered, median of 4 runs):
+
+| cgroup CPU | pool = 1 | pool = 2 | pool = 4 (what "auto" gives on 4 vCPU) |
+|---|---|---|---|
+| 0.25 | **19,381** | 11,119 | 6,723 |
+| 4.0 (no quota) | **93,717** | 73,089 | 55,957 |
+
+Monotonic in both shapes, so the default is 1 and every existing group picks
+it up on upgrade (one Kea config-reload, no restart). Note this is a *resize*
+and not `enable-multi-threading: false` — with MT off one thread must both
+receive and process, which measured **15,170** socket drops in a run where a
+pool of one measured **none**, and it also changes host-reservation lookup
+order. Kea's HA hook keeps its own `http-client-threads` /
+`http-listener-threads`, unaffected by this value, so a failover pair's peer
+traffic is not serialised behind the single worker.
+
+**`kea_packet_logging` defaults to on, which is exactly today's behaviour.**
+At INFO, Kea writes four lines per transaction to two appenders, one of them
+flushed. Turning this off raises only the `kea-dhcpN.packets` child logger to
+WARN — silencing `DHCP4_PACKET_RECEIVED` and `DHCP4_PACKET_SEND`, which carry
+the source address and receiving interface — for 1.30x more packets served
+(24,997-26,077 against 19,026-20,403 on the same rig). The lines naming the
+client and the address handed out come from other loggers and stay, so the
+Logs tab keeps one entry per transaction. It is an opt-in because it removes
+something an operator can see; the `socket_drop` counter above is what tells
+you whether you are at the knee where it is worth it.
+
+> `kea-dhcpN.dhcpN` is *not* touched, though it looks like the same kind of
+> noise. At INFO it also carries `DHCP4_OPEN_SOCKETS_FAILED` — a real failure
+> Kea logs at INFO — plus `DHCP4_CONFIG_COMPLETE`, `DHCP4_STARTED` and
+> `DHCP4_MULTI_THREADING_INFO`, the last being the line that reports whether
+> the pool size above took effect.
+
+---
+
 ## 5. DHCP Lease Tracking
 
 Leases are **read-only** in SpatiumDDI — they are pulled from the DHCP server, not managed directly.

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -652,19 +652,44 @@ Three counters, and only one of them moves:
 
 Verified against kea-dhcp4 3.0.3: a run that lost **9,700** datagrams to
 buffer overflow reported `pkt4-receive-drop = 0` for its entire duration.
-Both are now reported per 60 s bucket on `dhcp_metric_sample` as
-`socket_drop` and `receive_drop`; the server detail modal's **Stats** tab
-draws a dashed *DROPPED* line and a red `N dropped` chip, and the default-on
-**`dhcp_packets_dropped`** alert rule fires on any confirmed loss over a
-15-minute window (raise the rule's minimum-count threshold to alert only
-past a number of packets).
+Both are reported per 60 s bucket on `dhcp_metric_sample` as `socket_drop`
+and `receive_drop`, but only the first is treated as loss.
+
+> **`receive_drop` is context, not a fault.** Kea counts a packet there when
+> it reads one and throws it away — *including on purpose*. Verified against
+> kea-dhcp4 3.0.3: a client matching a `DROP` client-class increments it once
+> per packet, and a `DROP` class is exactly what the shipped
+> [DHCP MAC blocklist](#4a-dhcp-mac-blocklist) renders; Kea's HA hook drops
+> out-of-scope queries in `hot-standby` the same way. So the *DROPPED* line,
+> the `N dropped` chip and the alert rule all read `socket_drop` **alone** —
+> a rule that counted `receive_drop` would fire permanently, and never
+> auto-resolve, on any install with a blocklisted MAC or an HA pair.
+> `receive_drop` is still surfaced beside it, labelled as what it is.
+
+The server detail modal's **Stats** tab draws a dashed *DROPPED* line and a
+red `N dropped` chip from `socket_drop`, and the default-on
+**`dhcp_packets_dropped`** alert rule fires on any confirmed kernel-side loss
+over a 15-minute window (raise the rule's minimum-count threshold to alert
+only past a number of packets).
 
 > **`NULL` is not zero, anywhere in this chain.** An agent older than #980,
-> or one whose runtime cannot read `/proc/net/udp`, reports neither counter
+> or one whose runtime cannot read `/proc/net/udp`, reports no `socket_drop`
 > and the column stays NULL. That renders as *loss not measured*, the alert
 > skips the server rather than vouching for it, and nothing folds it to 0 —
 > a wall of green zeros from an un-upgraded fleet is precisely the false
-> reassurance this section exists to remove.
+> reassurance this section exists to remove. Every "was this measured?" test
+> keys on `socket_drop` **by itself**: `receive_drop` always arrives from a
+> #980 agent, so testing the pair would report a server whose kernel-side
+> loss is unmeasurable as measured-and-clean.
+>
+> A partial read counts as no read. If one of `/proc/net/udp` /
+> `/proc/net/udp6` exists but cannot be read, the whole sample is discarded
+> rather than returning the half that succeeded — otherwise the missing
+> inodes drop out of the baseline, and when the next read succeeds they
+> return as new sockets whose entire lifetime `sk_drops` is charged to that
+> one bucket. On a socket up for days that is a fabricated spike, on a rule
+> whose floor is one packet. (A file that is *absent* is different, and is
+> a valid partial answer: no IPv6 stack means no v6 sockets to miss.)
 >
 > One real blind spot: the AF_PACKET socket Kea opens for
 > `dhcp-socket-type: raw` is not covered. `/proc/net/packet` carries no drop
@@ -716,9 +741,15 @@ it up on upgrade (one Kea config-reload, no restart). Note this is a *resize*
 and not `enable-multi-threading: false` — with MT off one thread must both
 receive and process, which measured **15,170** socket drops in a run where a
 pool of one measured **none**, and it also changes host-reservation lookup
-order. Kea's HA hook keeps its own `http-client-threads` /
-`http-listener-threads`, unaffected by this value, so a failover pair's peer
-traffic is not serialised behind the single worker.
+order.
+
+Kea's HA hook does **not** keep independent HTTP pools by default —
+`http-listener-threads` / `http-client-threads` default to `0`, which Kea
+reads as *"same as `thread-pool-size`"*. Counting OS threads with the hook
+loaded: pool=1 gave 8, pool=8 gave 29, a delta of 21 for a pool delta of 7,
+i.e. three pools of N. Left alone, this change would have taken a failover
+pair's peer HTTP concurrency to 1 as an unmeasured side effect, so the agent
+pins both to 4 and the setting moves only the packet-worker pool.
 
 **`kea_packet_logging` defaults to on, which is exactly today's behaviour.**
 At INFO, Kea writes four lines per transaction to two appenders, one of them

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7832,6 +7832,17 @@ export interface DHCPServerGroup {
    * suppresses the lease-events that drive DDNS + the IPAM lease mirror. */
   lease_cache_threshold: number;
   lease_cache_max_age: number | null;
+  /** #980 — Kea `multi-threading.thread-pool-size`. 1 (the default) measured
+   *  1.7x-2.9x more packets served than Kea's own auto-sizing, which starts
+   *  one worker per HOST cpu regardless of the container's cgroup share and
+   *  leaves them competing with the thread that drains the receive socket.
+   *  0 hands sizing back to Kea. */
+  kea_thread_pool_size: number;
+  /** #980 — true (the default, and today's behaviour) logs every packet
+   *  received and sent. False raises only `kea-dhcpN.packets` to WARN, worth
+   *  ~1.3x more packets served on a constrained node, at the cost of the two
+   *  log codes that carry the source address and receiving interface. */
+  kea_packet_logging: boolean;
   // Number of Kea servers currently in the group. ≥ 2 means HA is
   // rendered into every peer's Kea config via libdhcp_ha.so.
   kea_member_count: number;
@@ -7853,6 +7864,8 @@ export interface DHCPServerGroupCreate {
   auto_failover?: boolean;
   lease_cache_threshold?: number;
   lease_cache_max_age?: number | null;
+  kea_thread_pool_size?: number;
+  kea_packet_logging?: boolean;
 }
 
 export interface DHCPServer {
@@ -8247,6 +8260,14 @@ export interface DHCPRateBucket {
   nak: number;
   decline: number;
   release: number;
+  /** #980 — packets lost, and where. `socket_drop` is the kernel dropping
+   *  datagrams before the server could read them (its receive buffer filled;
+   *  the node is short of CPU). `receive_drop` is the server reading a packet
+   *  and discarding it. `null` means the agent did not measure it — too old,
+   *  or unable to read /proc/net/udp — and must render as "not measured",
+   *  never as 0. Zero is a measurement; null is the absence of one. */
+  receive_drop: number | null;
+  socket_drop: number | null;
 }
 
 export interface DHCPServerStatsResponse {
@@ -10855,6 +10876,14 @@ export interface DHCPMetricsPoint {
   decline: number;
   release: number;
   inform: number;
+  /** #980 — packets lost, and where. `socket_drop` is the kernel dropping
+   *  datagrams before the server could read them (its receive buffer filled;
+   *  the node is short of CPU). `receive_drop` is the server reading a packet
+   *  and discarding it. `null` means the agent did not measure it — too old,
+   *  or unable to read /proc/net/udp — and must render as "not measured",
+   *  never as 0. Zero is a measurement; null is the absence of one. */
+  receive_drop: number | null;
+  socket_drop: number | null;
 }
 
 export interface DHCPMetricsSeries {

--- a/frontend/src/lib/dhcp-loss.test.ts
+++ b/frontend/src/lib/dhcp-loss.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { bucketLoss, summariseLoss } from "./dhcp-loss";
+
+describe("bucketLoss", () => {
+  it("passes a measured value through, including zero", () => {
+    expect(bucketLoss({ socket_drop: 12 })).toBe(12);
+    expect(bucketLoss({ socket_drop: 0 })).toBe(0);
+  });
+
+  it("reports an explicit null as not measured", () => {
+    expect(bucketLoss({ socket_drop: null })).toBeNull();
+  });
+
+  it("reports an OMITTED key as not measured, not as zero", () => {
+    // A control plane older than #980 does not send the field at all. The
+    // generated type says `number | null`, so `tsc` cannot catch this —
+    // only the runtime coalesce does. Reading it as 0 would tell the
+    // operator "nothing was lost" about a server nobody measured, which is
+    // the exact false reassurance the issue was filed about.
+    expect(bucketLoss({})).toBeNull();
+    expect(bucketLoss({ socket_drop: undefined })).toBeNull();
+  });
+});
+
+describe("summariseLoss", () => {
+  it("an empty window is not measured", () => {
+    expect(summariseLoss([])).toEqual({ measured: false, total: 0 });
+  });
+
+  it("all-unmeasured is not measured", () => {
+    expect(summariseLoss([{}, { socket_drop: null }])).toEqual({
+      measured: false,
+      total: 0,
+    });
+  });
+
+  it("measured zero is measured — a clean bill, not an absent one", () => {
+    expect(summariseLoss([{ socket_drop: 0 }, { socket_drop: 0 }])).toEqual({
+      measured: true,
+      total: 0,
+    });
+  });
+
+  it("sums measured buckets", () => {
+    expect(summariseLoss([{ socket_drop: 3 }, { socket_drop: 4 }])).toEqual({
+      measured: true,
+      total: 7,
+    });
+  });
+
+  it("a partly-measured window reports what it knows", () => {
+    // One agent restart mid-window must not hide the loss either side of it.
+    expect(summariseLoss([{ socket_drop: 5 }, {}, { socket_drop: 2 }])).toEqual(
+      { measured: true, total: 7 },
+    );
+  });
+});

--- a/frontend/src/lib/dhcp-loss.ts
+++ b/frontend/src/lib/dhcp-loss.ts
@@ -1,0 +1,61 @@
+/** #980 — reading the DHCP packet-loss counters without lying about them.
+ *
+ * Two counters ride on every metric bucket and they do not mean the same
+ * thing:
+ *
+ *  * `socket_drop` — the kernel discarded the datagram because Kea's receive
+ *    buffer was full, so Kea never saw it. Unambiguous loss, usually a node
+ *    short of CPU.
+ *  * `receive_drop` — Kea read the packet and discarded it, which INCLUDES
+ *    doing so on purpose: a blocklisted MAC (the shipped DHCP MAC blocklist
+ *    renders a Kea `DROP` class) or an HA standby declining an out-of-scope
+ *    query both land here.
+ *
+ * So everything user-facing reads `socket_drop` alone. Extracted from the
+ * server-detail modal because the null handling below is the load-bearing
+ * property of the whole feature and is invisible to `tsc`.
+ */
+
+/** One bucket, as the API sends it — deliberately looser than the generated
+ *  type. `undefined` models a control plane older than #980, which omits the
+ *  key entirely; the point of this module is that such a bucket must not read
+ *  as "measured, no loss". */
+export interface LossBucket {
+  socket_drop?: number | null;
+}
+
+/**
+ * Kernel-side loss for one bucket, or `null` when it was not measured.
+ *
+ * `?? null` normalises at the boundary: the generated type says
+ * `number | null`, but an omitted key arrives as `undefined` and every
+ * downstream check is `!== null`. Without this a version-skewed API reads as
+ * measured-and-zero — the one thing this feature exists not to say.
+ */
+export function bucketLoss(b: LossBucket): number | null {
+  return b.socket_drop ?? null;
+}
+
+export interface LossSummary {
+  /** False when NOTHING in the window measured loss — an agent older than
+   *  #980, or one that cannot read /proc/net/udp. Distinct from measuring
+   *  zero, and must render as "not measured" rather than as a clean bill. */
+  measured: boolean;
+  total: number;
+}
+
+/**
+ * Roll a window of buckets into the three states the UI distinguishes:
+ * measured and lossy, measured and clean, never measured.
+ *
+ * A window that mixes measured and unmeasured buckets counts as measured and
+ * sums the ones that were: partial knowledge is still knowledge, and the
+ * alternative would hide real loss behind one agent restart.
+ */
+export function summariseLoss(buckets: LossBucket[]): LossSummary {
+  const measured = buckets
+    .map(bucketLoss)
+    .filter((v): v is number => v !== null);
+  if (measured.length === 0) return { measured: false, total: 0 };
+  return { measured: true, total: measured.reduce((a, v) => a + v, 0) };
+}

--- a/frontend/src/pages/dhcp/CreateServerGroupModal.tsx
+++ b/frontend/src/pages/dhcp/CreateServerGroupModal.tsx
@@ -41,6 +41,16 @@ export function CreateServerGroupModal({
   const [leaseCacheMaxAge, setLeaseCacheMaxAge] = useState(
     group?.lease_cache_max_age != null ? String(group.lease_cache_max_age) : "",
   );
+  // #980 — Kea packet-path tuning. `?? 1` / `?? true` rather than a falsy
+  // fallback: 0 is a real pool size (Kea's auto) and false is a real logging
+  // choice, so `||` would silently rewrite either back to the default when
+  // editing a group that had opted out.
+  const [threadPoolSize, setThreadPoolSize] = useState(
+    String(group?.kea_thread_pool_size ?? 1),
+  );
+  const [packetLogging, setPacketLogging] = useState(
+    group?.kea_packet_logging ?? true,
+  );
   const [error, setError] = useState("");
 
   const isHA = mode === "hot-standby" || mode === "load-balancing";
@@ -70,6 +80,17 @@ export function CreateServerGroupModal({
         throw new Error("Lease cache max age must be at least 1 second.");
       }
 
+      // #980 — blank means the default (1), not 0: 0 is "let Kea auto-size",
+      // which is the behaviour this setting exists to replace, and clearing a
+      // box should not opt you into it.
+      const parsedPool =
+        threadPoolSize.trim() === "" ? 1 : parseInt(threadPoolSize, 10);
+      if (Number.isNaN(parsedPool) || parsedPool < 0 || parsedPool > 64) {
+        throw new Error(
+          "Packet worker threads must be between 0 and 64 (0 = let Kea decide).",
+        );
+      }
+
       const data = {
         name,
         description,
@@ -82,6 +103,8 @@ export function CreateServerGroupModal({
         auto_failover: autoFailover,
         lease_cache_threshold: parsedCacheThreshold,
         lease_cache_max_age: parsedCacheMaxAge,
+        kea_thread_pool_size: parsedPool,
+        kea_packet_logging: packetLogging,
       };
       return editing
         ? dhcpApi.updateGroup(group!.id, data)
@@ -195,6 +218,49 @@ export function CreateServerGroupModal({
                 value={leaseCacheMaxAge}
                 onChange={(e) => setLeaseCacheMaxAge(e.target.value)}
               />
+            </Field>
+          </div>
+        </div>
+
+        <div className="rounded-md border bg-muted/20 p-3 space-y-3">
+          <p className="text-xs font-semibold text-muted-foreground">
+            Packet path (#980)
+          </p>
+          <p className="text-xs text-muted-foreground">
+            When a Kea server is short of CPU it stops draining its receive
+            socket fast enough and the kernel discards DHCP packets before Kea
+            ever sees them. Kea reports itself perfectly healthy throughout — it
+            answers 100% of what it reads — so the only symptom is clients
+            taking several retransmit rounds to get an address. Watch{" "}
+            <strong>Dropped</strong> on a server&apos;s Stats tab to see whether
+            it is happening here.
+          </p>
+          <div className="grid grid-cols-2 gap-3">
+            <Field
+              label="Packet worker threads"
+              hint="Kea's multi-threading.thread-pool-size. Left to Kea, this is one worker per CPU on the MACHINE, ignoring the share this container actually gets — and those workers then compete with the single thread that has to drain the receive socket. 1 (the default) measured 1.7x–2.9x more packets served than Kea's auto-sizing at every CPU allocation tested. 0 hands sizing back to Kea."
+            >
+              <input
+                className={inputCls}
+                type="number"
+                min="0"
+                max="64"
+                value={threadPoolSize}
+                onChange={(e) => setThreadPoolSize(e.target.value)}
+              />
+            </Field>
+            <Field
+              label="Per-packet logging"
+              hint="Kea logs four lines per transaction. Turning this off raises only the two that restate the transaction (DHCP4_PACKET_RECEIVED / _SEND, carrying the source address and receiving interface) to WARN, for roughly 1.3x more packets served on a constrained node. The lines naming the client and the address handed out stay, so the Logs tab keeps one entry per transaction."
+            >
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={packetLogging}
+                  onChange={(e) => setPacketLogging(e.target.checked)}
+                />
+                Log every packet received and sent
+              </label>
             </Field>
           </div>
         </div>

--- a/frontend/src/pages/dhcp/CreateServerGroupModal.tsx
+++ b/frontend/src/pages/dhcp/CreateServerGroupModal.tsx
@@ -245,6 +245,7 @@ export function CreateServerGroupModal({
                 type="number"
                 min="0"
                 max="64"
+                step="1"
                 value={threadPoolSize}
                 onChange={(e) => setThreadPoolSize(e.target.value)}
               />

--- a/frontend/src/pages/dhcp/ServerDetailModal.tsx
+++ b/frontend/src/pages/dhcp/ServerDetailModal.tsx
@@ -16,9 +16,10 @@ import {
 } from "lucide-react";
 import {
   Area,
-  AreaChart,
   CartesianGrid,
+  ComposedChart,
   Legend,
+  Line,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -802,8 +803,27 @@ function StatsTab({ serverId }: { serverId: string }) {
       nak: b.nak,
       decline: b.decline,
       release: b.release,
+      // #980 — null (not measured) must stay null. Recharts breaks the line
+      // at a null point, which is the honest rendering: a gap where nobody
+      // looked, rather than a zero that reads as "nothing was lost".
+      dropped:
+        b.socket_drop === null && b.receive_drop === null
+          ? null
+          : (b.socket_drop ?? 0) + (b.receive_drop ?? 0),
     }));
   }, [data, withDate]);
+
+  // #980 — three states, not two. Loss measured and non-zero; loss measured
+  // and zero; loss never measured (an agent older than #980, or one that
+  // cannot read /proc/net/udp). The third must not render as the second.
+  const loss = useMemo(() => {
+    const measured = points.filter((p) => p.dropped !== null);
+    if (measured.length === 0) return { measured: false, total: 0 };
+    return {
+      measured: true,
+      total: measured.reduce((a, p) => a + (p.dropped ?? 0), 0),
+    };
+  }, [points]);
 
   // date_bin emits only non-empty buckets, so an idle server usually yields
   // points.length === 0. But a window can also hold rows whose seven plotted
@@ -820,7 +840,12 @@ function StatsTab({ serverId }: { serverId: string }) {
             p.ack +
             p.nak +
             p.decline +
-            p.release >
+            p.release +
+            // #980 — loss counts as activity. A server starved badly enough
+            // that nothing completes has zeros in every message column and
+            // thousands of drops, and "No activity in the last 1h" is the
+            // worst possible thing to tell an operator at that moment.
+            (p.dropped ?? 0) >
           0,
       ),
     [points],
@@ -841,6 +866,22 @@ function StatsTab({ serverId }: { serverId: string }) {
                 {data.leases_active === 1 ? "lease" : "leases"}
               </span>
             )}
+            {data &&
+              (!loss.measured ? (
+                <span
+                  className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+                  title="This server's agent does not report packet loss (it predates the counters, or cannot read /proc/net/udp). This is NOT the same as reporting no loss."
+                >
+                  loss not measured
+                </span>
+              ) : loss.total > 0 ? (
+                <span
+                  className="rounded bg-rose-500/15 px-1.5 py-0.5 text-[10px] font-medium text-rose-600"
+                  title="Packets lost before or during receive. Most often the node is short of CPU: Kea answers 100% of what it reads, so no other signal shows this."
+                >
+                  {loss.total} dropped
+                </span>
+              ) : null)}
           </div>
           <select
             value={range}
@@ -867,7 +908,7 @@ function StatsTab({ serverId }: { serverId: string }) {
             </p>
           ) : (
             <ResponsiveContainer width="100%" height="100%">
-              <AreaChart
+              <ComposedChart
                 data={points}
                 margin={{ top: 5, right: 12, left: 0, bottom: 0 }}
               >
@@ -902,7 +943,24 @@ function StatsTab({ serverId }: { serverId: string }) {
                     strokeWidth={1.5}
                   />
                 ))}
-              </AreaChart>
+                {/* #980 — a LINE, not another stacked area: dropped packets
+                    are not a message type and adding them to the stack would
+                    inflate the traffic total by the traffic that never
+                    arrived. Rendered only once something has been measured,
+                    so an un-upgraded agent shows no misleading flat zero. */}
+                {loss.measured && (
+                  <Line
+                    type="monotone"
+                    dataKey="dropped"
+                    name="DROPPED"
+                    stroke="#e11d48"
+                    strokeWidth={2}
+                    strokeDasharray="4 2"
+                    dot={false}
+                    connectNulls={false}
+                  />
+                )}
+              </ComposedChart>
             </ResponsiveContainer>
           )}
         </div>

--- a/frontend/src/pages/dhcp/ServerDetailModal.tsx
+++ b/frontend/src/pages/dhcp/ServerDetailModal.tsx
@@ -803,19 +803,26 @@ function StatsTab({ serverId }: { serverId: string }) {
       nak: b.nak,
       decline: b.decline,
       release: b.release,
-      // #980 — null (not measured) must stay null. Recharts breaks the line
-      // at a null point, which is the honest rendering: a gap where nobody
-      // looked, rather than a zero that reads as "nothing was lost".
-      dropped:
-        b.socket_drop === null && b.receive_drop === null
-          ? null
-          : (b.socket_drop ?? 0) + (b.receive_drop ?? 0),
+      // #980 — DROPPED is socket_drop ALONE. receive_drop counts packets
+      // Kea read and threw away on purpose as well as by accident: a
+      // blocklisted MAC (the shipped DHCP MAC blocklist renders a Kea DROP
+      // class) and an HA standby declining an out-of-scope query both land
+      // there. Adding it in would draw a permanent "loss" line on a
+      // correctly-working server.
+      //
+      // Null (not measured) stays null, and is keyed on socket_drop by
+      // itself — receive_drop always arrives from a #980 agent, so testing
+      // the pair would render an unmeasurable server as measured-and-clean.
+      // Recharts breaks the line at a null point, which is the honest
+      // rendering: a gap where nobody looked, not a zero.
+      dropped: b.socket_drop,
     }));
   }, [data, withDate]);
 
   // #980 — three states, not two. Loss measured and non-zero; loss measured
   // and zero; loss never measured (an agent older than #980, or one that
   // cannot read /proc/net/udp). The third must not render as the second.
+  // Keyed on socket_drop only — see the `dropped` mapping above.
   const loss = useMemo(() => {
     const measured = points.filter((p) => p.dropped !== null);
     if (measured.length === 0) return { measured: false, total: 0 };
@@ -870,14 +877,14 @@ function StatsTab({ serverId }: { serverId: string }) {
               (!loss.measured ? (
                 <span
                   className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
-                  title="This server's agent does not report packet loss (it predates the counters, or cannot read /proc/net/udp). This is NOT the same as reporting no loss."
+                  title="This server's agent does not report kernel-side packet loss (it predates the counters, or cannot read /proc/net/udp). This is NOT the same as reporting no loss."
                 >
                   loss not measured
                 </span>
               ) : loss.total > 0 ? (
                 <span
                   className="rounded bg-rose-500/15 px-1.5 py-0.5 text-[10px] font-medium text-rose-600"
-                  title="Packets lost before or during receive. Most often the node is short of CPU: Kea answers 100% of what it reads, so no other signal shows this."
+                  title="Packets the kernel discarded before the server could read them — its receive buffer filled. Most often the node is short of CPU: Kea answers 100% of what it reads, so no other signal shows this. Does not count packets Kea read and dropped on purpose, such as a blocklisted MAC."
                 >
                   {loss.total} dropped
                 </span>

--- a/frontend/src/pages/dhcp/ServerDetailModal.tsx
+++ b/frontend/src/pages/dhcp/ServerDetailModal.tsx
@@ -14,6 +14,7 @@ import {
   ScrollText,
   Server,
 } from "lucide-react";
+import { bucketLoss, summariseLoss } from "@/lib/dhcp-loss";
 import {
   Area,
   CartesianGrid,
@@ -803,34 +804,17 @@ function StatsTab({ serverId }: { serverId: string }) {
       nak: b.nak,
       decline: b.decline,
       release: b.release,
-      // #980 — DROPPED is socket_drop ALONE. receive_drop counts packets
-      // Kea read and threw away on purpose as well as by accident: a
-      // blocklisted MAC (the shipped DHCP MAC blocklist renders a Kea DROP
-      // class) and an HA standby declining an out-of-scope query both land
-      // there. Adding it in would draw a permanent "loss" line on a
-      // correctly-working server.
-      //
-      // Null (not measured) stays null, and is keyed on socket_drop by
-      // itself — receive_drop always arrives from a #980 agent, so testing
-      // the pair would render an unmeasurable server as measured-and-clean.
-      // Recharts breaks the line at a null point, which is the honest
-      // rendering: a gap where nobody looked, not a zero.
-      dropped: b.socket_drop,
+      // #980 — DROPPED is socket_drop ALONE, and an unmeasured bucket stays
+      // null so Recharts breaks the line there: a gap where nobody looked,
+      // not a zero. See lib/dhcp-loss.ts for why receive_drop is excluded
+      // and why the coalesce matters.
+      dropped: bucketLoss(b),
     }));
   }, [data, withDate]);
 
-  // #980 — three states, not two. Loss measured and non-zero; loss measured
-  // and zero; loss never measured (an agent older than #980, or one that
-  // cannot read /proc/net/udp). The third must not render as the second.
-  // Keyed on socket_drop only — see the `dropped` mapping above.
-  const loss = useMemo(() => {
-    const measured = points.filter((p) => p.dropped !== null);
-    if (measured.length === 0) return { measured: false, total: 0 };
-    return {
-      measured: true,
-      total: measured.reduce((a, p) => a + (p.dropped ?? 0), 0),
-    };
-  }, [points]);
+  // #980 — three states, not two: measured and lossy, measured and clean,
+  // never measured. The third must not render as the second.
+  const loss = useMemo(() => summariseLoss(data?.rate_buckets ?? []), [data]);
 
   // date_bin emits only non-empty buckets, so an idle server usually yields
   // points.length === 0. But a window can also hold rows whose seven plotted


### PR DESCRIPTION
Closes #980

A DHCP server short of CPU does not slow down — it loses packets in the kernel before Kea reads them, and every product surface stays green, because Kea answers 100% of what it *does* read.

Reproduced against a live kea-dhcp4 3.0.3 rather than reasoned about, which **corrected the issue's own diagnosis twice**.

## The counter the issue asked us to surface does not move

`pkt4-receive-drop` stayed at **0** through a run that lost 9,700 datagrams to receive-buffer overflow. It counts packets Kea *read* and discarded; this loss is the kernel discarding them first. The number that moves is the kernel's per-socket `sk_drops` in `/proc/net/udp` — the same event as the `Udp RcvbufErrors` the reporter saw.

## Both proposed mitigations are dead ends

| mitigation | result |
|---|---|
| larger `packet-queue-size` | 64 → 2048 (32×) changed neither throughput nor drops — that queue sits *behind* the receive thread |
| larger receive buffer | already known from #952 to trade drops for a 34 s DORA p50 |

## The fix nobody proposed

Kea sizes its packet-worker pool from `hardware_concurrency()` — the **machine's** CPU count, ignoring the container's cgroup share. A container limited to 0.20 CPU starts **ten** workers, which then compete with the one thread draining the socket.

Packets served at 12,000 relayed pkt/s (memfile, median of 4 runs):

| cgroup CPU | pool=1 | pool=2 | pool=4 (= "auto" on 4 vCPU) |
|---|---|---|---|
| 0.25 | **19,381** | 11,119 | 6,723 |
| 4.0, no quota | **93,717** | 73,089 | 55,957 |

Monotonic in both shapes, so `kea_thread_pool_size` defaults to **1**; `0` restores Kea's auto-sizing. It's a *resize*, deliberately not `enable-multi-threading: false` — MT-off makes one thread both receive and process, measuring 15,170 socket drops where pool 1 measured **none**.

## Naming the loss

`socket_drop` and `receive_drop` are per-bucket columns on `dhcp_metric_sample`, a dashed DROPPED line + chip on the Stats tab, the InfluxDB export, and the default-on `dhcp_packets_dropped` alert.

**Only `socket_drop` is treated as loss.** `pkt4-receive-drop` counts packets Kea read and discarded *on purpose* — verified, a `DROP` client-class match increments it, and a `DROP` class is exactly what our shipped **DHCP MAC blocklist** renders (HA hot-standby drops out-of-scope queries the same way). A rule counting it would fire permanently and never auto-resolve on two ordinary working configurations.

**NULL means unmeasured**, keyed on `socket_drop` alone — `receive_drop` always arrives from an upgraded agent, so testing the pair would read an unmeasurable server as measured-and-clean.

## Judgement calls worth a second opinion

- **`kea_packet_logging` defaults to ON** (unchanged), though off is worth 1.30×. It removes two log codes an operator can see, so it's opt-in — the #637 lease-cache call.
- **`kea-dhcpN.dhcpN` is not silenced** despite looking like identical noise: it also carries `DHCP4_OPEN_SOCKETS_FAILED` and the line reporting whether the pool size took effect.
- **HA's HTTP pools are pinned to 4.** They default to `0` = "same as `thread-pool-size`" (counted: pool=1 → 8 OS threads, pool=8 → 29, three pools of N), so the packet-path fix would otherwise have serialised HA peer traffic. 4 is a *decoupling* constant, not a tuned one — not measured against a live HA pair.
- **Adjacent fix taken on:** the metrics ingest *substituted* rather than accumulated on a bucket collision, silently discarding ~1 poll in 40 since #195. I wasn't willing to add a loss counter to a lossy path.

## Known gap

The AF_PACKET socket used for `dhcp-socket-type: raw` isn't covered — `/proc/net/packet` has no drop column and its stats need `PACKET_STATISTICS` on the socket itself. Relayed traffic (the reported case) is unicast and fully covered; directly-attached broadcast isn't. Documented as such.

## Verification

Real Kea validates all 10 render combinations incl. HA, both daemons. The `/proc` parser is checked against a real socket with real drops. Every guard negative-controlled by mutation (19 mutations, all caught). 188 agent tests, 68 backend, 127 across 11 existing DHCP suites, 42 frontend; ruff/black/mypy/migration-linter/untyped-routes clean, Trivy clean, frontend build green.

The second commit is the `/code-review` pass — eight findings, all verified before fixing; three were claims I'd made about Kea without testing, and measuring found two of them false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)