### PR TITLE
feat: #1009 — make the SSH source-CIDR allowlist enforceable, behind an explicit switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,41 @@ the formatter handles the rest.
 
 ## Unreleased
 
+### Added
+
+- **The SSH source-CIDR allowlist can now actually be enforced
+  (#1009).** It has shipped since #157 and, on the default port,
+  restricted nothing: `/etc/nftables.conf` opened `tcp dport 22`
+  unconditionally *above* the drop-in include glob, and nftables
+  is first-match-wins, so the scoped rule was dead code. #1001
+  fixed the rendering; this makes it reachable. The floor moved
+  to the retireable sentinel
+  `/etc/nftables.d/00-spatium-ssh.nft`, the three firewall
+  renderers stamp `# spatium-ssh: retire|keep`, and the host
+  runner retires it through the same machinery the Web-UI
+  sentinel has used since #769.
+  A new **Enforce source restriction** switch
+  (`ssh_lockdown`) is what retires it, and it is deliberately a
+  second control rather than a consequence of typing a CIDR:
+  retiring the floor removes what
+  `docs/design/FLEET_FIREWALL.md` §6.1 calls the irreducible
+  recovery channel, and that document's risk register names the
+  same floor as the mitigation for every *other* firewall
+  mistake. It is the anti-lockout pattern pfSense and OPNsense
+  ship, and the shape §6.1 already specified (as
+  `firewall_mgmt_lockdown`).
+  **Default off, including on upgrade** — an operator who
+  configured an allowlist while it was inert does not get their
+  SSH tightened by an upgrade they never asked for. Enforcement
+  then applies on port 22 and on a moved port alike, so the
+  behaviour no longer depends on which port SSH is running on.
+  Two guards on the way in: enforcing with an empty list is
+  refused outright (that closes SSH from everywhere, not
+  restricts it), and enforcing from an address the list does not
+  cover asks for an explicit acknowledgement first — the mistake
+  operators actually make, caught at the moment they make it
+  rather than at their next SSH attempt.
+
 ### Security
 
 - **The SSH source-CIDR allowlist was discarded and the port

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2231,6 +2231,26 @@ suggestion, free-space treemap.
   never heard of the flag does the safe thing by construction. Behaviour also
   stops depending on the port number, which was the real defect: post-#1001 it
   enforced on a moved port and not on 22.
+  **/code-review found six, and the first re-created the bug one layer down.**
+  The ssh bundle's `config_hash` — the only thing that re-fires the host
+  runner — was sha256 over the authorized-keys and sshd-config bodies, and the
+  scope appears in neither (it is an nftables scope, not an sshd directive).
+  Harmless while the scoped rule was dead code; not harmless now: toggling
+  lockdown changed the effective scope and nothing else, so the hash was
+  unchanged, the trigger never fired, and `50-spatium-ssh.nft` kept its
+  UNCONDITIONAL accept — which sorts ahead of the scoped management line —
+  while the firewall plane had already retired the floor. SSH open from
+  anywhere, every surface reporting it restricted. The hash now covers the
+  scope and the port. Also: the UI matched on `err.message`, which on an
+  AxiosError is always `Request failed with status code 422` and never the
+  FastAPI detail — so the acknowledgement modal could never open and
+  `ssh_lockdown_force` was unreachable from the product; removing the last
+  CIDR under lockdown left the toggle checked AND disabled, with Save 422ing
+  and no way out; the self-lockout pre-flight gated on the resulting state
+  rather than the transition, demanding an acknowledgement on every later
+  `ssh_*` save; the force flag latched on a save that failed for any other
+  reason; and the ordering test sorted its own literals, so it exercised
+  `sorted()` and could never catch the rename that would silently un-enforce.
   Two refusals on the way in — enforcing with an empty list (that closes SSH
   from everywhere rather than restricting it, the 422 §6.1 already specified),
   and enforcing from an address the list does not cover, which is advisory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2187,6 +2187,65 @@ suggestion, free-space treemap.
   future override key that firstboot omits fails loudly instead of silently
   restoring the second revision. Its failure message names the offending keys.
 
+- ✅ [**SSH source-CIDR allowlist was dead code on port 22**](https://github.com/spatiumddi/spatiumddi/issues/1009)
+  — the second of the two independent reasons the allowlist did nothing, and
+  the one #1001 deliberately left. `/etc/nftables.conf` opened
+  `tcp dport 22` unconditionally in its management floor, *above* the
+  `include "/etc/nftables.d/*.nft"` glob, and nftables is first-match-wins —
+  so a perfectly-rendered scoped rule restricted nothing, while Fleet showed
+  the CIDR list exactly as typed. Verified against a real kernel in both
+  directions: with the floor present every packet takes it; with it retired,
+  every port-22 accept that remains is source-scoped.
+  **The design doc had already decided this, differently from the issue.**
+  `docs/design/FLEET_FIREWALL.md` §6.1 specifies `firewall_mgmt_cidrs` +
+  `firewall_mgmt_lockdown` — the floor becomes scoped only behind an explicit
+  second opt-in — and calls the LAN-wide floor the *irreducible recovery
+  channel*, which its risk register then names as the mitigation for every
+  OTHER firewall risk. Neither field existed in code. So the shipped answer is
+  that design under the name `ssh_lockdown`, reusing #157's existing
+  `ssh_allowed_source_networks` rather than adding a second CIDR list. It is
+  also the pfSense / OPNsense anti-lockout pattern, which is what operators
+  already expect.
+  **Reading §6.1 closely turns up a contradiction worth knowing about**, now
+  annotated in the doc: "the base-conf floor stays LAN-wide regardless" cannot
+  hold at the same time as line 192's `OR ip saddr {mgmt} when
+  firewall_mgmt_lockdown` — first-match-wins makes the second dead. The floor
+  is therefore *retireable*, not un-removable: present by default so §6.1's
+  guarantee holds for every install that has not opted in.
+  **The mechanism already existed and is reused rather than reinvented.** The
+  Web UI's unconditional accept has lived in a retireable sentinel since #769,
+  and `spatium-firewall-reload` carries a generic `apply_sentinel_directive`.
+  The SSH accept was baked into the base config instead, which is the only
+  reason it could not be retired — so it moved to
+  `/etc/nftables.d/00-spatium-ssh.nft` and became the third caller.
+  **Retiring the sentinel alone is not enough, and the pair has to move
+  together**: all three renderers ALSO emit an SSH accept in
+  `spatium-role.nft`, which sorts *after* `50-spatium-ssh.nft` in the glob, so
+  a packet the scoped rule declined would fall straight through to it. Under
+  lockdown that line is emitted source-scoped too, and a test asserts both
+  halves so a future edit cannot do one without the other.
+  **Nothing tightens on upgrade**: `effective_ssh_scope` — the one place the
+  flag is resolved — returns `[]` while lockdown is off, which every consumer
+  already reads as "open unconditionally", so an operator who configured the
+  list while it was inert is unaffected, and an older host runner that has
+  never heard of the flag does the safe thing by construction. Behaviour also
+  stops depending on the port number, which was the real defect: post-#1001 it
+  enforced on a moved port and not on 22.
+  Two refusals on the way in — enforcing with an empty list (that closes SSH
+  from everywhere rather than restricting it, the 422 §6.1 already specified),
+  and enforcing from an address the list does not cover, which is advisory
+  rather than fatal because browsing the UI from one network and SSHing from
+  another is legitimate. That second one reads the same spoofing-resistant
+  client IP the login throttle uses, and fails OPEN when the address is
+  unknown: it exists to catch a typo, not to be a security control, and a
+  pre-flight that blocks on "I could not tell" is one operators learn to force
+  past by reflex. Turning lockdown back OFF never needs the acknowledgement —
+  that is the recovery path. Migration `e5b1d47a9c62`; 1 field on the existing
+  `find_ssh_settings` MCP tool (reported as a pair with the list, since
+  "restricted to 10/8" and "would be if enforced" are opposite answers to the
+  only question worth asking); no new feature module (#14 — it extends an
+  existing resource).
+
 - ⬜ [**Storage redundancy — RAID1 + multipath: fleet monitoring, management, and
   install support**](https://github.com/spatiumddi/spatiumddi/issues/999) — split out
   of #995 items 23 + 24, whose *refusal* half shipped there. Three parts, and the

--- a/agent/supervisor/spatium_supervisor/firewall_renderer.py
+++ b/agent/supervisor/spatium_supervisor/firewall_renderer.py
@@ -242,6 +242,7 @@ def render_drop_in(
     cp_member_count: int = 1,
     vip_configured: bool = False,
     web_ui_allowed_cidrs: list[Any] | None = None,
+    ssh_scope_cidrs: list[Any] | None = None,
 ) -> FirewallProfile:
     """Translate a role_assignment + the heartbeat's derived firewall
     inputs into an nftables drop-in body.
@@ -312,9 +313,33 @@ def render_drop_in(
     # say the same thing); clearing a scope restores it.
     webui_action = "retire" if web_ui_allowed_cidrs else "keep"
     lines.append(f"# spatium-webui: {webui_action}")
+    # #1009 — host-runner directive for the baked SSH sentinel
+    # (00-spatium-ssh.nft), which opens port 22 unconditionally from first
+    # boot. Same shape as the Web-UI sentinel above and for the same
+    # reason: it sorts EARLIER in the include glob than the scoped rule
+    # spatiumddi-ssh-reload renders, and nftables accepts on first match,
+    # so the operator's allowlist was dead code behind it.
+    #
+    # Retired only under ``ssh_lockdown`` (services.appliance.ssh.
+    # effective_ssh_scope resolves the flag; an empty scope here means it
+    # is off). That floor is what docs/design/FLEET_FIREWALL.md §6.1 calls
+    # the irreducible recovery channel, so removing it is an explicit
+    # operator decision, never a side effect of typing a CIDR.
+    ssh_action = "retire" if ssh_scope_cidrs else "keep"
+    lines.append(f"# spatium-ssh: {ssh_action}")
     lines.append("")
     lines.append("# ── Management (always open) ────────────────────────────────")
-    lines.append('tcp dport 22 accept comment "ssh"')
+    # SSH — the management floor. Unconditional unless the operator has
+    # turned on lockdown, in which case it is source-scoped to the same
+    # CIDRs the sentinel directive above retires the baked floor for.
+    # BOTH have to move together: this line sits AFTER 50-spatium-ssh.nft
+    # in the include glob, so leaving it unconditional would let every
+    # packet the scoped rule declined fall straight through to it (#1009).
+    if ssh_scope_cidrs:
+        ssh_v4, ssh_v6 = _split_families(list(ssh_scope_cidrs))
+        _emit_family_rule(lines, ssh_v4, ssh_v6, "tcp dport 22 accept", "ssh")
+    else:
+        lines.append('tcp dport 22 accept comment "ssh"')
     lines.append('icmp type echo-request accept comment "icmpv4 ping"')
     lines.append('icmpv6 type echo-request accept comment "icmpv6 ping"')
     lines.append('iif lo accept comment "loopback"')

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -1183,8 +1183,10 @@ def heartbeat_once(
         # carry no roles, no peers and no pods. ``_maybe_apply_firewall`` already
         # self-gates on ``detect_deployment_kind() == "appliance"`` and the host
         # runner short-circuits on an unchanged body hash, so an unconditional
-        # call is cheap + idempotent. SSH/22 stays in the un-removable base floor,
-        # so even a total drop-in failure leaves the node SSH-recoverable.
+        # call is cheap + idempotent. SSH/22 is opened by the baked sentinel
+        # 00-spatium-ssh.nft (#1009 — it used to be in the base conf), which is
+        # a separate file the glob pulls in, so even a total drop-in failure
+        # still leaves the node SSH-recoverable.
         _maybe_apply_firewall(
             role_assignment,
             log,

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -352,6 +352,7 @@ def _maybe_apply_firewall(
     cp_member_count: int = 1,
     vip_configured: bool = False,
     web_ui_allowed_cidrs: list[Any] | None = None,
+    ssh_scope_cidrs: list[Any] | None = None,
 ) -> None:
     """Render the firewall drop-in + write a trigger file the host
     runner picks up.
@@ -414,6 +415,7 @@ def _maybe_apply_firewall(
         cp_member_count=cp_member_count,
         vip_configured=vip_configured,
         web_ui_allowed_cidrs=web_ui_allowed_cidrs,
+        ssh_scope_cidrs=ssh_scope_cidrs,
     )
     body = profile.body
 
@@ -454,6 +456,7 @@ def _maybe_apply_firewall(
                 cp_member_count=cp_member_count,
                 vip_configured=vip_configured,
                 web_ui_allowed_cidrs=web_ui_allowed_cidrs,
+                ssh_scope_cidrs=ssh_scope_cidrs,
             )
             body = profile.body
 
@@ -1147,6 +1150,11 @@ def heartbeat_once(
     fw_vip_configured = bool(body_out.get("desired_control_plane_vip") or "")
     # #285 Phase 6 — operator Web-UI source restriction (empty = open).
     fw_web_ui_cidrs = body_out.get("web_ui_allowed_cidrs") or []
+    # #1009 — the EFFECTIVE ssh scope (empty unless the operator turned
+    # lockdown on). Non-empty retires the baked port-22 floor and scopes
+    # the management line; absent from an older control plane, which
+    # keeps the floor — the safe direction.
+    fw_ssh_scope_cidrs = body_out.get("ssh_scope_cidrs") or []
     # #285 Phase 2a — bundle-first / renderer-fallback dispatch. When the
     # control plane has firewall authority (firewall_enabled on → a non-empty
     # ``firewall_settings.config_hash``), pipe its server-rendered body to the
@@ -1186,6 +1194,7 @@ def heartbeat_once(
             cp_member_count=fw_cp_member_count,
             vip_configured=fw_vip_configured,
             web_ui_allowed_cidrs=fw_web_ui_cidrs,
+            ssh_scope_cidrs=fw_ssh_scope_cidrs,
         )
 
     target = compute_target_env(role_assignment)

--- a/appliance/mkosi.extra/etc/nftables.conf
+++ b/appliance/mkosi.extra/etc/nftables.conf
@@ -48,10 +48,19 @@ table inet filter {
         meta l4proto icmp   accept
         meta l4proto icmpv6 accept
 
-        # SSH — the un-removable management escape hatch. Stays here in the
-        # base floor (never scoped) so a bad Web-UI source restriction below
-        # is always recoverable over SSH / the console, never a brick.
-        tcp dport 22 accept
+        # SSH — the management escape hatch. Intentionally NOT opened here
+        # any more (#1009). It moved to the baked drop-in
+        # /etc/nftables.d/00-spatium-ssh.nft, which the include glob below
+        # pulls in, so it is still open from the very first boot and still
+        # makes a bad Web-UI source restriction recoverable over SSH.
+        #
+        # The move is what makes it RETIREABLE. A rule in this file cannot
+        # be taken out of the chain, and nftables is first-match-wins — so
+        # the source-scoped rule spatiumddi-ssh-reload renders into
+        # 50-spatium-ssh.nft was dead code behind it, and the operator's
+        # allowlist restricted nothing on port 22 while every surface
+        # reported it applied. The sentinel is retired only under
+        # ``ssh_lockdown``; see that file's header.
 
         # Web UI (HTTP + HTTPS) — #285 Phase 6. Intentionally NOT opened here
         # any more. The supervisor's spatium-role.nft drop-in (pulled in by the

--- a/appliance/mkosi.extra/etc/nftables.d/00-spatium-ssh.nft
+++ b/appliance/mkosi.extra/etc/nftables.d/00-spatium-ssh.nft
@@ -1,0 +1,40 @@
+# SpatiumDDI SSH management floor (#1009).
+#
+# Opens port 22 unconditionally from the very first boot, before the
+# supervisor exists and before any drop-in has been rendered — the
+# management escape hatch `docs/design/FLEET_FIREWALL.md` §6.1 calls the
+# irreducible recovery channel, and the mitigation its risk register names
+# for every OTHER firewall risk (a bad Web-UI scope, a peer-CIDR typo).
+#
+# Why it moved here from /etc/nftables.conf. It was a bare rule in the base
+# chain, ABOVE the `include "/etc/nftables.d/*.nft"` glob. nftables is
+# first-match-wins, so the source-scoped rule spatiumddi-ssh-reload renders
+# into 50-spatium-ssh.nft could never be reached on port 22: the operator's
+# allowlist rendered perfectly, passed the `nft -c` dry-run, showed in the
+# Fleet UI exactly as typed, and restricted nothing (#1009). A rule baked
+# into the base config cannot be retired; one in this directory can, by the
+# same `apply_sentinel_directive` machinery 00-spatium-webui.nft already
+# uses — which is the whole reason for the move.
+#
+# Retirement. The three firewall renderers stamp `# spatium-ssh: retire` in
+# the drop-in header when — and only when — the operator has turned on
+# `ssh_lockdown` AND configured a non-empty allowlist
+# (services.appliance.ssh.effective_ssh_scope resolves both into one
+# answer). spatium-firewall-reload then moves this file aside to
+# `.retired`; clearing lockdown stamps `keep` and restores it. Default is
+# `keep`, so an install that never opts in is unchanged.
+#
+# Retiring this file alone is NOT sufficient, and the pair must move
+# together: the renderers also emit an SSH accept in spatium-role.nft,
+# which sorts AFTER 50-spatium-ssh.nft in the glob — so a packet the scoped
+# rule declined would fall straight through to it. Under lockdown that line
+# is emitted source-scoped to the same CIDRs.
+#
+# Same lifecycle as 00-spatium-webui.nft and 00-spatium-k3s-bootstrap.nft:
+# lives in /etc so it rides the /etc overlay onto /var and survives A/B
+# slot swaps, and its `.retired` form persists the same way.
+#
+# This fragment is included INSIDE `chain input` by the
+# `include "/etc/nftables.d/*.nft"` glob in /etc/nftables.conf, so it is a
+# bare rule (no table/chain wrapper).
+tcp dport 22 accept comment "ssh-floor"

--- a/appliance/mkosi.extra/usr/local/bin/spatium-firewall-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-firewall-reload
@@ -70,6 +70,11 @@ SENTINEL_RETIRED="$SENTINEL.retired"
 # sorts earlier in the include glob and would defeat that scope.
 WEBUI_SENTINEL=/etc/nftables.d/00-spatium-webui.nft
 WEBUI_SENTINEL_RETIRED="$WEBUI_SENTINEL.retired"
+# #1009 — SSH management floor. Same machinery: retired only when the
+# operator turns on ssh_lockdown, which is the one thing that lets the
+# source-scoped rule in 50-spatium-ssh.nft be reached on port 22.
+SSH_SENTINEL=/etc/nftables.d/00-spatium-ssh.nft
+SSH_SENTINEL_RETIRED="$SSH_SENTINEL.retired"
 # #285 Phase 2c — test-apply + auto-revert. A test trigger (``__test__`` on
 # line 2) snapshots the current drop-in + sentinel state to .last-good and
 # arms a deadline; the always-running spatiumddi-firewall-revert.timer
@@ -82,6 +87,7 @@ CONFIRM_FILE=/var/lib/spatiumddi/release-state/firewall-confirm
 LAST_GOOD=/var/lib/spatiumddi/release-state/firewall-role.nft.last-good
 LAST_GOOD_SENTINEL=/var/lib/spatiumddi/release-state/firewall-sentinel.last-good
 LAST_GOOD_WEBUI_SENTINEL=/var/lib/spatiumddi/release-state/firewall-webui-sentinel.last-good
+LAST_GOOD_SSH_SENTINEL=/var/lib/spatiumddi/release-state/firewall-ssh-sentinel.last-good
 
 log() { printf '[spatium-firewall-reload] %s\n' "$*"; }
 
@@ -175,6 +181,17 @@ if [ "$TEST_MODE" = 1 ]; then
     else
         echo absent > "$LAST_GOOD_WEBUI_SENTINEL"
     fi
+    # #1009 — and the SSH floor, for the same reason and more sharply: a
+    # test-apply that retires it is the one change in this plane that can
+    # cost the operator their own session, so a revert that left it retired
+    # would strand them on exactly the ruleset nobody confirmed.
+    if [ -f "$SSH_SENTINEL" ]; then
+        echo present > "$LAST_GOOD_SSH_SENTINEL"
+    elif [ -f "$SSH_SENTINEL_RETIRED" ]; then
+        echo retired > "$LAST_GOOD_SSH_SENTINEL"
+    else
+        echo absent > "$LAST_GOOD_SSH_SENTINEL"
+    fi
 fi
 
 mv "$STAGING" "$DROP_IN"
@@ -241,6 +258,12 @@ apply_sentinel_directive bootstrap "spatium-bootstrap" "$SENTINEL" "$SENTINEL_RE
 # Web UI stays open — the safe direction: a stale unscoped accept is a
 # visible posture, a silently-closed Web UI is a support call.
 apply_sentinel_directive web-ui "spatium-webui" "$WEBUI_SENTINEL" "$WEBUI_SENTINEL_RETIRED"
+# #1009 — same machinery for the SSH floor. An absent directive (a pre-#1009
+# render reaching a post-#1009 host) leaves the file as-is, so SSH stays
+# open — the safe direction, and the same choice the web-ui line above makes:
+# a stale unscoped accept is a visible posture, a silently-closed SSH port is
+# a console trip.
+apply_sentinel_directive ssh "spatium-ssh" "$SSH_SENTINEL" "$SSH_SENTINEL_RETIRED"
 
 if ! nft -f "$NFT_MAIN" 2>/tmp/nft-apply.err; then
     log "nft -f $NFT_MAIN failed — runtime apply error:"

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firewall-revert
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firewall-revert
@@ -36,6 +36,12 @@ CONFIRM_FILE=$STATE/firewall-confirm
 LAST_GOOD=$STATE/firewall-role.nft.last-good
 LAST_GOOD_SENTINEL=$STATE/firewall-sentinel.last-good
 LAST_GOOD_WEBUI_SENTINEL=$STATE/firewall-webui-sentinel.last-good
+# #1009 — the SSH floor is a retireable sentinel too, so a reverted
+# test-apply has to restore whether it was present. Without this a
+# test-apply that retired it and then reverted would leave SSH scoped by a
+# ruleset nobody confirmed — the one posture this whole plane exists to
+# make impossible.
+LAST_GOOD_SSH_SENTINEL=$STATE/firewall-ssh-sentinel.last-good
 LOCK=$STATE/firewall.lock
 APPLIED_HASH=$STATE/firewall-applied-hash
 APPLIED_STATUS=$STATE/firewall-applied-status
@@ -45,6 +51,9 @@ SENTINEL_RETIRED="$SENTINEL.retired"
 # #769 — Web-UI bootstrap sentinel (80/443 open from first boot).
 WEBUI_SENTINEL=/etc/nftables.d/00-spatium-webui.nft
 WEBUI_SENTINEL_RETIRED="$WEBUI_SENTINEL.retired"
+# #1009 — SSH management floor sentinel.
+SSH_SENTINEL=/etc/nftables.d/00-spatium-ssh.nft
+SSH_SENTINEL_RETIRED="$SSH_SENTINEL.retired"
 NFT_MAIN=/etc/nftables.conf
 
 log() { printf '[spatiumddi-firewall-revert] %s\n' "$*"; }
@@ -116,6 +125,11 @@ restore_sentinel_state "$LAST_GOOD_SENTINEL" "$SENTINEL" "$SENTINEL_RETIRED"
 # retired it must not survive a revert whose whole purpose is undoing a
 # lockout: that would leave the Web UI narrower than before the test.
 restore_sentinel_state "$LAST_GOOD_WEBUI_SENTINEL" "$WEBUI_SENTINEL" "$WEBUI_SENTINEL_RETIRED"
+# #1009 — and the SSH floor. This is the sharpest case the revert covers:
+# retiring it is the only change in this plane that can close the operator's
+# own session, so a revert that left it retired would strand them on the
+# ruleset nobody confirmed.
+restore_sentinel_state "$LAST_GOOD_SSH_SENTINEL" "$SSH_SENTINEL" "$SSH_SENTINEL_RETIRED"
 
 if nft -c -f "$NFT_MAIN" 2>/tmp/nft-revert.err && nft -f "$NFT_MAIN" 2>>/tmp/nft-revert.err; then
     sha256sum "$DROP_IN" | cut -d' ' -f1 > "$APPLIED_HASH" 2>/dev/null || true
@@ -126,4 +140,4 @@ else
     log "REVERT FAILED on nft apply — manual intervention needed:"
     sed 's/^/[spatiumddi-firewall-revert]  /' /tmp/nft-revert.err 2>/dev/null || true
 fi
-rm -f "$LAST_GOOD_SENTINEL" "$LAST_GOOD_WEBUI_SENTINEL"
+rm -f "$LAST_GOOD_SENTINEL" "$LAST_GOOD_WEBUI_SENTINEL" "$LAST_GOOD_SSH_SENTINEL"

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-ssh-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-ssh-reload
@@ -276,18 +276,20 @@ PYEOF
         # reported success. Rendering goes to a temp file so a refusal below
         # cannot leave a truncated fragment where the real rule used to be.
         #
-        # KNOWN LIMIT, also #1001: on the DEFAULT port this rule is still
-        # dead code. /etc/nftables.conf emits an unconditional
-        # `tcp dport 22 accept` in its management floor, above the include
-        # glob that pulls this file in, and nftables is first-match-wins
-        # (verified against a real kernel). That floor is the deliberate
-        # un-removable recovery channel, so #1001 left it alone — the
-        # allowlist therefore only bites once SSH is moved off 22. The Web UI
-        # handles the same collision by retiring its unconditional accept
-        # when a scope is set (`webui_action` in firewall_renderer.py); doing
-        # that here would turn a wrong CIDR into a console-only recovery, so
-        # it is a decision rather than a fix — tracked as #1009. Pinned by
-        # appliance/tests/test_host_runner_stdin_programs.py.
+        # #1009 closed the other half. Until then this rule was dead code on
+        # port 22 whatever it contained: /etc/nftables.conf opened 22
+        # unconditionally ABOVE the include glob that pulls this file in, and
+        # nftables is first-match-wins. That floor now lives in the baked
+        # sentinel /etc/nftables.d/00-spatium-ssh.nft, which the firewall
+        # renderers retire when the operator turns on ``ssh_lockdown``.
+        #
+        # Which is also why CIDR_JSON is EMPTY unless lockdown is on: the
+        # control plane resolves the flag once (services.appliance.ssh.
+        # effective_ssh_scope) and ships the effective scope, so this runner
+        # renders an unconditional accept whenever the floor is staying — the
+        # two can never disagree about whether SSH is restricted, and an
+        # older control plane that predates the flag sends nothing, which
+        # lands on the same safe answer.
         NFT_TMP=$(mktemp /tmp/spatium-ssh-nft.XXXXXX)
         trap 'rm -f "$BODY_TMP" "$AK_TMP" "$SSHD_TMP" "$TEST_CONF" "$NFT_TMP"; rm -rf "$STAGE_DIR"' EXIT
         if ! python3 - "$PORT" "$CIDR_JSON" > "$NFT_TMP" <<'PYEOF'

--- a/appliance/tests/test_firewall_ssh_sentinel.py
+++ b/appliance/tests/test_firewall_ssh_sentinel.py
@@ -1,0 +1,184 @@
+"""The SSH source-CIDR allowlist can finally be enforced (#1009).
+
+``ssh_allowed_source_networks`` has shipped since #157 and, on the default
+port, restricted nothing.  ``/etc/nftables.conf`` opened ``tcp dport 22``
+unconditionally in its management floor, ABOVE the
+``include "/etc/nftables.d/*.nft"`` glob that pulls in the scoped rule
+``spatiumddi-ssh-reload`` renders — and nftables is first-match-wins, so the
+scoped rule was dead code.  Verified against a real kernel while #1001 was
+written: both rules load, the unconditional one lists first.
+
+The floor moves here, to a baked sentinel, for exactly one reason: a rule in
+the base config cannot be taken out of the chain, and one in this directory
+can — by the same ``apply_sentinel_directive`` machinery
+``00-spatium-webui.nft`` has used since #769.
+
+Retiring it removes what ``docs/design/FLEET_FIREWALL.md`` §6.1 calls the
+irreducible recovery channel and R1 names as the mitigation for every OTHER
+firewall risk, so it happens only under ``ssh_lockdown`` — a second,
+default-off switch, which is the shape §6.1 specified (as
+``firewall_mgmt_lockdown``) and the anti-lockout pattern pfSense / OPNsense
+ship.  An install that never opts in is byte-for-byte unchanged.
+
+HOW TO RUN (from the repo root):
+    python3 -m pytest appliance/tests/test_firewall_ssh_sentinel.py -v
+
+No appliance, no nftables, no root — this reads the shipped files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+NFT_DIR = REPO / "appliance/mkosi.extra/etc/nftables.d"
+SENTINEL = NFT_DIR / "00-spatium-ssh.nft"
+WEBUI_SENTINEL = NFT_DIR / "00-spatium-webui.nft"
+RELOAD = REPO / "appliance/mkosi.extra/usr/local/bin/spatium-firewall-reload"
+REVERT = REPO / "appliance/mkosi.extra/usr/local/bin/spatiumddi-firewall-revert"
+SSH_RELOAD = REPO / "appliance/mkosi.extra/usr/local/bin/spatiumddi-ssh-reload"
+BASE_CONF = REPO / "appliance/mkosi.extra/etc/nftables.conf"
+
+
+def _text(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+def _rules(p: Path) -> list[str]:
+    return [
+        ln.strip()
+        for ln in _text(p).splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    ]
+
+
+# --------------------------------------------------------------------------
+# 1. the floor still exists, and still opens 22 from a cold boot
+# --------------------------------------------------------------------------
+def test_the_floor_is_baked_and_still_opens_port_22() -> None:
+    """Moving it must not close it.
+
+    This is the recovery channel for a bad Web-UI scope and a peer-CIDR typo
+    alike, and it has to be live from the first boot — before the supervisor
+    exists, and on a node whose drop-in has never rendered.
+    """
+    assert SENTINEL.is_file(), "the SSH escape hatch would be gone entirely"
+    assert _rules(SENTINEL) == ['tcp dport 22 accept comment "ssh-floor"']
+
+
+def test_it_is_a_bare_rule_like_its_sibling() -> None:
+    """The glob includes these INSIDE ``chain input``.
+
+    A ``table``/``chain`` wrapper here fails the whole transactional
+    ``nft -f`` at boot — which is fail-OPEN, no input filtering at all.
+    """
+    # Rule lines only — the header prose necessarily says "chain input".
+    for rule in _rules(SENTINEL):
+        assert not rule.startswith(("table ", "chain ", "add rule"))
+        assert "{" not in rule and "}" not in rule
+
+
+def test_it_sorts_before_the_scoped_rule_and_the_supervisor_drop_in() -> None:
+    """Ordering IS the mechanism, in both directions.
+
+    While present it must win over ``50-spatium-ssh.nft`` (that is what makes
+    it a floor); once retired, the scoped rule is what remains.
+    """
+    names = sorted(["00-spatium-ssh.nft", "50-spatium-ssh.nft", "spatium-role.nft"])
+    assert names == ["00-spatium-ssh.nft", "50-spatium-ssh.nft", "spatium-role.nft"]
+
+
+def test_the_base_conf_no_longer_opens_22_itself() -> None:
+    """The whole point: a rule in the base config cannot be retired.
+
+    Leaving it there would keep the allowlist dead however correctly
+    everything else behaves — which is the #1009 bug.
+    """
+    for line in _text(BASE_CONF).splitlines():
+        code = line.split("#", 1)[0].strip()
+        assert code != "tcp dport 22 accept", (
+            "the port-22 accept is back in the base config, where it cannot be "
+            "retired — the ssh allowlist is dead code again (#1009)"
+        )
+
+
+def test_the_base_conf_still_includes_the_drop_in_glob() -> None:
+    """...and the floor is only still open because of this line."""
+    assert 'include "/etc/nftables.d/*.nft"' in _text(BASE_CONF)
+
+
+# --------------------------------------------------------------------------
+# 2. the runners manage it
+# --------------------------------------------------------------------------
+def test_the_reload_runner_manages_all_three_sentinels() -> None:
+    body = _text(RELOAD)
+    for directive in ("spatium-bootstrap", "spatium-webui", "spatium-ssh"):
+        assert f'"{directive}"' in body, directive
+    # Three CALLS (the definition is ``apply_sentinel_directive() {``, no
+    # space) — a directive declared but never applied is the failure this
+    # catches, and it would look exactly like success.
+    assert body.count("apply_sentinel_directive ") == 3
+
+
+def test_the_reload_runner_snapshots_the_ssh_state_for_revert() -> None:
+    """A test-apply that retires the floor must be undoable.
+
+    This is the sharpest case the revert plane covers: retiring the floor is
+    the only change in it that can close the operator's OWN session, so a
+    revert that left it retired would strand them on the one ruleset nobody
+    confirmed.
+    """
+    body = _text(RELOAD)
+    assert "LAST_GOOD_SSH_SENTINEL" in body
+    for state in ("present", "retired", "absent"):
+        assert f'echo {state} > "$LAST_GOOD_SSH_SENTINEL"' in body, state
+
+
+def test_the_revert_runner_restores_the_ssh_sentinel() -> None:
+    body = _text(REVERT)
+    assert (
+        'restore_sentinel_state "$LAST_GOOD_SSH_SENTINEL" "$SSH_SENTINEL" '
+        '"$SSH_SENTINEL_RETIRED"' in body
+    )
+    assert '"$LAST_GOOD_SSH_SENTINEL"' in body.split("rm -f")[-1]
+
+
+def test_the_sentinel_paths_agree_across_both_runners() -> None:
+    """Two files, one path. A typo here retires nothing and reverts nothing,
+    silently — both runners would still report success."""
+    for body in (_text(RELOAD), _text(REVERT)):
+        assert "SSH_SENTINEL=/etc/nftables.d/00-spatium-ssh.nft" in body
+        assert 'SSH_SENTINEL_RETIRED="$SSH_SENTINEL.retired"' in body
+
+
+# --------------------------------------------------------------------------
+# 3. the pair that must move together
+# --------------------------------------------------------------------------
+def test_retiring_the_floor_alone_would_not_be_enough() -> None:
+    """The renderers emit a SECOND unconditional accept, after the scoped one.
+
+    ``spatium-role.nft`` sorts after ``50-spatium-ssh.nft`` in the glob, so a
+    packet the scoped rule declined would fall straight through to it. The
+    renderers therefore scope that line under lockdown too — this test exists
+    so a future edit that retires the sentinel without scoping the management
+    line (or vice versa) fails rather than half-working.
+    """
+    renderers = [
+        REPO / "agent/supervisor/spatium_supervisor/firewall_renderer.py",
+        REPO / "backend/app/services/appliance/firewall.py",
+        REPO / "backend/app/services/appliance/firewall_merge.py",
+    ]
+    for path in renderers:
+        if not path.is_file():
+            continue
+        body = _text(path)
+        assert "# spatium-ssh: {ssh_action}" in body, f"{path.name}: no directive"
+        assert "ssh_scope_cidrs" in body, f"{path.name}: floor not scoped under lockdown"
+
+
+def test_the_ssh_reload_runner_still_renders_the_scoped_rule() -> None:
+    """The other half of the pair, from #1001. Retiring the floor is only
+    useful because this rule is waiting behind it."""
+    body = _text(SSH_RELOAD)
+    assert 'python3 - "$PORT" "$CIDR_JSON"' in body
+    assert "ip saddr" in body

--- a/appliance/tests/test_firewall_ssh_sentinel.py
+++ b/appliance/tests/test_firewall_ssh_sentinel.py
@@ -28,6 +28,7 @@ No appliance, no nftables, no root — this reads the shipped files.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
@@ -42,6 +43,18 @@ BASE_CONF = REPO / "appliance/mkosi.extra/etc/nftables.conf"
 
 def _text(p: Path) -> str:
     return p.read_text(encoding="utf-8")
+
+
+def _one(p: Path, pattern: str) -> str:
+    """The single regex capture in ``p``, or a loud failure.
+
+    Deliberately asserts on the match count: a renamed or reformatted
+    declaration must fail the extraction rather than quietly yield the first
+    of several, or none.
+    """
+    hits = re.findall(pattern, _text(p), re.MULTILINE)
+    assert len(hits) == 1, f"{p.name}: {pattern!r} matched {len(hits)}x"
+    return hits[0]
 
 
 def _rules(p: Path) -> list[str]:
@@ -81,11 +94,27 @@ def test_it_is_a_bare_rule_like_its_sibling() -> None:
 def test_it_sorts_before_the_scoped_rule_and_the_supervisor_drop_in() -> None:
     """Ordering IS the mechanism, in both directions.
 
-    While present it must win over ``50-spatium-ssh.nft`` (that is what makes
-    it a floor); once retired, the scoped rule is what remains.
+    While present the floor must win over ``50-spatium-ssh.nft`` (that is what
+    makes it a floor); once retired, the scoped rule is what remains, and it
+    must in turn win over the management line in ``spatium-role.nft``.
+
+    The three names are read from the places that actually produce them — the
+    shipped file on disk, and the two runners' own path constants — rather
+    than restated here. A test that sorts its own literals exercises
+    ``sorted()``: rename the sentinel to ``60-…`` and lockdown silently stops
+    enforcing, with the literal version still green.
     """
-    names = sorted(["00-spatium-ssh.nft", "50-spatium-ssh.nft", "spatium-role.nft"])
-    assert names == ["00-spatium-ssh.nft", "50-spatium-ssh.nft", "spatium-role.nft"]
+    floor = SENTINEL.name
+
+    scoped = _one(SSH_RELOAD, r"^NFT_DROPIN=/etc/nftables\.d/(\S+)$")
+    role = _one(RELOAD, r"^DROP_IN=/etc/nftables\.d/(\S+)$")
+
+    glob_order = sorted([floor, scoped, role])
+    assert glob_order == [floor, scoped, role], (
+        f"the include glob applies these in the order {glob_order}, but the "
+        f"mechanism needs floor({floor}) < scoped({scoped}) < role({role}) — "
+        "nftables accepts on first match"
+    )
 
 
 def test_the_base_conf_no_longer_opens_22_itself() -> None:

--- a/appliance/tests/test_firewall_webui_sentinel.py
+++ b/appliance/tests/test_firewall_webui_sentinel.py
@@ -94,13 +94,16 @@ def test_base_conf_still_does_not_open_web_ports() -> None:
 def test_reload_runner_manages_both_sentinels() -> None:
     body = _text(RELOAD)
     assert "00-spatium-webui.nft" in body
-    # Both sentinels go through the one directive helper — a second
-    # hand-rolled copy is how the two drift apart.
+    # EVERY sentinel goes through the one directive helper — a second
+    # hand-rolled copy is how they drift apart. Asserted as "one definition,
+    # every sentinel among the calls" rather than as an exact call count,
+    # which #1009 legitimately changed by adding a third (the SSH floor).
     assert body.count("apply_sentinel_directive()") == 1
     calls = re.findall(r"^apply_sentinel_directive .+$", body, re.M)
-    assert len(calls) == 2, calls
-    assert any("spatium-bootstrap" in c for c in calls)
-    assert any("spatium-webui" in c for c in calls)
+    assert any("spatium-bootstrap" in c for c in calls), calls
+    assert any("spatium-webui" in c for c in calls), calls
+    assert any("spatium-ssh" in c for c in calls), calls
+    assert len(calls) == 3, calls
 
 
 def test_reload_runner_snapshots_webui_state_for_revert() -> None:
@@ -116,8 +119,15 @@ def test_revert_runner_restores_webui_sentinel() -> None:
     body = _text(REVERT)
     assert "LAST_GOOD_WEBUI_SENTINEL" in body
     calls = re.findall(r"^restore_sentinel_state .+$", body, re.M)
-    assert len(calls) == 2, calls
-    assert any("WEBUI" in c for c in calls)
-    # The snapshot must be cleared alongside the k3s one, or a stale file
-    # would drive the next revert.
-    assert 'rm -f "$LAST_GOOD_SENTINEL" "$LAST_GOOD_WEBUI_SENTINEL"' in body
+    assert any("WEBUI" in c for c in calls), calls
+    # Three since #1009 added the SSH floor; the count is pinned so a
+    # sentinel that gains a retire directive without a matching restore —
+    # which would survive a revert, the one thing a revert must undo — fails
+    # here rather than in the field.
+    assert len(calls) == 3, calls
+    # Every snapshot must be cleared together, or a stale file would drive
+    # the next revert.
+    assert (
+        'rm -f "$LAST_GOOD_SENTINEL" "$LAST_GOOD_WEBUI_SENTINEL" '
+        '"$LAST_GOOD_SSH_SENTINEL"' in body
+    )

--- a/appliance/tests/test_host_runner_stdin_programs.py
+++ b/appliance/tests/test_host_runner_stdin_programs.py
@@ -222,48 +222,39 @@ def test_everything_that_can_refuse_runs_before_the_sshd_drop_in() -> None:
     )
 
 
-def test_the_scoped_rule_is_still_dead_code_on_port_22() -> None:
-    """The allowlist now renders correctly and STILL does nothing on port 22.
+def test_the_scoped_rule_is_no_longer_dead_code_on_port_22() -> None:
+    """#1001 made the allowlist render correctly; #1009 made it reachable.
 
-    ``/etc/nftables.conf`` emits an unconditional ``tcp dport 22 accept`` in
-    its management floor, ABOVE the ``include "/etc/nftables.d/*.nft"`` that
-    pulls this drop-in in. nftables is first-match-wins, so on the default
-    port the scoped rule is never reached. Verified against a real nftables
-    kernel while #1001 was written: both rules load, and ``nft list chain``
-    shows the unconditional accept first.
+    Both were needed, and for a while only the first was done. The base
+    ``/etc/nftables.conf`` opened ``tcp dport 22`` unconditionally ABOVE the
+    ``include "/etc/nftables.d/*.nft"`` glob, and nftables is first-match-wins
+    — verified against a real kernel, both rules loaded, the unconditional one
+    listed first — so a perfectly-rendered scoped rule restricted nothing on
+    the default port.
 
-    That floor is deliberate — it is the un-removable recovery channel that
-    keeps a bad Web-UI source restriction from bricking the appliance — so
-    #1001 did not remove it. But it means the fix above only bites once SSH
-    has been moved off 22, and saying otherwise would overstate it.
+    That floor now lives in the retireable sentinel
+    ``/etc/nftables.d/00-spatium-ssh.nft`` (#1009), which the firewall
+    renderers retire under ``ssh_lockdown``. This test guards the half that
+    lives in this file's subject matter: the base config must not take the
+    accept back, because a rule there cannot be retired by anything.
 
-    The Web UI solves the same collision by RETIRING its unconditional accept
-    once a scope is configured (``webui_action`` in the supervisor's firewall
-    renderer). Doing that for SSH is a behaviour decision, not a bug fix: it
-    would make a wrong CIDR a real SSH lockout, recoverable only at the
-    console. Tracked as #1009; this test exists so whoever takes that
-    decision finds this note rather than rediscovering the ordering — move
-    it to assert the new behaviour rather than deleting it.
+    The rest of the mechanism — the sentinel, both host runners, and the
+    second unconditional accept the renderers emit AFTER the scoped rule —
+    is pinned by ``test_firewall_ssh_sentinel.py``.
     """
     base = (
         Path(__file__).parent.parent / "mkosi.extra" / "etc" / "nftables.conf"
     ).read_text(encoding="utf-8")
-    lines = [ln.strip() for ln in base.splitlines()]
-    accept = next(
-        (i for i, ln in enumerate(lines) if ln == "tcp dport 22 accept"), None
-    )
-    include = next(
-        (i for i, ln in enumerate(lines) if ln.startswith('include "/etc/nftables.d/')),
-        None,
-    )
-    assert accept is not None, "the base management floor no longer opens 22"
-    assert include is not None, "the drop-in include glob is gone"
-    assert accept < include, (
-        "the unconditional port-22 accept now sorts AFTER the drop-in include "
-        "— the ssh source-CIDR allowlist has become live on the default port. "
-        "That is a real behaviour change (a wrong CIDR is now an SSH lockout, "
-        "recoverable only at the console): update this test, the #1001 note in "
-        "spatiumddi-ssh-reload, and the CHANGELOG together."
+    for line in base.splitlines():
+        code = line.split("#", 1)[0].strip()
+        assert code != "tcp dport 22 accept", (
+            "the unconditional port-22 accept is back in the base config, "
+            "where nothing can retire it — the ssh source-CIDR allowlist is "
+            "dead code again on the default port (#1001 / #1009)"
+        )
+    assert 'include "/etc/nftables.d/*.nft"' in base, (
+        "the drop-in glob is gone, so neither the floor nor the scoped rule "
+        "reaches the chain at all"
     )
 
 

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -639,6 +639,7 @@ backend/alembic/versions/e5a3f17b2d8c_device_profiling_phase2.py:drop_column:110
 backend/alembic/versions/e5a3f17b2d8c_device_profiling_phase2.py:drop_column:111
 backend/alembic/versions/e5a3f17b2d8c_device_profiling_phase2.py:drop_table:113
 backend/alembic/versions/e5a72f14c890_proxmox_infer_vnet_subnets.py:drop_column:38
+backend/alembic/versions/e5b1d47a9c62_ssh_lockdown.py:drop_column:41
 backend/alembic/versions/e5b21a8f0d94_release_check_state.py:drop_column:56
 backend/alembic/versions/e5b21a8f0d94_release_check_state.py:drop_column:57
 backend/alembic/versions/e5b21a8f0d94_release_check_state.py:drop_column:58

--- a/backend/alembic/versions/e5b1d47a9c62_ssh_lockdown.py
+++ b/backend/alembic/versions/e5b1d47a9c62_ssh_lockdown.py
@@ -1,0 +1,41 @@
+"""ssh_lockdown — make the SSH source-CIDR allowlist enforceable (#1009)
+
+The allowlist has shipped since #157 and, on the default port, enforced
+nothing: the management floor opens 22 unconditionally *before* the scoped
+drop-in in the include glob, and nftables is first-match-wins. Retiring that
+floor removes what ``docs/design/FLEET_FIREWALL.md`` §6.1 calls the
+irreducible recovery channel, so it is an explicit operator decision rather
+than a side effect of typing a CIDR.
+
+Defaults FALSE, which is deliberately a no-op for every existing install:
+an operator who configured the list while it was inert does not get their
+SSH tightened by an upgrade they did not ask for.
+
+Revision ID: e5b1d47a9c62
+Revises: c93f1a72e408
+Create Date: 2026-09-07
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "e5b1d47a9c62"
+down_revision = "c93f1a72e408"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "ssh_lockdown",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("platform_settings", "ssh_lockdown")

--- a/backend/app/api/v1/appliance/firewall.py
+++ b/backend/app/api/v1/appliance/firewall.py
@@ -888,6 +888,7 @@ def _render_for(inputs: dict[str, Any], ps: PolicySet, ap: _Policy | None) -> st
         policy_set=ps,
         appliance_policy=ap,
         web_ui_allowed_cidrs=inputs.get("web_ui_allowed_cidrs") or [],
+        ssh_scope_cidrs=inputs.get("ssh_scope_cidrs") or [],
     )
 
 

--- a/backend/app/api/v1/appliance/firewall.py
+++ b/backend/app/api/v1/appliance/firewall.py
@@ -170,7 +170,9 @@ class RuleIn(BaseModel):
     def _v_shape(self) -> RuleIn:
         # Floor backstop (the DB CHECK is authoritative; this is the friendly 422).
         if self.action == "drop" and 22 in self.ports:
-            raise ValueError("a rule may not DROP port 22 (ssh) — the mgmt floor is un-removable")
+            raise ValueError(
+                "a rule may not DROP port 22 (ssh) — the mgmt floor is not " "removable by a rule"
+            )
         if self.source_kind == "cidr":
             if not self.source_cidrs:
                 raise ValueError("source_kind='cidr' requires source_cidrs")
@@ -1271,9 +1273,15 @@ async def apply_posture(
 # ANTI-LOCKOUT: a non-empty set that doesn't cover the operator's CURRENT
 # source IP would brick the very session making the change (the request is
 # arriving through the frontend right now). We reject that 422 unless the
-# operator explicitly passes override_lockout=true. SSH/22 stays in the
-# un-removable base floor regardless, so even an overridden lockout is
-# always recoverable over SSH / the console.
+# operator explicitly passes override_lockout=true.
+#
+# SSH/22 is the recovery path for an overridden lockout — but since #1009 it
+# is recoverable rather than guaranteed: the port-22 floor is a retireable
+# sentinel, and an operator who ALSO turned on ``ssh_lockdown`` with a scope
+# that excludes them has closed both doors and is left with the console. The
+# two are independent settings and each warns on its own; nothing here can
+# see the other, which is why this comment says "console" rather than
+# promising SSH.
 
 
 def _ip_in_cidrs(ip: str | None, cidrs: list[str]) -> bool:

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -112,7 +112,7 @@ from app.services.appliance.slot_image_target import (
     stamp_desired_slot_image,
 )
 from app.services.appliance.snmp import snmp_bundle
-from app.services.appliance.ssh import ssh_bundle
+from app.services.appliance.ssh import effective_ssh_scope, ssh_bundle
 from app.services.appliance.syslog import syslog_bundle
 
 logger = structlog.get_logger(__name__)
@@ -1389,6 +1389,14 @@ class SupervisorHeartbeatResponse(BaseModel):
     # supervisor's in-pod render_drop_in scopes 80/443 to these CIDRs (the
     # base /etc/nftables.conf no longer opens 80/443 LAN-wide).
     web_ui_allowed_cidrs: list[str] = Field(default_factory=list)
+    # #1009 — the EFFECTIVE SSH source scope: the operator's allowlist when
+    # ``ssh_lockdown`` is on, and EMPTY otherwise. Non-empty is what makes
+    # the supervisor's in-pod render stamp ``# spatium-ssh: retire`` and
+    # scope the port-22 management line, so the baked floor is only removed
+    # when the operator asked for it. Empty is what every consumer already
+    # reads as "open unconditionally", which is why an older supervisor that
+    # ignores this field keeps the floor — the safe direction.
+    ssh_scope_cidrs: list[str] = Field(default_factory=list)
     # #277 — the committed control-plane size (count of settled
     # primary + member nodes, floored at 1). The seed's supervisor
     # patches the spatium-control HelmChart's ``# spatium:cp-size`` lines
@@ -2371,6 +2379,12 @@ async def supervisor_heartbeat(
         firewall_enabled=bool(cfg_row.firewall_enabled) if cfg_row else False,
         appliance_id=row.id,
         web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
+        # #1009 — the EFFECTIVE ssh scope, not the typed list: empty unless
+        # the operator turned lockdown on. Non-empty is what retires the
+        # baked port-22 floor, so it must be resolved in exactly one place
+        # (services.appliance.ssh.effective_ssh_scope) or the firewall and
+        # the ssh plane could disagree about whether SSH is restricted.
+        ssh_scope_cidrs=(effective_ssh_scope(cfg_row) if cfg_row else []),
         firewall_logging_enabled=(bool(cfg_row.firewall_logging_enabled) if cfg_row else False),
     )
     # Persist the rendered hash so 2d's apply-stalled alarm + the Fleet drift
@@ -2432,6 +2446,12 @@ async def supervisor_heartbeat(
         firewall_pod_cidrs=firewall_pod_cidrs,
         firewall_service_cidrs=firewall_service_cidrs,
         web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
+        # #1009 — the EFFECTIVE ssh scope, not the typed list: empty unless
+        # the operator turned lockdown on. Non-empty is what retires the
+        # baked port-22 floor, so it must be resolved in exactly one place
+        # (services.appliance.ssh.effective_ssh_scope) or the firewall and
+        # the ssh plane could disagree about whether SSH is restricted.
+        ssh_scope_cidrs=(effective_ssh_scope(cfg_row) if cfg_row else []),
         control_plane_size=control_plane_size,
         desired_metallb_enabled=metallb_enabled,
         desired_metallb_pool_addresses=metallb_pool,
@@ -2495,6 +2515,10 @@ async def firewall_render_inputs(db: DB, row: Appliance) -> dict[str, Any]:
         "vip_configured": bool((cfg_row.control_plane_vip or "") if cfg_row else ""),
         "firewall_enabled": bool(cfg_row.firewall_enabled) if cfg_row else False,
         "web_ui_allowed_cidrs": (list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
+        # #1009 — mirrors web_ui_allowed_cidrs: the supervisor's in-pod
+        # fallback renderer needs the same input the server-authoritative
+        # render used, or the two would disagree about the floor.
+        "ssh_scope_cidrs": (effective_ssh_scope(cfg_row) if cfg_row else []),
     }
 
 

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -2072,9 +2072,26 @@ async def update_settings(
     # SSHing from another is legitimate — but it must be acknowledged, since
     # the alternative is discovering it at the next SSH attempt. Superadmin
     # forces past it with ``ssh_lockdown_force``.
+    #
+    # Gated on the TRANSITION, not on the resulting state. Keyed on the
+    # latter it fires on every ``ssh_*`` save made while lockdown is already
+    # on — adding a key, changing the port — demanding an acknowledgement for
+    # a change that alters nothing about who can reach the box. An operator
+    # asked to accept a lockout warning for an unrelated edit learns to tick
+    # it without reading, which costs more than the warning buys.
+    #
+    # Two transitions introduce the risk: turning it on, and narrowing the
+    # scope while it is on. Both are re-checked against the caller's address
+    # even when the OLD scope already excluded them, since the fix for that
+    # is a save that includes them and it should stop warning the moment it
+    # does.
+    _lockdown_was_on = bool(settings.ssh_lockdown)
+    _scope_changing = "ssh_allowed_source_networks" in changes and list(_resulting_scope) != list(
+        settings.ssh_allowed_source_networks or []
+    )
+    _lockdown_newly_enforced = _resulting_lockdown and (not _lockdown_was_on or _scope_changing)
     if (
-        _ssh_field_in_request
-        and _resulting_lockdown
+        _lockdown_newly_enforced
         and _resulting_scope
         and not body.ssh_lockdown_force
         and not _caller_within_scope(request, _resulting_scope)

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -1148,8 +1148,9 @@ class SettingsUpdate(BaseModel):
             raise ValueError("ssh_port must be 1–65535")
         # Privileged-port floor — reject < 1024 except 22 so an operator
         # can't park sshd somewhere that needs root-only bind privileges
-        # the runner can't reliably reach. 22 stays the un-removable
-        # default; the host runner does the real bind / in-use check.
+        # the runner can't reliably reach. 22 is always an allowed value;
+        # the host runner does the real bind / in-use check. (Unrelated to
+        # the port-22 firewall floor, which #1009 made retireable.)
         if v < 1024 and v != 22:
             raise ValueError(
                 "ssh_port below 1024 is not allowed (except 22) — pick a "

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -2101,9 +2101,10 @@ async def update_settings(
             detail=(
                 "Your own address is not inside the allowed networks, so "
                 "enforcing this restriction may close your SSH access to every "
-                "appliance (recoverable at the console, or by turning the "
-                "restriction back off here). Re-send with ssh_lockdown_force "
-                "to proceed."
+                "appliance. The console always recovers it; turning the "
+                "restriction back off here only works if you can still reach "
+                "this UI, which a Web UI source restriction may also be "
+                "limiting. Re-send with ssh_lockdown_force to proceed."
             ),
         )
     if _ssh_field_in_request and not validate_lockout_safe(

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -10,7 +10,16 @@ from ipaddress import ip_network
 from typing import Any, Literal
 
 import structlog
-from fastapi import APIRouter, File, Header, HTTPException, Response, UploadFile, status
+from fastapi import (
+    APIRouter,
+    File,
+    Header,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+    status,
+)
 from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -20,6 +29,7 @@ from app.core.agent_wake import HOSTCONFIG_ALL, publish_wake
 from app.core.demo_mode import forbid_in_demo_mode
 from app.core.http_etag import etag_matches, format_etag
 from app.core.permissions import is_effective_superadmin, user_has_permission
+from app.core.request_meta import get_trusted_client_ip
 from app.models.audit import AuditLog
 from app.models.audit_forward import AuditForwardTarget
 from app.models.influxdb import (
@@ -254,6 +264,7 @@ class SettingsResponse(BaseModel):
     ssh_allow_root_login: bool = False
     ssh_port: int = 22
     ssh_allowed_source_networks: list[str] = []
+    ssh_lockdown: bool = False
     # ── Appliance DNS resolver (issue #158) ───────────────────────
     # No secrets — resolver IPs / search domains are not sensitive, so
     # the read shape mirrors the stored shape directly (like NTP / SSH
@@ -956,6 +967,10 @@ class SettingsUpdate(BaseModel):
     ssh_allow_root_login: bool | None = None
     ssh_port: int | None = None
     ssh_allowed_source_networks: list[str] | None = None
+    ssh_lockdown: bool | None = None
+    # Not a column — the acknowledgement for the self-lockout pre-flight
+    # below. Popped out of ``changes`` before anything is written.
+    ssh_lockdown_force: bool | None = None
     # ── Appliance DNS resolver (issue #158) ───────────────────────
     resolver_mode: str | None = None
     resolver_servers: list[str] | None = None
@@ -1725,9 +1740,43 @@ async def get_settings_defaults(current_user: CurrentUser) -> dict[str, Any]:
     return _column_defaults()
 
 
+def _caller_within_scope(request: Request, cidrs: list[str]) -> bool:
+    """Is the address this request came from inside ``cidrs``? (#1009)
+
+    Uses the same spoofing-resistant value the login throttle and the audit
+    trail use, so a client cannot talk its way past the check with a header.
+
+    Returns True when the address is UNKNOWN. This gate exists to catch an
+    operator typo, not to be a security control — the restriction it guards
+    is enforced by nftables on the host regardless — and refusing every
+    request whose source we cannot read would make the setting unreachable
+    from a deployment shape that hides it. A pre-flight that fails closed on
+    "I could not tell" is one operators learn to force past by reflex, which
+    costs more than it buys.
+    """
+    from ipaddress import ip_address, ip_network  # noqa: PLC0415
+
+    raw = get_trusted_client_ip(request)
+    if not raw:
+        return True
+    try:
+        addr = ip_address(raw)
+    except ValueError:
+        return True
+    for cidr in cidrs:
+        try:
+            if addr in ip_network(str(cidr).strip(), strict=False):
+                return True
+        except ValueError:
+            # Already validated on the way in; a bad entry here cannot make
+            # the caller "covered", so skip it rather than fail the check.
+            continue
+    return False
+
+
 @router.put("", response_model=SettingsResponse)
 async def update_settings(
-    body: SettingsUpdate, current_user: CurrentUser, db: DB
+    body: SettingsUpdate, request: Request, current_user: CurrentUser, db: DB
 ) -> PlatformSettings:
     forbid_in_demo_mode("Platform settings updates are disabled")
     # Superadmin passes via user_has_permission shortcut; users with an
@@ -1740,6 +1789,9 @@ async def update_settings(
 
     settings = await _get_or_create(db)
     changes = body.model_dump(exclude_none=True)
+    # #1009 — an acknowledgement, not a column. Pop before anything reads
+    # ``changes`` as the set of fields to write or to audit.
+    changes.pop("ssh_lockdown_force", None)
 
     # CROSS-FIELD merged-state guard for the DNS resolver (#158). The
     # model_validator already rejects override + explicitly-empty servers in
@@ -1989,6 +2041,53 @@ async def update_settings(
     _ssh_field_in_request = any(f.startswith("ssh_") for f in changes) or (
         ssh_keys_normalised is not None
     )
+    # #1009 — ``ssh_lockdown`` with nothing to allow from.
+    #
+    # The flag retires the port-22 management floor so the allowlist can
+    # finally be reached. With an empty list the rendered scope accepts from
+    # nowhere, which is not a restriction but a closed port — and it would
+    # close it on every appliance at once, recoverable only at the console.
+    # docs/design/FLEET_FIREWALL.md §6.1 specified this 422 for the same
+    # combination under its ``firewall_mgmt_lockdown`` name.
+    _resulting_lockdown = bool(changes.get("ssh_lockdown", settings.ssh_lockdown))
+    _resulting_scope = (
+        changes["ssh_allowed_source_networks"]
+        if "ssh_allowed_source_networks" in changes
+        else list(settings.ssh_allowed_source_networks or [])
+    )
+    if _ssh_field_in_request and _resulting_lockdown and not _resulting_scope:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "Refusing to enforce the SSH source restriction with an empty "
+                "allowed-networks list — that closes SSH from everywhere, on "
+                "every appliance, leaving only the console. Add at least one "
+                "network first, or leave the restriction off."
+            ),
+        )
+    # ...and the mistake an operator actually makes: turning it on with a
+    # list that does not contain the address they are speaking to us from.
+    # Advisory rather than a refusal — browsing the UI from one network and
+    # SSHing from another is legitimate — but it must be acknowledged, since
+    # the alternative is discovering it at the next SSH attempt. Superadmin
+    # forces past it with ``ssh_lockdown_force``.
+    if (
+        _ssh_field_in_request
+        and _resulting_lockdown
+        and _resulting_scope
+        and not body.ssh_lockdown_force
+        and not _caller_within_scope(request, _resulting_scope)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "Your own address is not inside the allowed networks, so "
+                "enforcing this restriction may close your SSH access to every "
+                "appliance (recoverable at the console, or by turning the "
+                "restriction back off here). Re-send with ssh_lockdown_force "
+                "to proceed."
+            ),
+        )
     if _ssh_field_in_request and not validate_lockout_safe(
         _resulting_keys, _resulting_password_auth
     ):
@@ -2046,6 +2145,7 @@ async def update_settings(
                     "allow_root_login": bool(settings.ssh_allow_root_login),
                     "port": int(settings.ssh_port or 22),
                     "allowed_source_networks": list(settings.ssh_allowed_source_networks or []),
+                    "lockdown": bool(settings.ssh_lockdown),
                     "authorized_keys": [
                         {
                             "name": (k.get("name") or "") if isinstance(k, dict) else "",

--- a/backend/app/models/firewall.py
+++ b/backend/app/models/firewall.py
@@ -237,9 +237,12 @@ class FirewallRule(UUIDPrimaryKeyMixin, Base):
         UniqueConstraint("policy_id", "seq", name="uq_fw_rule_policy_seq"),
         Index("ix_fw_rule_policy_seq", "policy_id", "seq"),
         # Floor protection: no rule may DROP ssh (port 22). The mgmt floor
-        # is also emitted in code, first + un-removable — this is the
-        # belt-and-braces DB guard so the policy surface can't author a
-        # self-lockout.
+        # is also emitted in code, first, and not removable BY A RULE — this
+        # is the belt-and-braces DB guard so the policy surface can't author
+        # a self-lockout. (#1009 lets an operator scope that floor
+        # deliberately via ``ssh_lockdown``, which is a separate setting with
+        # its own guards; this constraint is about what a firewall POLICY may
+        # express, and the answer there is still never.)
         CheckConstraint(
             "NOT (action = 'drop' AND ports @> '22'::jsonb)",
             name="ck_fw_rule_no_drop_ssh",

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -965,8 +965,12 @@ class PlatformSettings(Base):
     # MetalLB control-plane VIP). Empty = open (today's behaviour). When set,
     # both firewall renderers emit a peer-scoped 80/443 accept (requires the
     # base-conf strip of the LAN-wide 80/443) AND the frontend LoadBalancer
-    # Service gets loadBalancerSourceRanges. SSH/22 + console stay in the
-    # un-removable floor, so a bad scope is recoverable, never a brick.
+    # Service gets loadBalancerSourceRanges. A bad scope here is recoverable
+    # over SSH — the port-22 floor is open by default — or at the console.
+    # Since #1009 that SSH half is a default-on floor rather than a guarantee:
+    # an operator who also turned on ``ssh_lockdown`` with a scope excluding
+    # themselves has closed both doors and is left with the console. The two
+    # settings are independent and each warns on its own.
     web_ui_allowed_cidrs: Mapped[list[str]] = mapped_column(
         JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
     )

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -852,10 +852,26 @@ class PlatformSettings(Base):
     # ``PermitRootLogin yes|no``. ``ssh_port`` → sshd ``Port`` (server
     # rejects < 1024 except 22). ``ssh_allowed_source_networks`` is a
     # JSONB list of CIDRs the host nftables drop-in source-scopes the
-    # ssh port to (sshd has no native source filter); empty = open the
-    # port unconditionally, and the un-removable port-22 accept floor
-    # in the firewall renderer always stays so a bad port change can't
-    # brick the box.
+    # ssh port to (sshd has no native source filter).
+    #
+    # ``ssh_lockdown`` is what makes that list ENFORCEMENT rather than a
+    # note (#1009). Port 22 is opened unconditionally by a management
+    # floor — baked at ``/etc/nftables.d/00-spatium-ssh.nft`` and emitted
+    # again by the firewall renderers — and nftables is first-match-wins,
+    # so the scoped rule sat behind it as dead code. Retiring that floor
+    # removes what ``docs/design/FLEET_FIREWALL.md`` §6.1 calls the
+    # irreducible recovery channel, which is a decision an operator has
+    # to take rather than a side effect of typing a CIDR: hence a second,
+    # default-off switch, the same shape §6.1 specified as
+    # ``firewall_mgmt_lockdown`` and the same anti-lockout pattern
+    # pfSense / OPNsense ship.
+    #
+    # OFF (the default, including on upgrade): the port is opened
+    # unconditionally on every port, and the list is inert — so nothing
+    # tightens under an operator who never asked for it.
+    # ON: refused unless the list is non-empty (there would be nothing
+    # left to accept from), the floor is retired, and the scope applies
+    # on port 22 and on a moved port alike.
     ssh_authorized_keys: Mapped[list[dict]] = mapped_column(
         JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
     )
@@ -870,6 +886,9 @@ class PlatformSettings(Base):
     )
     ssh_allowed_source_networks: Mapped[list[str]] = mapped_column(
         JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
+    )
+    ssh_lockdown: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
     )
 
     # ── Appliance DNS resolver (issue #158) ─────────────────────────

--- a/backend/app/services/ai/tools/firewall.py
+++ b/backend/app/services/ai/tools/firewall.py
@@ -288,6 +288,7 @@ async def find_firewall_effective(
         policy_set=ps,
         appliance_policy=ap,
         web_ui_allowed_cidrs=inputs.get("web_ui_allowed_cidrs") or [],
+        ssh_scope_cidrs=inputs.get("ssh_scope_cidrs") or [],
     )
     state = await db.get(FirewallApplyState, row.id)
     return {

--- a/backend/app/services/ai/tools/ssh.py
+++ b/backend/app/services/ai/tools/ssh.py
@@ -65,6 +65,15 @@ async def find_ssh_settings(
         "allow_root_login": bool(settings.ssh_allow_root_login),
         "port": int(settings.ssh_port or 22),
         "allowed_source_networks": list(settings.ssh_allowed_source_networks or []),
+        # #1009 — the list above is what the operator typed; this is whether
+        # it is in force. Reported as a pair rather than collapsed, because
+        # "restricted to 10/8" and "would be restricted to 10/8 if enforced"
+        # are opposite answers to "can this host be reached over SSH?" and
+        # the copilot has no other way to tell them apart.
+        "lockdown": bool(settings.ssh_lockdown),
+        "source_restriction_enforced": bool(
+            settings.ssh_lockdown and list(settings.ssh_allowed_source_networks or [])
+        ),
         "authorized_keys": [
             {
                 "name": (k.get("name") or "") if isinstance(k, dict) else "",

--- a/backend/app/services/appliance/firewall.py
+++ b/backend/app/services/appliance/firewall.py
@@ -195,8 +195,10 @@ def compile_firewall_body(
     lines.append('iif lo accept comment "loopback"')
     # Web UI (HTTP + HTTPS) — #285 Phase 6. Open by default; source-scoped
     # when web_ui_allowed_cidrs is set (the base /etc/nftables.conf no longer
-    # opens 80/443, so this drop-in is authoritative). SSH/22 above stays the
-    # un-removable escape hatch, so a bad Web-UI scope is never a brick.
+    # opens 80/443, so this drop-in is authoritative). SSH/22 above is the
+    # escape hatch that keeps a bad Web-UI scope recoverable — open by
+    # default, and only scoped when the operator turns on ``ssh_lockdown``
+    # (#1009), which is a separate, deliberate act with its own guards.
     if web_ui_allowed_cidrs:
         web_v4, web_v6 = _split_families(list(web_ui_allowed_cidrs))
         _emit_family_rule(lines, web_v4, web_v6, "tcp dport { 80, 443 } accept", "web-ui")

--- a/backend/app/services/appliance/firewall.py
+++ b/backend/app/services/appliance/firewall.py
@@ -129,6 +129,7 @@ def compile_firewall_body(
     cp_member_count: int = 1,
     vip_configured: bool = False,
     web_ui_allowed_cidrs: list[Any] | None = None,
+    ssh_scope_cidrs: list[Any] | None = None,
 ) -> str:
     """Byte-identical port of ``firewall_renderer.render_drop_in`` — returns
     just the drop-in body string (the supervisor wraps it in a
@@ -162,9 +163,33 @@ def compile_firewall_body(
     # say the same thing); clearing a scope restores it.
     webui_action = "retire" if web_ui_allowed_cidrs else "keep"
     lines.append(f"# spatium-webui: {webui_action}")
+    # #1009 — host-runner directive for the baked SSH sentinel
+    # (00-spatium-ssh.nft), which opens port 22 unconditionally from first
+    # boot. Same shape as the Web-UI sentinel above and for the same
+    # reason: it sorts EARLIER in the include glob than the scoped rule
+    # spatiumddi-ssh-reload renders, and nftables accepts on first match,
+    # so the operator's allowlist was dead code behind it.
+    #
+    # Retired only under ``ssh_lockdown`` (services.appliance.ssh.
+    # effective_ssh_scope resolves the flag; an empty scope here means it
+    # is off). That floor is what docs/design/FLEET_FIREWALL.md §6.1 calls
+    # the irreducible recovery channel, so removing it is an explicit
+    # operator decision, never a side effect of typing a CIDR.
+    ssh_action = "retire" if ssh_scope_cidrs else "keep"
+    lines.append(f"# spatium-ssh: {ssh_action}")
     lines.append("")
     lines.append("# ── Management (always open) ────────────────────────────────")
-    lines.append('tcp dport 22 accept comment "ssh"')
+    # SSH — the management floor. Unconditional unless the operator has
+    # turned on lockdown, in which case it is source-scoped to the same
+    # CIDRs the sentinel directive above retires the baked floor for.
+    # BOTH have to move together: this line sits AFTER 50-spatium-ssh.nft
+    # in the include glob, so leaving it unconditional would let every
+    # packet the scoped rule declined fall straight through to it (#1009).
+    if ssh_scope_cidrs:
+        ssh_v4, ssh_v6 = _split_families(list(ssh_scope_cidrs))
+        _emit_family_rule(lines, ssh_v4, ssh_v6, "tcp dport 22 accept", "ssh")
+    else:
+        lines.append('tcp dport 22 accept comment "ssh"')
     lines.append('icmp type echo-request accept comment "icmpv4 ping"')
     lines.append('icmpv6 type echo-request accept comment "icmpv6 ping"')
     lines.append('iif lo accept comment "loopback"')
@@ -279,6 +304,7 @@ async def firewall_bundle(
     firewall_enabled: bool,
     appliance_id: Any = None,
     web_ui_allowed_cidrs: list[Any] | None = None,
+    ssh_scope_cidrs: list[Any] | None = None,
     firewall_logging_enabled: bool = False,
 ) -> dict[str, Any]:
     """The ``firewall_settings`` block shipped on the supervisor heartbeat.
@@ -316,6 +342,7 @@ async def firewall_bundle(
         policy_set=policy_set,
         appliance_policy=appliance_policy,
         web_ui_allowed_cidrs=web_ui_allowed_cidrs,
+        ssh_scope_cidrs=ssh_scope_cidrs,
     )
     if firewall_logging_enabled:
         # #404 — a rate-limited catch-all log just before the chain's

--- a/backend/app/services/appliance/firewall_lint.py
+++ b/backend/app/services/appliance/firewall_lint.py
@@ -8,7 +8,9 @@ findings two ways:
 
 * ``error`` — genuinely dangerous patterns that get a hard 422 in the write
   path: nft-injection / shell metacharacters (``; ` $ \\ | &``), unbalanced
-  braces, and any rule that DROPs port 22 (the un-removable mgmt floor).
+  braces, and any rule that DROPs port 22 (the mgmt floor, which a rule
+  may never remove — #1009's ``ssh_lockdown`` scopes it as a SETTING,
+  which is a different surface with its own guards).
 * ``warning`` — grammar the linter doesn't love but ``nft -c -f`` (the
   ultimate authority on the host) may still accept: an unscoped rule (no
   ``ip/ip6 saddr``), a missing action, ``dport`` on icmp, a family-mismatched
@@ -157,7 +159,9 @@ def _lint_line(i: int, line: str, findings: list[LintFinding]) -> None:
     if "drop" in toks and 22 in ports:
         findings.append(
             LintFinding(
-                i, "error", "must not drop port 22 (ssh) — the management floor is un-removable"
+                i,
+                "error",
+                "must not drop port 22 (ssh) — the management floor is not " "removable by a rule",
             )
         )
 

--- a/backend/app/services/appliance/firewall_merge.py
+++ b/backend/app/services/appliance/firewall_merge.py
@@ -96,9 +96,12 @@ class PolicySet:
 
 
 # ── The mgmt floor — code, not data ──────────────────────────────────
-# Always-open management rules, emitted first + un-removable (the policy
-# surface cannot author these away; the no-drop-22 CHECK is the DB twin).
-# Byte-identical to firewall.compile_firewall_body lines 150-153.
+# Management rules, emitted first and not authorable away by the policy
+# surface (the no-drop-22 CHECK is the DB twin). Always OPEN, except that
+# #1009 lets an operator source-scope the SSH line via ``ssh_lockdown`` —
+# which is a setting, not a rule, and is why the first entry is emitted
+# separately by the caller rather than taken from this tuple wholesale.
+# Byte-identical to firewall.compile_firewall_body.
 _MGMT_FLOOR: tuple[str, ...] = (
     'tcp dport 22 accept comment "ssh"',
     'icmp type echo-request accept comment "icmpv4 ping"',

--- a/backend/app/services/appliance/firewall_merge.py
+++ b/backend/app/services/appliance/firewall_merge.py
@@ -503,6 +503,7 @@ def compile_firewall_from_policies(
     mgmt_cidrs: list[Any] | None = None,
     vip_cidrs: list[Any] | None = None,
     web_ui_allowed_cidrs: list[Any] | None = None,
+    ssh_scope_cidrs: list[Any] | None = None,
 ) -> str:
     """Render the drop-in body from the policy model. Fed ``builtin_policy_set``
     + no operator overlay, this is byte-identical to ``compile_firewall_body``.
@@ -539,9 +540,34 @@ def compile_firewall_from_policies(
     # Byte-identical to compile_firewall_body + render_drop_in.
     webui_action = "retire" if web_ui_allowed_cidrs else "keep"
     lines.append(f"# spatium-webui: {webui_action}")
+    # #1009 — host-runner directive for the baked SSH sentinel
+    # (00-spatium-ssh.nft), which opens port 22 unconditionally from first
+    # boot. Same shape as the Web-UI sentinel above and for the same
+    # reason: it sorts EARLIER in the include glob than the scoped rule
+    # spatiumddi-ssh-reload renders, and nftables accepts on first match,
+    # so the operator's allowlist was dead code behind it.
+    #
+    # Retired only under ``ssh_lockdown`` (services.appliance.ssh.
+    # effective_ssh_scope resolves the flag; an empty scope here means it
+    # is off). That floor is what docs/design/FLEET_FIREWALL.md §6.1 calls
+    # the irreducible recovery channel, so removing it is an explicit
+    # operator decision, never a side effect of typing a CIDR.
+    ssh_action = "retire" if ssh_scope_cidrs else "keep"
+    lines.append(f"# spatium-ssh: {ssh_action}")
     lines.append("")
     lines.append("# ── Management (always open) ────────────────────────────────")
-    lines.extend(_MGMT_FLOOR)
+    # SSH — the management floor. Unconditional unless the operator has
+    # turned on lockdown, in which case it is source-scoped to the same
+    # CIDRs the sentinel directive above retires the baked floor for.
+    # BOTH have to move together: this line sits AFTER 50-spatium-ssh.nft
+    # in the include glob, so leaving it unconditional would let every
+    # packet the scoped rule declined fall straight through to it (#1009).
+    if ssh_scope_cidrs:
+        ssh_v4, ssh_v6 = _split_families(list(ssh_scope_cidrs))
+        _emit_family_rule(lines, ssh_v4, ssh_v6, "tcp dport 22 accept", "ssh")
+    else:
+        lines.append(_MGMT_FLOOR[0])
+    lines.extend(_MGMT_FLOOR[1:])
     # Web UI (HTTP + HTTPS) — #285 Phase 6. Open by default; source-scoped when
     # web_ui_allowed_cidrs is set (the base /etc/nftables.conf no longer opens
     # 80/443). Byte-identical to compile_firewall_body + render_drop_in.

--- a/backend/app/services/appliance/ssh.py
+++ b/backend/app/services/appliance/ssh.py
@@ -23,13 +23,25 @@ Design notes:
   keys would lock the operator out, so :func:`validate_lockout_safe`
   refuses that combination — enforced both on the settings PUT and again
   defensively on the host runner.
-* ``Port`` may be changed, but the firewall renderer hardcodes an
-  un-removable ``tcp dport 22 accept`` floor (``firewall.py`` /
-  ``firewall_merge.py``) so even a bad port change leaves port 22 open as
-  the escape hatch. The host nft drop-in opens the configured port,
+* ``Port`` may be changed, but a management floor opens ``tcp dport 22``
+  regardless — baked at ``/etc/nftables.d/00-spatium-ssh.nft`` and emitted
+  again by the firewall renderers (``firewall.py`` / ``firewall_merge.py``
+  / the supervisor's) — so even a bad port change leaves 22 open as the
+  escape hatch. The host nft drop-in opens the configured port,
   SOURCE-SCOPED to ``ssh_allowed_source_networks`` (sshd has no native
   source-CIDR filter — this DIVERGES from the SNMP / NTP drop-ins which
-  open unscoped). Empty allowed-list = open the port unconditionally.
+  open unscoped).
+* ``ssh_lockdown`` (#1009) is what turns that scope into enforcement, and
+  :func:`effective_ssh_scope` is the ONE place that resolves it. nftables
+  is first-match-wins and the floor sorts first, so until the floor is
+  retired the scoped rule is dead code on port 22 — the allowlist rendered
+  perfectly and restricted nothing, while the UI, the applied sidecar and
+  the nft dry-run all reported success. Retiring the floor removes what
+  ``docs/design/FLEET_FIREWALL.md`` §6.1 calls the irreducible recovery
+  channel, so it is an explicit switch rather than a consequence of typing
+  a CIDR. With it off the effective scope is EMPTY, which every consumer
+  already reads as "open unconditionally" — so an older host runner that
+  has never heard of lockdown does the safe thing by construction.
 * ``ssh_bundle`` returns a STABLE dict shape even when "disabled"
   (here "disabled" = the default state: password auth on, no managed
   keys) so every hash-compare caller (DHCP-agent ETag mix, supervisor
@@ -239,6 +251,26 @@ def _valid_key_count(settings: PlatformSettings) -> int:
     )
 
 
+def effective_ssh_scope(settings: PlatformSettings) -> list[str]:
+    """The source CIDRs the host firewall should actually enforce.
+
+    ``ssh_allowed_source_networks`` is what the operator typed;
+    ``ssh_lockdown`` is whether it is in force. Everything downstream — the
+    ssh bundle the host runner renders ``50-spatium-ssh.nft`` from, and the
+    three firewall renderers that decide whether to retire the port-22
+    floor — reads THIS, so the two halves can never disagree about whether
+    SSH is restricted (#1009).
+
+    Empty means "open unconditionally", which is exactly what every existing
+    consumer already does with an empty list — so lockdown-off is
+    indistinguishable from never having configured a scope, including to an
+    older host runner that predates the flag.
+    """
+    if not settings.ssh_lockdown:
+        return []
+    return list(settings.ssh_allowed_source_networks or [])
+
+
 def ssh_bundle(settings: PlatformSettings) -> dict[str, Any]:
     """Build the ``ssh_settings`` block shipped to agents + supervisor.
 
@@ -256,8 +288,9 @@ def ssh_bundle(settings: PlatformSettings) -> dict[str, Any]:
         can write).
       * ``sshd_conf`` — the rendered sshd drop-in body.
       * ``ssh_port`` — int, for the host nft drop-in.
-      * ``allowed_source_networks`` — list[str] CIDRs the host nft
-        drop-in source-scopes the port to (empty = open unconditionally).
+      * ``allowed_source_networks`` — the EFFECTIVE scope from
+        :func:`effective_ssh_scope`, i.e. empty unless ``ssh_lockdown``
+        is on (empty = open unconditionally).
       * ``password_auth`` — bool, surfaced so the runner can apply the
         lockout guard defensively.
       * ``key_count`` — count of well-formed keys the runner is expected
@@ -277,6 +310,10 @@ def ssh_bundle(settings: PlatformSettings) -> dict[str, Any]:
         and key_count == 0
         and int(settings.ssh_port or 22) == 22
         and not bool(settings.ssh_allow_root_login)
+        # The typed list, not the effective scope: a configured-but-not-
+        # enforced allowlist is still operator config, and collapsing it
+        # into "default" here would tear the drop-in down and lose the
+        # port/keys state the runner is managing.
         and not list(settings.ssh_allowed_source_networks or [])
     )
     enabled = not is_default
@@ -288,7 +325,7 @@ def ssh_bundle(settings: PlatformSettings) -> dict[str, Any]:
         "authorized_keys": authorized_keys,
         "sshd_conf": sshd_conf,
         "ssh_port": int(settings.ssh_port or 22),
-        "allowed_source_networks": list(settings.ssh_allowed_source_networks or []),
+        "allowed_source_networks": effective_ssh_scope(settings),
         "password_auth": password_auth,
         "key_count": key_count,
     }

--- a/backend/app/services/appliance/ssh.py
+++ b/backend/app/services/appliance/ssh.py
@@ -281,7 +281,10 @@ def ssh_bundle(settings: PlatformSettings) -> dict[str, Any]:
       * ``enabled`` — True unless this is the pristine default state
         (password auth on + no managed keys). The host runner uses this
         to decide between applying the drop-in and tearing it back down.
-      * ``config_hash`` — sha256 over ``authorized_keys + sshd_conf`` so
+      * ``config_hash`` — sha256 over every input the host runner renders
+        from: the two file bodies PLUS the ssh port and the effective source
+        scope (see below — the scope reaches neither body, and omitting it
+        meant a lockdown toggle never re-fired the runner). Hashed so
         any change to either body shifts the agent/supervisor ETag.
       * ``authorized_keys`` — the rendered authorized_keys body (always
         rendered so a disable still ships an empty-keys body the runner
@@ -318,7 +321,38 @@ def ssh_bundle(settings: PlatformSettings) -> dict[str, Any]:
     )
     enabled = not is_default
     body = authorized_keys + sshd_conf
-    config_hash = hashlib.sha256(body.encode("utf-8")).hexdigest() if enabled else ""
+    # The hash is the ONLY thing that re-fires the host runner
+    # (``_fire_host_config`` short-circuits on an unchanged one), so it has to
+    # cover every input the runner renders from — not just the two file bodies
+    # it happens to be built out of.
+    #
+    # ``allowed_source_networks`` appears in NEITHER body: it is an nftables
+    # scope, not an sshd directive. Before #1009 that was harmless, because
+    # the drop-in it feeds was dead code on port 22 anyway. It is not harmless
+    # now: toggling ``ssh_lockdown`` changes the effective scope and nothing
+    # else, so the hash would be unchanged, the trigger would not fire, and
+    # ``50-spatium-ssh.nft`` would keep its UNCONDITIONAL accept — which sorts
+    # ahead of the scoped management line — while the firewall plane had
+    # already retired the port-22 floor. SSH open from anywhere, every surface
+    # reporting it restricted: the exact #1009 bug, re-created one layer down.
+    #
+    # The port is folded in defensively. It does reach ``sshd_conf`` today, so
+    # this is belt-and-braces rather than a fix — but it is the other value
+    # the nft drop-in renders from, and the coupling that makes it safe to
+    # omit is not one this function states anywhere.
+    #
+    # Consequence, and it is intended: the formula changed, so every install
+    # sees one hash change on upgrade and re-fires the trigger once. The apply
+    # is idempotent and the runner compares byte-for-byte, so the cost is one
+    # no-op reload.
+    hash_input = "\n".join(
+        [
+            body,
+            f"port={int(settings.ssh_port or 22)}",
+            "scope=" + ",".join(effective_ssh_scope(settings)),
+        ]
+    )
+    config_hash = hashlib.sha256(hash_input.encode("utf-8")).hexdigest() if enabled else ""
     return {
         "enabled": enabled,
         "config_hash": config_hash,

--- a/backend/app/services/appliance/ssh.py
+++ b/backend/app/services/appliance/ssh.py
@@ -345,6 +345,15 @@ def ssh_bundle(settings: PlatformSettings) -> dict[str, Any]:
     # sees one hash change on upgrade and re-fires the trigger once. The apply
     # is idempotent and the runner compares byte-for-byte, so the cost is one
     # no-op reload.
+    #
+    # CodeQL flags the sha256 below as ``py/weak-sensitive-data-hashing``, and
+    # it is a false positive every time (dismissed as alerts 60 and 97 — the
+    # rule re-raises whenever this line moves). Nothing hashed here is a
+    # secret: ``authorized_keys`` holds SSH PUBLIC keys, and the "password"
+    # the taint tracker matches is the literal ``PasswordAuthentication
+    # yes|no`` boolean ``render_sshd_config`` writes into the drop-in. This is
+    # a change-detection fingerprint, not password storage — a slow KDF here
+    # would make the heartbeat expensive and buy nothing.
     hash_input = "\n".join(
         [
             body,

--- a/backend/tests/test_appliance_firewall_render.py
+++ b/backend/tests/test_appliance_firewall_render.py
@@ -95,6 +95,7 @@ def _call(fn, case: dict):
         cp_member_count=case.get("cp_member_count", 1),
         vip_configured=case.get("vip_configured", False),
         web_ui_allowed_cidrs=case.get("web_ui_allowed_cidrs"),
+        ssh_scope_cidrs=case.get("ssh_scope_cidrs"),
     )
 
 
@@ -108,6 +109,7 @@ def _call_merge(case: dict) -> str:
         vip_configured=case.get("vip_configured", False),
         policy_set=builtin_policy_set(),
         web_ui_allowed_cidrs=case.get("web_ui_allowed_cidrs"),
+        ssh_scope_cidrs=case.get("ssh_scope_cidrs"),
     )
 
 
@@ -290,6 +292,96 @@ def test_webui_sentinel_directive_all_renderers() -> None:
         for body in bodies:
             assert f"# spatium-webui: {expected}" in body
             assert f"# spatium-webui: {other}" not in body
+
+
+def test_ssh_sentinel_directive_all_renderers() -> None:
+    """The ``# spatium-ssh:`` host-runner directive, in every renderer (#1009).
+
+    The baked ``00-spatium-ssh.nft`` opens port 22 from first boot — the
+    management escape hatch ``docs/design/FLEET_FIREWALL.md`` §6.1 calls the
+    irreducible recovery channel. It sorts EARLIER in the include glob than
+    the scoped rule ``spatiumddi-ssh-reload`` renders, and nftables accepts on
+    first match, so the operator's allowlist was dead code behind it.
+
+    Retire it exactly when lockdown is on — which is what a non-empty
+    ``ssh_scope_cidrs`` means, since ``effective_ssh_scope`` resolves the flag
+    server-side. Keep is the default, so an install that never opts in renders
+    byte-for-byte as before.
+    """
+    sup = _load_supervisor_renderer()
+
+    off = {"role_assignment": {"roles": []}}
+    on = {"role_assignment": {"roles": []}, "ssh_scope_cidrs": ["192.168.0.0/24"]}
+
+    for case, expected in ((off, "keep"), (on, "retire")):
+        other = "retire" if expected == "keep" else "keep"
+        bodies = [_call(compile_firewall_body, case), _call_merge(case)]
+        if sup is not None:
+            bodies.append(_call(sup.render_drop_in, case).body)
+        for body in bodies:
+            assert f"# spatium-ssh: {expected}" in body
+            assert f"# spatium-ssh: {other}" not in body
+
+
+def test_ssh_management_line_is_scoped_under_lockdown_all_renderers() -> None:
+    """Retiring the sentinel alone would not be enough.
+
+    Every renderer also emits an SSH accept in ``spatium-role.nft``, which
+    sorts AFTER ``50-spatium-ssh.nft`` in the glob — so a packet the scoped
+    rule declined would fall straight through to it and the restriction would
+    still do nothing. The two have to move together.
+    """
+    sup = _load_supervisor_renderer()
+    case = {"role_assignment": {"roles": []}, "ssh_scope_cidrs": ["10.0.0.0/8"]}
+
+    bodies = [_call(compile_firewall_body, case), _call_merge(case)]
+    if sup is not None:
+        bodies.append(_call(sup.render_drop_in, case).body)
+    for body in bodies:
+        ssh_rules = [
+            ln for ln in body.splitlines() if "dport 22" in ln and not ln.strip().startswith("#")
+        ]
+        assert ssh_rules, "no SSH accept at all — the floor must not vanish"
+        assert all("saddr" in ln for ln in ssh_rules), ssh_rules
+        assert any("10.0.0.0/8" in ln for ln in ssh_rules), ssh_rules
+
+
+def test_the_ssh_floor_is_unconditional_when_lockdown_is_off() -> None:
+    """The default, and the reason nothing tightens on upgrade."""
+    sup = _load_supervisor_renderer()
+    case = {"role_assignment": {"roles": []}}
+
+    bodies = [_call(compile_firewall_body, case), _call_merge(case)]
+    if sup is not None:
+        bodies.append(_call(sup.render_drop_in, case).body)
+    for body in bodies:
+        assert 'tcp dport 22 accept comment "ssh"' in body
+
+
+def test_a_configured_allowlist_alone_does_not_retire_the_floor() -> None:
+    """``ssh_scope_cidrs`` IS the resolved answer, not the typed list.
+
+    ``effective_ssh_scope`` returns [] while lockdown is off, so an operator
+    who configured an allowlist back when it was inert does not have their
+    SSH tightened by an upgrade they never asked for. Asserted here at the
+    renderer boundary because that is where a future caller could pass the
+    raw column by mistake and change every appliance's posture silently.
+    """
+    from app.models.settings import PlatformSettings
+    from app.services.appliance.ssh import effective_ssh_scope
+
+    row = PlatformSettings(ssh_allowed_source_networks=["10.0.0.0/8"], ssh_lockdown=False)
+    assert effective_ssh_scope(row) == []
+
+    body = _call(
+        compile_firewall_body,
+        {
+            "role_assignment": {"roles": []},
+            "ssh_scope_cidrs": effective_ssh_scope(row),
+        },
+    )
+    assert "# spatium-ssh: keep" in body
+    assert 'tcp dport 22 accept comment "ssh"' in body
 
 
 # ── #993 — kubelet 10250 reachable from inside the cluster ──────────────

--- a/backend/tests/test_settings_ssh.py
+++ b/backend/tests/test_settings_ssh.py
@@ -222,3 +222,163 @@ async def test_denied_without_write_settings(db_session: AsyncSession, client: A
         json={"ssh_allow_root_login": True},
     )
     assert resp.status_code == 403, resp.text
+
+
+# ── #1009 — ssh_lockdown, the switch that makes the allowlist enforcement ──
+
+
+@pytest.mark.asyncio
+async def test_lockdown_defaults_off_and_leaves_the_scope_inert(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """The reason nothing tightens on upgrade.
+
+    An operator who configured an allowlist while it was inert (which it was,
+    on the default port, from #157 until #1009) must not have their SSH
+    restricted by an upgrade they never asked for.
+    """
+    from app.services.appliance.ssh import effective_ssh_scope
+
+    _, token = await _make_user(db_session, username="sshlock1", superadmin=True)
+    await db_session.commit()
+    resp = await client.put(
+        "/api/v1/settings",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"ssh_allowed_source_networks": ["10.0.0.0/8"]},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ssh_lockdown"] is False
+
+    row = await db_session.get(PlatformSettings, 1)
+    await db_session.refresh(row)
+    assert list(row.ssh_allowed_source_networks) == ["10.0.0.0/8"]
+    # ...and the resolved scope, which is what every renderer consumes, is
+    # empty — so the port-22 floor stays and the rule stays unscoped.
+    assert effective_ssh_scope(row) == []
+
+
+@pytest.mark.asyncio
+async def test_lockdown_with_an_empty_list_is_refused(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """Not a restriction — a closed port, on every appliance at once.
+
+    ``docs/design/FLEET_FIREWALL.md`` §6.1 specified this same 422 for the
+    same combination under its ``firewall_mgmt_lockdown`` name.
+    """
+    _, token = await _make_user(db_session, username="sshlock2", superadmin=True)
+    await db_session.commit()
+    resp = await client.put(
+        "/api/v1/settings",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"ssh_lockdown": True},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "empty allowed-networks list" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_lockdown_from_outside_the_scope_needs_an_acknowledgement(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """The mistake an operator actually makes.
+
+    Advisory rather than a refusal — browsing the UI from one network and
+    SSHing from another is legitimate — but it must be acknowledged, because
+    the alternative is finding out at the next SSH attempt.
+    """
+    _, token = await _make_user(db_session, username="sshlock3", superadmin=True)
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}", "X-Real-IP": "203.0.113.9"}
+
+    resp = await client.put(
+        "/api/v1/settings",
+        headers=headers,
+        json={"ssh_lockdown": True, "ssh_allowed_source_networks": ["10.0.0.0/8"]},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "not inside the allowed networks" in resp.text
+
+    forced = await client.put(
+        "/api/v1/settings",
+        headers=headers,
+        json={
+            "ssh_lockdown": True,
+            "ssh_allowed_source_networks": ["10.0.0.0/8"],
+            "ssh_lockdown_force": True,
+        },
+    )
+    assert forced.status_code == 200, forced.text
+    assert forced.json()["ssh_lockdown"] is True
+
+
+@pytest.mark.asyncio
+async def test_lockdown_from_inside_the_scope_needs_no_acknowledgement(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    from app.services.appliance.ssh import effective_ssh_scope
+
+    _, token = await _make_user(db_session, username="sshlock4", superadmin=True)
+    await db_session.commit()
+    resp = await client.put(
+        "/api/v1/settings",
+        headers={"Authorization": f"Bearer {token}", "X-Real-IP": "10.1.2.3"},
+        json={"ssh_lockdown": True, "ssh_allowed_source_networks": ["10.0.0.0/8"]},
+    )
+    assert resp.status_code == 200, resp.text
+
+    row = await db_session.get(PlatformSettings, 1)
+    await db_session.refresh(row)
+    assert effective_ssh_scope(row) == ["10.0.0.0/8"]
+
+
+@pytest.mark.asyncio
+async def test_the_force_flag_is_never_written_as_a_column(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """It is an acknowledgement, and ``changes`` is both the write set and
+    the audit payload — so leaving it in would 500 on setattr and, worse,
+    record a field that does not exist."""
+    _, token = await _make_user(db_session, username="sshlock5", superadmin=True)
+    await db_session.commit()
+    resp = await client.put(
+        "/api/v1/settings",
+        headers={"Authorization": f"Bearer {token}", "X-Real-IP": "10.1.2.3"},
+        json={
+            "ssh_lockdown": True,
+            "ssh_allowed_source_networks": ["10.0.0.0/8"],
+            "ssh_lockdown_force": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert "ssh_lockdown_force" not in resp.json()
+    row = await db_session.get(PlatformSettings, 1)
+    assert not hasattr(row, "ssh_lockdown_force")
+
+
+@pytest.mark.asyncio
+async def test_turning_lockdown_off_again_is_always_allowed(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """The recovery path, and it must never need an acknowledgement.
+
+    An operator who has locked themselves out of SSH still has the Web UI
+    (scoped separately, by ``web_ui_allowed_cidrs``), and this is what they
+    reach for. Refusing it because their address is outside the scope they
+    are trying to REMOVE would be exactly backwards.
+    """
+    _, token = await _make_user(db_session, username="sshlock6", superadmin=True)
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}", "X-Real-IP": "203.0.113.9"}
+    await client.put(
+        "/api/v1/settings",
+        headers=headers,
+        json={
+            "ssh_lockdown": True,
+            "ssh_allowed_source_networks": ["10.0.0.0/8"],
+            "ssh_lockdown_force": True,
+        },
+    )
+    resp = await client.put("/api/v1/settings", headers=headers, json={"ssh_lockdown": False})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ssh_lockdown"] is False

--- a/backend/tests/test_settings_ssh.py
+++ b/backend/tests/test_settings_ssh.py
@@ -382,3 +382,116 @@ async def test_turning_lockdown_off_again_is_always_allowed(
     resp = await client.put("/api/v1/settings", headers=headers, json={"ssh_lockdown": False})
     assert resp.status_code == 200, resp.text
     assert resp.json()["ssh_lockdown"] is False
+
+
+@pytest.mark.asyncio
+async def test_toggling_lockdown_changes_the_bundle_hash() -> None:
+    """The hash is the ONLY thing that re-fires the host runner.
+
+    ``_fire_host_config`` short-circuits on an unchanged ``config_hash``, and
+    the scope appears in neither of the two bodies the hash used to be built
+    from (it is an nftables scope, not an sshd directive). So toggling
+    lockdown would change the effective scope and nothing else: no trigger,
+    ``50-spatium-ssh.nft`` keeps its UNCONDITIONAL accept — which sorts ahead
+    of the scoped management line — while the firewall plane has already
+    retired the port-22 floor. SSH open from anywhere, every surface
+    reporting it restricted: the #1009 bug, re-created one layer down.
+    """
+    from app.services.appliance.ssh import ssh_bundle
+
+    off = PlatformSettings(id=1, ssh_allowed_source_networks=["10.0.0.0/8"], ssh_lockdown=False)
+    on = PlatformSettings(id=1, ssh_allowed_source_networks=["10.0.0.0/8"], ssh_lockdown=True)
+    b_off, b_on = ssh_bundle(off), ssh_bundle(on)
+
+    assert b_off["config_hash"] != b_on["config_hash"]
+    # ...and the payload the runner renders from moved with it.
+    assert b_off["allowed_source_networks"] == []
+    assert b_on["allowed_source_networks"] == ["10.0.0.0/8"]
+
+
+@pytest.mark.asyncio
+async def test_narrowing_the_scope_changes_the_bundle_hash() -> None:
+    """Same trap, one step along: editing the CIDRs under an already-on
+    lockdown must re-fire, or the host keeps enforcing the OLD scope."""
+    from app.services.appliance.ssh import ssh_bundle
+
+    wide = PlatformSettings(id=1, ssh_allowed_source_networks=["10.0.0.0/8"], ssh_lockdown=True)
+    narrow = PlatformSettings(id=1, ssh_allowed_source_networks=["10.1.0.0/16"], ssh_lockdown=True)
+    assert ssh_bundle(wide)["config_hash"] != ssh_bundle(narrow)["config_hash"]
+
+
+@pytest.mark.asyncio
+async def test_the_hash_is_stable_for_unchanged_settings() -> None:
+    """Deterministic, or every heartbeat re-fires the runner forever."""
+    from app.services.appliance.ssh import ssh_bundle
+
+    def row() -> PlatformSettings:
+        return PlatformSettings(
+            id=1,
+            ssh_allowed_source_networks=["10.0.0.0/8"],
+            ssh_lockdown=True,
+            ssh_port=2222,
+        )
+
+    assert ssh_bundle(row())["config_hash"] == ssh_bundle(row())["config_hash"]
+
+
+@pytest.mark.asyncio
+async def test_an_unrelated_ssh_save_under_lockdown_needs_no_acknowledgement(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """The pre-flight gates on the TRANSITION, not the resulting state.
+
+    Keyed on the latter it fires on every ``ssh_*`` save made while lockdown
+    is already on — adding a key, changing the port — demanding an
+    acknowledgement for a change that alters nothing about who can reach the
+    box. An operator asked to accept a lockout warning for an unrelated edit
+    learns to tick it without reading.
+    """
+    _, token = await _make_user(db_session, username="sshlock7", superadmin=True)
+    await db_session.commit()
+    outside = {"Authorization": f"Bearer {token}", "X-Real-IP": "203.0.113.9"}
+
+    setup = await client.put(
+        "/api/v1/settings",
+        headers=outside,
+        json={
+            "ssh_lockdown": True,
+            "ssh_allowed_source_networks": ["10.0.0.0/8"],
+            "ssh_lockdown_force": True,
+        },
+    )
+    assert setup.status_code == 200, setup.text
+
+    # An edit that touches neither the flag nor the scope, still from outside.
+    resp = await client.put("/api/v1/settings", headers=outside, json={"ssh_port": 2222})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ssh_port"] == 2222
+    assert resp.json()["ssh_lockdown"] is True
+
+
+@pytest.mark.asyncio
+async def test_narrowing_the_scope_under_lockdown_does_need_one(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """...but a scope change is a new lockout risk and must be re-checked,
+    even though lockdown was already on."""
+    _, token = await _make_user(db_session, username="sshlock8", superadmin=True)
+    await db_session.commit()
+    inside = {"Authorization": f"Bearer {token}", "X-Real-IP": "10.9.9.9"}
+
+    setup = await client.put(
+        "/api/v1/settings",
+        headers=inside,
+        json={"ssh_lockdown": True, "ssh_allowed_source_networks": ["10.0.0.0/8"]},
+    )
+    assert setup.status_code == 200, setup.text
+
+    # Narrow it to a range that no longer contains the caller.
+    resp = await client.put(
+        "/api/v1/settings",
+        headers=inside,
+        json={"ssh_allowed_source_networks": ["10.1.0.0/16"]},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "not inside the allowed networks" in resp.text

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -849,7 +849,10 @@ is `explode → deny-wins → source-union`; `source_kind` carries derived scope
 resolved per-node at render time, so promote/demote re-renders automatically.
 Seeded **builtin** role policies reproduce the Phase-2 hardcoded renderer
 byte-for-byte; operators tune their rules (the floor — ssh/22, ICMP, loopback —
-is un-removable, and no rule may `drop` 22).
+cannot be authored away by a rule, and no rule may `drop` 22). The ssh/22 half
+of that floor *can* be source-scoped, but only by the separate `ssh_lockdown`
+setting ([#1009](https://github.com/spatiumddi/spatiumddi/issues/1009)) — a
+deliberate act with its own guards, never a consequence of a firewall rule.
 
 **Fleet → Firewall tab.** A **left sub-nav** (#404 — was top sub-tabs) over
 five sections: **Policies** (fleet/role/appliance list + rule editor, with the
@@ -931,9 +934,16 @@ Unscoped, both rules say the same thing and the sentinel simply stays.
 `PUT /appliance/firewall/web-ui-access`
 carries an **anti-lockout guard**: a non-empty set that doesn't cover the
 operator's current source IP is rejected 422 unless `override_lockout=true`
-(the UI surfaces an "Add my IP" button + the override checkbox). SSH on :22
-stays in the un-removable base floor, so a bad scope is always recoverable from
-the console.
+(the UI surfaces an "Add my IP" button + the override checkbox). SSH on :22 is
+open by default — a baked sentinel, `/etc/nftables.d/00-spatium-ssh.nft` — so a
+bad Web-UI scope is recoverable over SSH, and from the console regardless.
+
+Since [#1009](https://github.com/spatiumddi/spatiumddi/issues/1009) that SSH
+half is a default-on floor rather than a guarantee: **the two lockdowns
+compose.** An operator who scopes the Web UI *and* turns on `ssh_lockdown` with
+a scope that excludes them has closed both doors, and the console is what
+remains. Neither setting can see the other, so neither warns about the
+combination — each guards only its own.
 
 ---
 

--- a/docs/design/FLEET_FIREWALL.md
+++ b/docs/design/FLEET_FIREWALL.md
@@ -394,6 +394,25 @@ A new top-level **Firewall** surface under the Fleet sidebar **Services** group 
 
 ## 6. Safety rails + IPv6 + injection-safety + audit/compliance
 
+> **Shipped, partially, as [#1009](https://github.com/spatiumddi/spatiumddi/issues/1009) — and one sentence below is wrong.**
+> The SSH half of this section is now real, under the name `ssh_lockdown`
+> rather than `firewall_mgmt_lockdown`, reusing the existing
+> `ssh_allowed_source_networks` (#157) as its CIDR source rather than adding
+> `firewall_mgmt_cidrs`. The floor moved from `/etc/nftables.conf` to the
+> retireable sentinel `/etc/nftables.d/00-spatium-ssh.nft`, and all three
+> renderers stamp `# spatium-ssh: retire|keep`.
+>
+> **"The base-conf floor stays LAN-wide regardless" cannot be true at the
+> same time as line 192's `OR ip saddr {mgmt} when firewall_mgmt_lockdown`.**
+> nftables is first-match-wins and the base conf is read before the include
+> glob, so a floor that stays LAN-wide makes the scoped rule dead code — which
+> is exactly the bug #1009 was filed for, designed in. The floor is therefore
+> *retireable* rather than *un-removable*: present by default (so §6.1's
+> guarantee holds for every install that has not opted in), retired only when
+> the operator turns lockdown on. The belt-and-braces of line 266 survives in
+> the form that matters — a node whose drop-in never rendered still has the
+> baked sentinel.
+
 **6.1 Un-removable management floor.** SSH/22 + ICMP v4/v6 + loopback are emitted **first**, outside any operator-controllable block, AND baked in the base conf (`ssh-floor`). No policy, no `firewall_extra`, no `default_action=drop` can remove them. `compile_firewall` **asserts** the body contains an SSH accept and refuses to ship a body lacking it (returns last-good / floor-only + logs). The write-time lint additionally **rejects any rule whose resolved port atoms include 22 with `action=drop`** so an operator can't even author a self-lockout. `firewall_mgmt_lockdown` is honoured only when `firewall_mgmt_cidrs` is non-empty AND yields a non-empty `ip saddr {…} tcp dport 22 accept`; the backend 422s `lockdown=true` with empty `mgmt_cidrs`. The base-conf floor stays LAN-wide regardless — the irreducible recovery channel.
 
 **6.2 IPv6 (three confirmed bugs, fixed at the model layer).** (a) *Lockout-via-validation-gap*: aliases/rules family-split at rest (`v4_members`/`v6_members`, `family`); the renderer routes by family (`ip saddr` vs `ip6 saddr`) so a v6 entry can never leak into a v4 set and wipe the drop-in; the API 422s a v6 CIDR in a v4-only context. (b) *node_ip family*: `_cluster_peer_cidrs` is family-split so a v6 InternalIP yields `/128` (not a garbage `/32`); collection reports **all** InternalIPs as `node_ips: list` (k3s lists both families on dual-stack) so the v6 peer set is derived from a real v6 address. The compiler emits `ip6 saddr {…/128}` **only** when the v6 peer set is non-empty, and a **preflight check flags an asymmetric v6 peer set** (some CP nodes have a v6 InternalIP, the firewall set doesn't) before allowing the base-conf close — preventing a silent v6 etcd hole or v6 quorum outage on a dual-stack cluster. (c) *Silent bypass*: the base conf's family-agnostic k3s accept is gone (§3.2); the floor keeps `icmpv6` so v6 ND/ICMP is never stranded.

--- a/frontend/src/components/SSHSection.test.tsx
+++ b/frontend/src/components/SSHSection.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * SSH lockdown — the wiring around a lockout-capable switch (#1009).
+ *
+ * `ssh_lockdown` retires the appliance's always-open port-22 floor, so the
+ * three things pinned here are the ones whose failure is invisible: an
+ * acknowledgement path that can never open, a toggle that cannot be turned
+ * off, and a forced save that latches. `tsc` is happy with all three, and so
+ * is a reading of the diff — each was found by review, not by the compiler.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { PlatformSettings } from "@/lib/api";
+
+const update = vi.fn();
+vi.mock("@/lib/api", async () => {
+  // formatApiError is the thing under test in one case, so use the REAL one:
+  // a stub would pass whatever err.message the component read and hide
+  // exactly the defect this file exists for.
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    settingsApi: { update: (p: unknown) => update(p) },
+  };
+});
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ setQueryData: vi.fn() }),
+  useMutation: ({ mutationFn, onSuccess, onError }: never) => {
+    const fn = mutationFn as (p: unknown) => Promise<unknown>;
+    return {
+      isPending: false,
+      mutate: (p: unknown) =>
+        fn(p).then(
+          (r) => (onSuccess as ((r: unknown) => void) | undefined)?.(r),
+          (e) => (onError as ((e: unknown) => void) | undefined)?.(e),
+        ),
+    };
+  },
+}));
+
+const { SSHSection } = await import("./SSHSection");
+
+/** The shape an AxiosError actually has: `message` is the generic status
+ *  line, and the server's sentence lives under `response.data.detail`. */
+function axios422(detail: string) {
+  return Object.assign(new Error("Request failed with status code 422"), {
+    isAxiosError: true,
+    response: { status: 422, data: { detail } },
+  });
+}
+
+const LOCKOUT_DETAIL =
+  "Your own address is not inside the allowed networks, so enforcing this " +
+  "restriction may close your SSH access to every appliance. Re-send with " +
+  "ssh_lockdown_force to proceed.";
+
+function values(over: Partial<PlatformSettings> = {}): PlatformSettings {
+  return {
+    ssh_authorized_keys: [],
+    ssh_password_auth_enabled: true,
+    ssh_allow_root_login: false,
+    ssh_port: 22,
+    ssh_allowed_source_networks: [],
+    ssh_lockdown: false,
+    ...over,
+  } as PlatformSettings;
+}
+
+function setup(over: Partial<PlatformSettings> = {}) {
+  render(
+    <SSHSection
+      values={values(over)}
+      isSuperadmin
+      applianceMode
+      inputCls="input"
+    />,
+  );
+  // Toggle renders a role="switch" <button> with aria-checked — not an
+  // <input>, so `.checked` and getByRole("checkbox") both miss it.
+  const enforce = screen.getByRole("switch", {
+    name: /enforce source restriction/i,
+  }) as HTMLButtonElement;
+  return {
+    enforce,
+    isOn: () => enforce.getAttribute("aria-checked") === "true",
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("the enforcement toggle", () => {
+  it("cannot be turned on without a network", () => {
+    const { enforce, isOn } = setup({ ssh_allowed_source_networks: [] });
+    expect(enforce.disabled).toBe(true);
+    expect(isOn()).toBe(false);
+  });
+
+  it("can always be turned OFF, even with no networks left", () => {
+    // Gating both directions on the list stranded an operator who removed
+    // their last CIDR: checked AND disabled, Save 422s, no way out without
+    // re-adding a CIDR or reloading.
+    const { enforce, isOn } = setup({
+      ssh_allowed_source_networks: [],
+      ssh_lockdown: true,
+    });
+    expect(isOn()).toBe(true);
+    expect(enforce.disabled).toBe(false);
+    fireEvent.click(enforce);
+    expect(isOn()).toBe(false);
+  });
+
+  it("says why saving as-is would be refused", () => {
+    setup({ ssh_allowed_source_networks: [], ssh_lockdown: true });
+    expect(screen.getByText(/close SSH from everywhere/i)).toBeTruthy();
+  });
+
+  it("is available once a network exists", () => {
+    const { enforce } = setup({ ssh_allowed_source_networks: ["10.0.0.0/8"] });
+    expect(enforce.disabled).toBe(false);
+  });
+});
+
+describe("the self-lockout acknowledgement", () => {
+  async function saveFrom(over: Partial<PlatformSettings>) {
+    const { enforce } = setup(over);
+    fireEvent.click(enforce);
+    fireEvent.click(screen.getByRole("button", { name: /save ssh settings/i }));
+    return enforce;
+  }
+
+  it("opens the confirmation on the server's 422, quoting its own words", async () => {
+    // The defect: on an AxiosError `err.message` is always the generic status
+    // line, never the detail — so matching on it never fired and the modal
+    // (and ssh_lockdown_force with it) was unreachable from the UI.
+    update.mockRejectedValueOnce(axios422(LOCKOUT_DETAIL));
+    await saveFrom({ ssh_allowed_source_networks: ["10.0.0.0/8"] });
+
+    await screen.findByText(/not inside the allowed networks/i);
+    expect(
+      screen.getByRole("button", { name: /enforce anyway/i }),
+    ).toBeTruthy();
+  });
+
+  it("re-sends with the acknowledgement once confirmed", async () => {
+    update.mockRejectedValueOnce(axios422(LOCKOUT_DETAIL));
+    update.mockResolvedValueOnce(
+      values({
+        ssh_allowed_source_networks: ["10.0.0.0/8"],
+        ssh_lockdown: true,
+      }),
+    );
+    await saveFrom({ ssh_allowed_source_networks: ["10.0.0.0/8"] });
+    await screen.findByText(/not inside the allowed networks/i);
+
+    fireEvent.click(
+      screen.getByLabelText(/I understand this may close my SSH access/i),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /enforce anyway/i }));
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(2));
+    expect(update.mock.calls[0][0].ssh_lockdown_force).toBeUndefined();
+    expect(update.mock.calls[1][0].ssh_lockdown_force).toBe(true);
+  });
+
+  it("never latches the acknowledgement onto a later save", async () => {
+    // It used to be remembered in state and cleared only on success, so a
+    // forced save that failed for ANY other reason left every subsequent
+    // save silently forced.
+    update.mockRejectedValueOnce(axios422(LOCKOUT_DETAIL));
+    update.mockRejectedValueOnce(axios422("something else entirely"));
+    await saveFrom({ ssh_allowed_source_networks: ["10.0.0.0/8"] });
+    await screen.findByText(/not inside the allowed networks/i);
+    fireEvent.click(
+      screen.getByLabelText(/I understand this may close my SSH access/i),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /enforce anyway/i }));
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(2));
+
+    update.mockResolvedValueOnce(values());
+    fireEvent.click(screen.getByRole("button", { name: /save ssh settings/i }));
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(3));
+    expect(update.mock.calls[2][0].ssh_lockdown_force).toBeUndefined();
+  });
+
+  it("shows an unrelated failure as an error, not as a confirmation", async () => {
+    update.mockRejectedValueOnce(axios422("ssh_port must be 1-65535"));
+    await saveFrom({ ssh_allowed_source_networks: ["10.0.0.0/8"] });
+
+    await screen.findByText(/ssh_port must be 1-65535/i);
+    expect(
+      screen.queryByRole("button", { name: /enforce anyway/i }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/components/SSHSection.tsx
+++ b/frontend/src/components/SSHSection.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, Plus, Trash2 } from "lucide-react";
 
 import {
+  formatApiError,
   settingsApi,
   type PlatformSettings,
   type SshAuthorizedKey,
@@ -122,9 +123,6 @@ export function SSHSection({
 
   const [saveErr, setSaveErr] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<number | null>(null);
-  // Set only after the operator confirms the server's self-lockout warning;
-  // cleared on every successful save so it can never be sticky.
-  const [lockdownForced, setLockdownForced] = useState(false);
   const [confirmLockout, setConfirmLockout] = useState<string | null>(null);
 
   const mutation = useMutation({
@@ -139,11 +137,14 @@ export function SSHSection({
       setLockdown(updated.ssh_lockdown ?? false);
       setSaveErr(null);
       setSavedAt(Date.now());
-      setLockdownForced(false);
       setTimeout(() => setSavedAt(null), 2500);
     },
     onError: (err: unknown) => {
-      const msg = err instanceof Error ? err.message : String(err);
+      // formatApiError, NOT err.message: on an AxiosError the latter is
+      // always "Request failed with status code 422" and never the FastAPI
+      // detail, so matching on it below would never fire and the
+      // acknowledgement would be unreachable from the UI entirely.
+      const msg = formatApiError(err, "Failed to save");
       // The self-lockout pre-flight is a question, not a failure — surface
       // it as a confirmation the operator can accept, with the server's own
       // wording rather than a paraphrase that could drift from it.
@@ -169,11 +170,12 @@ export function SSHSection({
       ssh_allowed_source_networks: sources.map((s) => s.trim()).filter(Boolean),
       ssh_lockdown: lockdown,
     };
-    // #1009 — the server refuses turning enforcement on from an address the
-    // allowlist does not cover, which is the mistake operators actually
-    // make. Confirming here re-sends with the acknowledgement rather than
-    // silently forcing: the operator has to read what they are accepting.
-    if (lockdownForced) patch.ssh_lockdown_force = true;
+    // No acknowledgement here, ever. The server refuses turning enforcement
+    // on from an address the allowlist does not cover; the ONLY path that
+    // sends ``ssh_lockdown_force`` is the confirm modal's own re-send, so
+    // each forced save is one the operator has just read and accepted. A
+    // remembered flag would latch on a save that failed for some other
+    // reason and silently force every later one.
     mutation.mutate(patch);
   }
 
@@ -449,16 +451,27 @@ export function SSHSection({
               )}
             </div>
           </div>
+          {/* Only turning it ON needs a CIDR. Gating both directions on the
+              list left an operator who removed their last CIDR with the
+              toggle checked AND disabled: Save then 422s, and there is no
+              way out without re-adding a CIDR or reloading the page. */}
           <Toggle
+            label="Enforce source restriction"
             checked={lockdown}
             onChange={setLockdown}
-            disabled={!isSuperadmin || sources.length === 0}
+            disabled={!isSuperadmin || (!lockdown && sources.length === 0)}
           />
         </div>
         {sources.length === 0 && (
-          <div className="mt-2 text-xs text-muted-foreground">
-            Add at least one network above first &mdash; enforcing an empty list
-            would close SSH from everywhere.
+          <div
+            className={cn(
+              "mt-2 text-xs",
+              lockdown ? "text-destructive" : "text-muted-foreground",
+            )}
+          >
+            {lockdown
+              ? "Enforcement is on with no networks listed — add one, or turn enforcement off. Saving as-is is refused, because it would close SSH from everywhere."
+              : "Add at least one network above first — enforcing an empty list would close SSH from everywhere."}
           </div>
         )}
       </div>
@@ -499,11 +512,8 @@ export function SSHSection({
         loading={mutation.isPending}
         onConfirm={() => {
           setConfirmLockout(null);
-          setLockdownForced(true);
-          // The acknowledgement rides the NEXT save, so re-issue it here
-          // rather than asking the operator to press Save again — and read
-          // the flag from a local rather than from state, which has not
-          // committed yet.
+          // Re-issue the save with the acknowledgement attached, rather than
+          // remembering it and asking the operator to press Save again.
           mutation.mutate({
             ssh_authorized_keys: keys.map((k) => ({
               name: k.name.trim(),

--- a/frontend/src/components/SSHSection.tsx
+++ b/frontend/src/components/SSHSection.tsx
@@ -445,8 +445,10 @@ export function SSHSection({
                   Off: SSH is reachable from anywhere and the list above is
                   recorded but not applied. Turning this on retires the
                   always-open port-22 floor &mdash; the recovery channel a wrong
-                  CIDR would otherwise leave you. Recover at the console, or by
-                  turning this back off here.
+                  CIDR would otherwise leave you. The console always recovers
+                  it. Turning this back off here works too, but only while you
+                  can still reach this UI &mdash; a Web UI source restriction
+                  can be limiting that separately.
                 </>
               )}
             </div>

--- a/frontend/src/components/SSHSection.tsx
+++ b/frontend/src/components/SSHSection.tsx
@@ -7,6 +7,7 @@ import {
   type PlatformSettings,
   type SshAuthorizedKey,
 } from "@/lib/api";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { Toggle } from "@/components/ui/toggle";
 import { cn } from "@/lib/utils";
 
@@ -89,6 +90,14 @@ export function SSHSection({
   const [sources, setSources] = useState<string[]>(
     values.ssh_allowed_source_networks || [],
   );
+  // #1009 — the allowlist above is a note until this is on. The host
+  // firewall opens port 22 unconditionally from a floor that sorts ahead of
+  // the scoped rule, so enforcing means retiring that floor — which is the
+  // appliance's recovery channel, hence an explicit switch rather than a
+  // consequence of typing a CIDR.
+  const [lockdown, setLockdown] = useState<boolean>(
+    values.ssh_lockdown ?? false,
+  );
 
   const dirty =
     passwordAuth !== values.ssh_password_auth_enabled ||
@@ -96,6 +105,7 @@ export function SSHSection({
     port !== (values.ssh_port || 22) ||
     JSON.stringify(sources) !==
       JSON.stringify(values.ssh_allowed_source_networks || []) ||
+    lockdown !== (values.ssh_lockdown ?? false) ||
     JSON.stringify(keys) !==
       JSON.stringify((values.ssh_authorized_keys || []).map((k) => ({ ...k })));
 
@@ -112,6 +122,10 @@ export function SSHSection({
 
   const [saveErr, setSaveErr] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<number | null>(null);
+  // Set only after the operator confirms the server's self-lockout warning;
+  // cleared on every successful save so it can never be sticky.
+  const [lockdownForced, setLockdownForced] = useState(false);
+  const [confirmLockout, setConfirmLockout] = useState<string | null>(null);
 
   const mutation = useMutation({
     mutationFn: (patch: Partial<PlatformSettings>) => settingsApi.update(patch),
@@ -122,12 +136,23 @@ export function SSHSection({
       setAllowRoot(updated.ssh_allow_root_login);
       setPort(updated.ssh_port || 22);
       setSources(updated.ssh_allowed_source_networks || []);
+      setLockdown(updated.ssh_lockdown ?? false);
       setSaveErr(null);
       setSavedAt(Date.now());
+      setLockdownForced(false);
       setTimeout(() => setSavedAt(null), 2500);
     },
     onError: (err: unknown) => {
-      setSaveErr(err instanceof Error ? err.message : String(err));
+      const msg = err instanceof Error ? err.message : String(err);
+      // The self-lockout pre-flight is a question, not a failure — surface
+      // it as a confirmation the operator can accept, with the server's own
+      // wording rather than a paraphrase that could drift from it.
+      if (msg.includes("not inside the allowed networks")) {
+        setConfirmLockout(msg);
+        setSaveErr(null);
+        return;
+      }
+      setSaveErr(msg);
     },
   });
 
@@ -142,7 +167,13 @@ export function SSHSection({
       ssh_allow_root_login: allowRoot,
       ssh_port: port,
       ssh_allowed_source_networks: sources.map((s) => s.trim()).filter(Boolean),
+      ssh_lockdown: lockdown,
     };
+    // #1009 — the server refuses turning enforcement on from an address the
+    // allowlist does not cover, which is the mistake operators actually
+    // make. Confirming here re-sends with the acknowledgement rather than
+    // silently forcing: the operator has to read what they are accepting.
+    if (lockdownForced) patch.ssh_lockdown_force = true;
     mutation.mutate(patch);
   }
 
@@ -337,8 +368,9 @@ export function SSHSection({
             <div className="text-sm font-medium">Allowed source networks</div>
             <div className="text-xs text-muted-foreground">
               CIDRs the host firewall scopes the SSH port to (e.g.{" "}
-              <code>10.0.0.0/24</code>). Empty = reachable from anywhere. The
-              port-22 floor stays open regardless.
+              <code>10.0.0.0/24</code>). Applied only when{" "}
+              <span className="font-medium">Enforce source restriction</span> is
+              on.
             </div>
           </div>
           <button
@@ -382,6 +414,55 @@ export function SSHSection({
         )}
       </div>
 
+      {/* #1009 — the switch that turns the list above into enforcement.
+          Separate from the list on purpose: enforcing means retiring the
+          appliance's unconditional port-22 floor, which docs/design/
+          FLEET_FIREWALL.md §6.1 calls the irreducible recovery channel and
+          its risk register names as the mitigation for every OTHER firewall
+          mistake. Typing a CIDR should not remove it; deciding to should. */}
+      <div
+        className={cn(
+          "rounded-md border p-3",
+          lockdown ? "border-amber-500/50 bg-amber-500/5" : "bg-muted/30",
+        )}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-sm font-medium">
+              Enforce source restriction
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {lockdown ? (
+                <>
+                  SSH is reachable only from the networks above, on port 22 and
+                  on a moved port alike. The appliance&rsquo;s always-open
+                  port-22 floor is retired while this is on.
+                </>
+              ) : (
+                <>
+                  Off: SSH is reachable from anywhere and the list above is
+                  recorded but not applied. Turning this on retires the
+                  always-open port-22 floor &mdash; the recovery channel a wrong
+                  CIDR would otherwise leave you. Recover at the console, or by
+                  turning this back off here.
+                </>
+              )}
+            </div>
+          </div>
+          <Toggle
+            checked={lockdown}
+            onChange={setLockdown}
+            disabled={!isSuperadmin || sources.length === 0}
+          />
+        </div>
+        {sources.length === 0 && (
+          <div className="mt-2 text-xs text-muted-foreground">
+            Add at least one network above first &mdash; enforcing an empty list
+            would close SSH from everywhere.
+          </div>
+        )}
+      </div>
+
       <div className="mt-4 flex items-center gap-3 border-t pt-4">
         <button
           type="button"
@@ -407,6 +488,40 @@ export function SSHSection({
           </span>
         )}
       </div>
+
+      <ConfirmModal
+        open={confirmLockout !== null}
+        title="Enforce SSH restriction from outside it?"
+        tone="destructive"
+        message={confirmLockout ?? ""}
+        confirmLabel="Enforce anyway"
+        requireCheckboxLabel="I understand this may close my SSH access to every appliance"
+        loading={mutation.isPending}
+        onConfirm={() => {
+          setConfirmLockout(null);
+          setLockdownForced(true);
+          // The acknowledgement rides the NEXT save, so re-issue it here
+          // rather than asking the operator to press Save again — and read
+          // the flag from a local rather than from state, which has not
+          // committed yet.
+          mutation.mutate({
+            ssh_authorized_keys: keys.map((k) => ({
+              name: k.name.trim(),
+              public_key: k.public_key.trim(),
+              comment: k.comment.trim(),
+            })),
+            ssh_password_auth_enabled: passwordAuth,
+            ssh_allow_root_login: allowRoot,
+            ssh_port: port,
+            ssh_allowed_source_networks: sources
+              .map((x) => x.trim())
+              .filter(Boolean),
+            ssh_lockdown: lockdown,
+            ssh_lockdown_force: true,
+          });
+        }}
+        onClose={() => setConfirmLockout(null)}
+      />
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3667,6 +3667,13 @@ export interface PlatformSettings {
   ssh_allow_root_login: boolean;
   ssh_port: number;
   ssh_allowed_source_networks: string[];
+  /** #1009 — whether the allowlist above is ENFORCED. Off, the host
+   *  firewall keeps its unconditional port-22 floor and the list is
+   *  inert; on, that floor is retired and the scope applies. */
+  ssh_lockdown: boolean;
+  /** Write-only acknowledgement for the self-lockout pre-flight —
+   *  never returned by the API. */
+  ssh_lockdown_force?: boolean;
   /** Appliance DNS resolver (issue #158). No secrets — resolver IPs /
    *  search domains are not sensitive, so read + write shapes match.
    *  ``automatic`` defers to per-link NetworkManager / DHCP DNS;


### PR DESCRIPTION
Closes #1009

The SSH source-CIDR allowlist has shipped since #157 and, on the default port, restricted **nothing**. `/etc/nftables.conf` opened `tcp dport 22` unconditionally in its management floor, *above* the `include "/etc/nftables.d/*.nft"` glob that pulls in the scoped rule, and nftables is first-match-wins — so a perfectly-rendered rule was dead code while Fleet showed the CIDR list exactly as typed. #1001 fixed the rendering; this makes it reachable.

## The design doc had already decided this, differently from the issue

`docs/design/FLEET_FIREWALL.md` §6.1 specifies `firewall_mgmt_cidrs` + `firewall_mgmt_lockdown` — the floor becomes scoped only behind an **explicit second opt-in** — and calls the LAN-wide floor the *irreducible recovery channel*, which its own risk register (R1) then names as the mitigation for every **other** firewall risk. Neither field existed in code.

So this ships that design as `ssh_lockdown`, reusing #157's existing `ssh_allowed_source_networks` rather than adding a second CIDR list. It is also the anti-lockout pattern pfSense and OPNsense ship, which is what operators already expect.

**Reading §6.1 closely turns up a contradiction, now annotated in the doc:** "the base-conf floor stays LAN-wide regardless" cannot hold at the same time as its own line 192 (`OR ip saddr {mgmt} when firewall_mgmt_lockdown`) — first-match-wins makes the second dead. That *is* #1009, designed in. The floor is therefore **retireable**, not un-removable: present by default, so §6.1's guarantee holds for every install that has not opted in.

## What made it cheap

The mechanism already existed. The Web UI's unconditional accept has lived in a retireable sentinel (`00-spatium-webui.nft`) since #769, and `spatium-firewall-reload` carries a generic `apply_sentinel_directive`. SSH's accept was baked into the base config instead, which is the **only** reason it could not be retired — so it moved to `/etc/nftables.d/00-spatium-ssh.nft` and became the third caller, with the matching last-good snapshot/restore in the auto-revert plane.

## Retiring the sentinel alone is not enough

All three renderers *also* emit an SSH accept in `spatium-role.nft`, which sorts **after** `50-spatium-ssh.nft` in the glob — so a packet the scoped rule declined would fall straight through to it and the restriction would still do nothing. Under lockdown that line is emitted source-scoped too, and a test pins both halves so a future edit cannot do one without the other.

## Nothing tightens on upgrade

`effective_ssh_scope` — the one place the flag is resolved — returns `[]` while lockdown is off, which every consumer already reads as "open unconditionally". So an operator who configured the list while it was inert is unaffected, and an older host runner that has never heard of the flag does the safe thing by construction.

Behaviour also stops depending on the port number, which was the real defect: post-#1001 it enforced on a moved port and not on 22.

## Guards

- Enforcing with an **empty list** is refused outright — that closes SSH from everywhere rather than restricting it (the 422 §6.1 already specified).
- Enforcing from an address the list does not cover asks for an explicit acknowledgement — the mistake operators actually make, caught when they make it rather than at their next SSH attempt. It reads the same spoofing-resistant client IP the login throttle uses and **fails OPEN** when the address is unknown: it catches a typo, it is not a security control, and a pre-flight that blocks on "I could not tell" is one operators force past by reflex.
- Turning lockdown **off** never needs the acknowledgement. That is the recovery path.

## The two lockdowns compose — and nothing warns about the combination

Ten places in the tree asserted an un-removable SSH floor. Most needed only precision (a *rule* still may never drop 22; that surface is unchanged). **Two were becoming conditionally false**: the Web-UI anti-lockout override and the `web_ui_allowed_cidrs` column both promise SSH as the recovery path for a bad Web-UI scope, and an operator who has *also* turned on `ssh_lockdown` with a scope excluding themselves has closed both doors and is left with the console. Neither setting can see the other, so neither warns — said plainly now, including a new paragraph in `APPLIANCE.md`.

## Verification

**Measured against a real nftables kernel, both directions.** Floor present → every packet takes it. Floor retired → every remaining port-22 accept is source-scoped, none unconditional. Negative-controlled against the pre-#1009 base config, which still shows the unconditional accept winning.

The three-way renderer byte-identity still holds (`test_byte_identical_with_supervisor_renderer`, run from a full checkout).

Gates: ruff / black / mypy / migration + appliance-runner linters; frontend format, eslint, `tsc`, `npm run build`, 80 vitest; 502 appliance, 347 supervisor, 65 backend firewall + settings. The 57 appliance failures on the dev machine are pre-existing and identical on `main` (host `python3` lacks PyYAML); they pass in CI.

## Review round

`/code-review` found six, and **the first re-created the bug one layer down**:

1. **`config_hash` did not cover the scope.** It is the only thing that re-fires the host runner, and it was sha256 over the authorized-keys + sshd-config bodies alone — the scope is an nftables scope, not an sshd directive, so it appears in neither. Toggling lockdown therefore changed nothing the hash could see: no trigger, and `50-spatium-ssh.nft` kept its **unconditional** accept (which sorts ahead of the scoped management line) while the firewall plane had already retired the floor. SSH open from anywhere, every surface reporting it restricted.
2. The UI matched the self-lockout 422 on `err.message`, which on an AxiosError is always `Request failed with status code 422` and never the FastAPI detail — the confirmation could never open, and `ssh_lockdown_force` was unreachable from the product.
3. Removing the last CIDR under lockdown left the toggle checked **and** disabled — Save 422s, no way out without re-adding a CIDR or reloading.
4. The pre-flight gated on the resulting state, so it fired on every later `ssh_*` save while lockdown was on, demanding an acknowledgement for changes that alter nothing — which teaches operators to tick it unread.
5. The force flag latched: cleared only on success, so a forced save that failed for any other reason silently forced every later one.
6. The ordering test sorted its own literals — it exercised `sorted()`, so a rename to `60-` would silently un-enforce lockdown with the test still green.

Each fix is negative-controlled against its own defect, including a new `SSHSection.test.tsx` for the three UI ones (all invisible to `tsc`).

## Migration

`e5b1d47a9c62` — one boolean column, `server_default false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
