### PR TITLE
fix: the two source restrictions composed into a console-only lockout (#1013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,11 +110,19 @@ the formatter handles the rest.
   `/appliance/firewall`, because the SSH screen must be able to
   ask with that module off.
 
-  **The per-door refusals got more useful on the way**, because
-  reaching one now *proves* a way in survives: had the other door
-  also excluded the caller, the escalation would have raised
-  first. So each names the surviving path and its scope instead of
-  hedging about it.
+  **The per-door refusals say more on the way**, because reaching
+  one now *proves* the other door did not exclude the caller's
+  address: had it, the escalation would have raised first. So each
+  names the other list and its scope instead of hedging about it.
+  Only as far as the fact goes, though — every verdict here is
+  about ONE address, the source of the HTTP request, and that is
+  the right address for the Web UI door (the operator is using it,
+  over that door, right now) but only a proxy for the SSH one,
+  since browsing from one network and SSHing from another is
+  legitimate. So the copy is asymmetric on purpose: "you can still
+  reach this UI" is asserted, "you can still SSH" is not — the SSH
+  list is reported as *including the address you are connecting
+  from*, which is what is actually known.
 
   **An address we cannot read is not covered — everywhere.** The
   two guards had been scoring that case in opposite directions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,18 +57,109 @@ the formatter handles the rest.
   operators actually make, caught at the moment they make it
   rather than at their next SSH attempt.
 
-  **The two lockdowns compose, and nothing checks it.** Scope the
-  Web UI *and* enable this with a scope that excludes you, and the
-  console is what remains. Neither setting can see the other, so
-  neither warns; every surface that used to promise SSH as an
-  unconditional recovery path now names the console first and
-  treats SSH as conditional. `test_ssh_recovery_claims.py` asserts
-  on the *claim* rather than its wording — three earlier passes
-  each grepped for the previous phrasing and missed the next
-  paraphrase, and the guard caught two false UI strings that all
-  three had walked past.
+  **The two lockdowns compose.** Scope the Web UI *and* enable
+  this with a scope that excludes you, and the console is what
+  remains. #1009 shipped with neither setting able to see the
+  other, so neither warned; every surface that used to promise SSH
+  as an unconditional recovery path now names the console first
+  and treats SSH as conditional.
+  `scripts/lint_ssh_recovery_claims.py` asserts on the *claim*
+  rather than its wording — three earlier passes each grepped for
+  the previous phrasing and missed the next paraphrase, and the
+  guard caught two false UI strings that all three had walked
+  past. The check that sees both settings at once landed in
+  #1013, below.
 
 ### Security
+
+- **The two source restrictions composed into a console-only
+  lockout, and neither guard could see the other (#1013).** The
+  appliance has two independent ways in and a source allowlist for
+  each — the Web UI (#285 Phase 6) and SSH (#1009). Each shipped
+  with an anti-lockout guard that checked only whether the
+  caller's address was inside *its own* list, so an operator could
+  pass both, one at a time, and end up reachable through neither.
+  That is not an exotic sequence: "lock this box down" means
+  scoping the Web UI to the management network and then scoping
+  SSH to the same one, and if that CIDR is stale both guards fire,
+  both offer an override, and each override is individually
+  reasonable. Nothing at any point said the other door was also
+  closing.
+  Before #1009 it could not happen — the port-22 floor was
+  un-removable, so SSH was the guaranteed recovery path the Web UI
+  guard leaned on. Making that floor retireable is what the SSH
+  allowlist needed in order to mean anything, and it removed the
+  guarantee.
+
+  Both write paths now resolve one shared question through
+  `backend/app/services/appliance/access.py`: **after this change,
+  does any remote door still admit the address I am talking to?**
+  When the answer is no they raise the *same* 422 — one state of
+  the appliance, so one sentence about it — requiring
+  `acknowledge_console_only=true`. Deliberately **not** satisfied
+  by the per-door `override_lockout` / `ssh_lockdown_force`: those
+  accept losing one door while another remains, which is a
+  materially smaller thing, and an operator may have ticked one
+  for an unrelated reason. The implication runs one way only —
+  accepting console-only already contains "this door closes on
+  me", so it is not asked for twice, which would be the
+  reflex-training pattern both guards' own comments warn about.
+  Both screens also read a new `GET /appliance/remote-access` and
+  show the *other* door's state at the point of decision; it sits
+  on the always-mounted `/appliance` hub rather than under
+  `/appliance/firewall`, because the SSH screen must be able to
+  ask with that module off.
+
+  **The per-door refusals got more useful on the way**, because
+  reaching one now *proves* a way in survives: had the other door
+  also excluded the caller, the escalation would have raised
+  first. So each names the surviving path and its scope instead of
+  hedging about it.
+
+  **An address we cannot read is not covered — everywhere.** The
+  two guards had been scoring that case in opposite directions:
+  the Web UI one counted it as excluded and warned, the SSH one as
+  covered and proceeded. Both had a written rationale and the pair
+  was not defensible. The conservative reading wins because the
+  costs are asymmetric — an unneeded warning costs a checkbox, a
+  missing one costs a trip to the console — and because #1009's
+  argument for the other direction ("a gate that blocks on *I
+  could not tell* gets forced past by reflex") was a claim about
+  frequency, and the frequency is near zero: the trusted
+  client-IP helper falls back to the ASGI peer address, which
+  every real HTTP request has.
+
+  **Found on the way:** the Web UI guard was reading `client_ip`,
+  which `core/request_meta` documents as spoofable and explicitly
+  unsuitable for a source-IP allowlist gate. It is also simply the
+  wrong address on a real topology — behind a reverse proxy,
+  uvicorn's `--forwarded-allow-ips *` resolves the browser's own
+  IP out of `X-Forwarded-For` while nftables judges the packet
+  source, which is the proxy — so the guard would clear an
+  operator who was about to be locked out, with no attacker
+  involved. It now reads the same trusted value the SSH guard
+  does.
+
+  **And the console is not universal.** `spatium-console` runs on
+  `tty1` and `ttyS0`; a remote VM with no virtual serial port and
+  no hypervisor console has no floor at all, so an acknowledged
+  console-only lockout there is a rebuild. The escalation says
+  that in as many words rather than describing the console as a
+  recovery path, and `docs/deployment/APPLIANCE.md` now states it.
+
+  Both 422s are routed in the UI by the **acknowledgement field**
+  each one names, not by its prose: a field name is the API
+  contract and the sentence around it is not, and a test pins that
+  the three markers stay mutually exclusive. `WebUIAccessCard` was
+  lifted out of `FirewallTab.tsx` into its own component so it can
+  be rendered in a test — the failure mode on both sides is a
+  modal or a checkbox that never appears, which neither review nor
+  `tsc` can see. 1 MCP tool (`find_remote_access_doors`,
+  read-only, default on): the composition was the one thing
+  neither existing tool could show, since `find_web_ui_access` is
+  tagged `module="appliance.firewall"` and `find_ssh_settings` is
+  not — so with that module off the copilot could see one door and
+  not the other. No migration, no new column.
 
 - **The SSH source-CIDR allowlist was discarded and the port
   opened to the world (#1001).** `spatiumddi-ssh-reload` renders

--- a/backend/app/api/v1/appliance/firewall.py
+++ b/backend/app/api/v1/appliance/firewall.py
@@ -44,7 +44,7 @@ from sqlalchemy.orm import selectinload
 from app.api.deps import DB, CurrentUser
 from app.core.agent_wake import HOSTCONFIG_ALL, publish_wake
 from app.core.permissions import user_has_permission
-from app.core.request_meta import client_ip
+from app.core.request_meta import get_trusted_client_ip
 from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
 from app.models.audit import AuditLog
 from app.models.firewall import (
@@ -55,6 +55,7 @@ from app.models.firewall import (
     FirewallRule,
 )
 from app.models.settings import PlatformSettings
+from app.services.appliance.access import console_only_detail, covers, effective_doors
 from app.services.appliance.firewall_lease import upgrade_in_flight
 from app.services.appliance.firewall_merge import (
     MergeContext,
@@ -1270,35 +1271,30 @@ async def apply_posture(
 # also drives ``loadBalancerSourceRanges`` on the MetalLB VIP Service so BOTH
 # the node-IP hostPort door and the VIP door are governed by one setting.
 #
-# ANTI-LOCKOUT: a non-empty set that doesn't cover the operator's CURRENT
-# source IP would brick the very session making the change (the request is
-# arriving through the frontend right now). We reject that 422 unless the
-# operator explicitly passes override_lockout=true.
+# ANTI-LOCKOUT, in two tiers (#285 Phase 6, then #1013).
 #
-# SSH/22 is the recovery path for an overridden lockout — but since #1009 it
-# is recoverable rather than guaranteed: the port-22 floor is a retireable
-# sentinel, and an operator who ALSO turned on ``ssh_lockdown`` with a scope
-# that excludes them has closed both doors and is left with the console. The
-# two are independent settings and each warns on its own; nothing here can
-# see the other, which is why this comment says "console" rather than
-# promising SSH.
-
-
-def _ip_in_cidrs(ip: str | None, cidrs: list[str]) -> bool:
-    if not ip:
-        return False
-    try:
-        addr = ipaddress.ip_address(ip)
-    except ValueError:
-        return False
-    for c in cidrs:
-        try:
-            net = ipaddress.ip_network(c, strict=False)
-        except ValueError:
-            continue
-        if addr.version == net.version and addr in net:
-            return True
-    return False
+# Tier 1 — this door. A non-empty set that doesn't cover the operator's
+# CURRENT source IP would brick the very session making the change (the
+# request is arriving through the frontend right now). Rejected 422 unless
+# the operator explicitly passes override_lockout=true. Losing this door is
+# survivable while another remains, which is what that override accepts.
+#
+# Tier 2 — every door. Since #1009 the port-22 floor is a retireable
+# sentinel, so SSH is a recoverable path rather than a guaranteed one: an
+# operator who has also turned on ``ssh_lockdown`` with a scope that excludes
+# them is left with the console. Both guards used to be blind to each other,
+# so both could be passed one at a time and neither would say so. They now
+# share ``services/appliance/access`` and this path escalates to a distinct
+# 422 with its own acknowledgement when the RESULTING state of both settings
+# admits the caller nowhere.
+#
+# The caller's address comes from ``get_trusted_client_ip``, not ``client_ip``
+# — see the two docstrings in ``core/request_meta``. This is a source-IP
+# allowlist gate, and the spoofable value is also simply the WRONG address on
+# a real topology: with a reverse proxy in front of the appliance, uvicorn's
+# ``--forwarded-allow-ips *`` resolves the browser's own IP out of
+# X-Forwarded-For while nftables will judge the packet source, which is the
+# proxy. The guard would clear an operator who is about to be locked out.
 
 
 class WebUIAccessResponse(BaseModel):
@@ -1310,7 +1306,14 @@ class WebUIAccessResponse(BaseModel):
 
 class SetWebUIAccessRequest(BaseModel):
     allowed_cidrs: list[str] = Field(default_factory=list)
+    #: Accept losing THIS door: the resulting list does not cover you, but
+    #: another remote path still does.
     override_lockout: bool = False
+    #: Accept losing EVERY remote door: after this change neither restriction
+    #: admits you and only the console does (#1013). Deliberately separate
+    #: from ``override_lockout`` — that one is a smaller statement, and may
+    #: have been ticked for an unrelated reason.
+    acknowledge_console_only: bool = False
 
     @field_validator("allowed_cidrs")
     @classmethod
@@ -1342,12 +1345,12 @@ async def get_web_ui_access(
     _require_read(current_user)
     cfg = await db.get(PlatformSettings, 1)
     cidrs = list(cfg.web_ui_allowed_cidrs or []) if cfg else []
-    ip = client_ip(request)
+    ip = get_trusted_client_ip(request)
     return WebUIAccessResponse(
         allowed_cidrs=cidrs,
         open=not cidrs,
         caller_ip=ip,
-        caller_covered=(not cidrs) or _ip_in_cidrs(ip, cidrs),
+        caller_covered=(not cidrs) or covers(ip, cidrs),
     )
 
 
@@ -1356,25 +1359,52 @@ async def set_web_ui_access(
     body: SetWebUIAccessRequest, request: Request, db: DB, current_user: CurrentUser
 ) -> WebUIAccessResponse:
     _require_admin(current_user)
-    ip = client_ip(request)
+    ip = get_trusted_client_ip(request)
+    cfg = await db.get(PlatformSettings, 1)
+    # Tier 2 first: it is the strictly more serious finding, and its message
+    # subsumes tier 1's. Checked against the state this request WOULD
+    # produce, with the SSH half read from storage — this endpoint cannot
+    # change it.
+    #
+    # Unlike the SSH side, this is NOT gated on a transition. There, the same
+    # PUT carries unrelated edits (a key, a port) and re-warning about a state
+    # the operator did not change is how a tick stops being read. Here the
+    # request's entire payload IS the door, so there is no unrelated edit to
+    # protect — and re-sending a list that already excludes you has always
+    # re-raised tier 1 for the same reason.
+    report = effective_doors(cfg, ip, web_ui_cidrs=body.allowed_cidrs)
+    if report.console_only and not body.acknowledge_console_only:
+        raise HTTPException(status_code=422, detail=console_only_detail(report))
     if (
         body.allowed_cidrs
-        and not body.override_lockout
-        and not _ip_in_cidrs(ip, body.allowed_cidrs)
+        # ``report.console_only`` here means the acknowledgement above was
+        # given: accepting "the console is my only way in" already contains
+        # "this door closes on me", so demanding a second tick for the
+        # smaller statement would be the reflex-training pattern. It cannot
+        # widen anything — when the escalation did NOT fire, this term is
+        # False and ``override_lockout`` stands on its own.
+        and not (body.override_lockout or report.console_only)
+        and not covers(ip, body.allowed_cidrs)
     ):
+        # Reaching here proves a way in survives: the condition above IS
+        # "the Web UI door would not admit you", and had the SSH door not
+        # admitted you either, the escalation would already have raised. So
+        # this names the surviving path instead of hedging about it.
+        ssh_desc = (
+            "allowed from " + ", ".join(report.ssh.allowed_cidrs)
+            if report.ssh.restricted
+            else "not source-restricted"
+        )
         raise HTTPException(
             status_code=422,
             detail=(
                 f"Refusing to restrict the Web UI: your current source IP ({ip or 'unknown'}) "
                 "is not covered by the allow-list, so this would lock you out of the very "
                 "session making the change. Add your IP / network to the list, or pass "
-                "override_lockout=true. The console always recovers the appliance; "
-                "SSH does too unless you have also turned on the SSH source "
-                "restriction (Appliance \u2192 Fleet \u2192 SSH) with a scope "
-                "that excludes you."
+                "override_lockout=true — you would still reach this fleet over SSH "
+                f"({ssh_desc}) and at the appliance console."
             ),
         )
-    cfg = await db.get(PlatformSettings, 1)
     if cfg is None:
         cfg = PlatformSettings(id=1)
         db.add(cfg)
@@ -1396,6 +1426,8 @@ async def set_web_ui_access(
                 new_value={
                     "web_ui_allowed_cidrs": body.allowed_cidrs,
                     "override_lockout": body.override_lockout,
+                    "acknowledge_console_only": body.acknowledge_console_only,
+                    "console_only_result": report.console_only,
                     "caller_ip": ip,
                 },
             )
@@ -1409,5 +1441,5 @@ async def set_web_ui_access(
         allowed_cidrs=cidrs,
         open=not cidrs,
         caller_ip=ip,
-        caller_covered=(not cidrs) or _ip_in_cidrs(ip, cidrs),
+        caller_covered=(not cidrs) or covers(ip, cidrs),
     )

--- a/backend/app/api/v1/appliance/firewall.py
+++ b/backend/app/api/v1/appliance/firewall.py
@@ -55,7 +55,12 @@ from app.models.firewall import (
     FirewallRule,
 )
 from app.models.settings import PlatformSettings
-from app.services.appliance.access import console_only_detail, covers, effective_doors
+from app.services.appliance.access import (
+    SSH_REACHABILITY_CAVEAT,
+    console_only_detail,
+    covers,
+    effective_doors,
+)
 from app.services.appliance.firewall_lease import upgrade_in_flight
 from app.services.appliance.firewall_merge import (
     MergeContext,
@@ -1386,14 +1391,19 @@ async def set_web_ui_access(
         and not (body.override_lockout or report.console_only)
         and not covers(ip, body.allowed_cidrs)
     ):
-        # Reaching here proves a way in survives: the condition above IS
-        # "the Web UI door would not admit you", and had the SSH door not
-        # admitted you either, the escalation would already have raised. So
-        # this names the surviving path instead of hedging about it.
+        # Reaching here proves the SSH door did not exclude this address:
+        # the condition above IS "the Web UI door would not admit you", and
+        # had SSH excluded you too, the escalation would already have raised.
+        #
+        # That is a fact about an ADDRESS, not a promise about a session —
+        # see SSH_REACHABILITY_CAVEAT. State the list; do not assert that the
+        # operator will be able to SSH, which needs an assumption about where
+        # they SSH from that this request cannot support.
         ssh_desc = (
-            "allowed from " + ", ".join(report.ssh.allowed_cidrs)
+            f"SSH is allowed from {', '.join(report.ssh.allowed_cidrs)}, "
+            f"{SSH_REACHABILITY_CAVEAT}"
             if report.ssh.restricted
-            else "not source-restricted"
+            else "SSH is not source-restricted"
         )
         raise HTTPException(
             status_code=422,
@@ -1401,8 +1411,8 @@ async def set_web_ui_access(
                 f"Refusing to restrict the Web UI: your current source IP ({ip or 'unknown'}) "
                 "is not covered by the allow-list, so this would lock you out of the very "
                 "session making the change. Add your IP / network to the list, or pass "
-                "override_lockout=true — you would still reach this fleet over SSH "
-                f"({ssh_desc}) and at the appliance console."
+                f"override_lockout=true. {ssh_desc}, and the appliance console recovers "
+                "this either way."
             ),
         )
     if cfg is None:

--- a/backend/app/api/v1/appliance/router.py
+++ b/backend/app/api/v1/appliance/router.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 from sqlalchemy import select
 
@@ -41,7 +41,10 @@ from app.api.v1.appliance.tls import router as tls_router
 from app.api.v1.appliance.upgrade_images import router as upgrade_images_router
 from app.config import settings
 from app.core.permissions import require_permission
+from app.core.request_meta import get_trusted_client_ip
 from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
+from app.models.settings import PlatformSettings
+from app.services.appliance.access import Door, effective_doors
 from app.services.feature_modules import require_module
 
 router = APIRouter()
@@ -91,6 +94,64 @@ router.include_router(pairing_router)
 # URL is ``/api/v1/appliance/supervisor/register`` rather than
 # ``/api/v1/appliance/supervisor/supervisor/register``.
 router.include_router(supervisor_router)
+
+
+class RemoteDoor(BaseModel):
+    """One source-restricted way in, and whether it admits this caller."""
+
+    name: str
+    restricted: bool
+    allowed_cidrs: list[str]
+    admits: bool
+
+
+class RemoteAccessResponse(BaseModel):
+    """Which remote doors currently admit the caller (#1013).
+
+    Read by BOTH lockout-sensitive screens — Fleet \u2192 Firewall (the Web UI
+    allow-list) and Fleet \u2192 SSH (the SSH allow-list) — so each can show
+    the state of the OTHER door at the moment the operator is deciding. Same
+    resolver the two write paths raise their 422s from, so the warning an
+    operator reads and the refusal they hit cannot disagree.
+
+    Lives on the always-mounted ``/appliance`` hub rather than under
+    ``/appliance/firewall``: that sub-router is behind the
+    ``appliance.firewall`` feature module, and the SSH screen must be able to
+    ask this question with the module off.
+    """
+
+    caller_ip: str | None
+    web_ui: RemoteDoor
+    ssh: RemoteDoor
+    #: True when neither door admits the caller — the console is all that is
+    #: left. Already the case, not a prediction about a pending change.
+    console_only: bool
+
+
+def _door_out(door: Door) -> RemoteDoor:
+    return RemoteDoor(
+        name=door.name,
+        restricted=door.restricted,
+        allowed_cidrs=list(door.allowed_cidrs),
+        admits=door.admits,
+    )
+
+
+@router.get(
+    "/remote-access",
+    response_model=RemoteAccessResponse,
+    dependencies=[Depends(require_permission("read", "appliance"))],
+    summary="Which remote doors admit this caller",
+)
+async def get_remote_access(request: Request, db: DB) -> RemoteAccessResponse:
+    cfg = await db.get(PlatformSettings, 1)
+    report = effective_doors(cfg, get_trusted_client_ip(request))
+    return RemoteAccessResponse(
+        caller_ip=report.caller_ip,
+        web_ui=_door_out(report.web_ui),
+        ssh=_door_out(report.ssh),
+        console_only=report.console_only,
+    )
 
 
 class SelfApplianceInfo(BaseModel):

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -49,6 +49,7 @@ from app.models.settings import (
     PlatformSettings,
 )
 from app.services import audit_forward as audit_forward_svc
+from app.services.appliance.access import console_only_detail, covers, effective_doors
 from app.services.appliance.apt import render_sources_list
 from app.services.appliance.ssh import is_valid_public_key, validate_lockout_safe
 from app.services.appliance.syslog import validate_syslog_filter, validate_syslog_host
@@ -968,9 +969,16 @@ class SettingsUpdate(BaseModel):
     ssh_port: int | None = None
     ssh_allowed_source_networks: list[str] | None = None
     ssh_lockdown: bool | None = None
-    # Not a column — the acknowledgement for the self-lockout pre-flight
-    # below. Popped out of ``changes`` before anything is written.
+    # Neither of these is a column — both are acknowledgements for the
+    # self-lockout pre-flights below, popped out of ``changes`` before
+    # anything is written.
+    #
+    # ``ssh_lockdown_force`` accepts losing THIS door while another remains.
+    # ``acknowledge_console_only`` (#1013) accepts losing EVERY remote door,
+    # which is a materially larger thing and so cannot be satisfied by the
+    # smaller tick — an operator may have sent that one for another reason.
     ssh_lockdown_force: bool | None = None
+    acknowledge_console_only: bool | None = None
     # ── Appliance DNS resolver (issue #158) ───────────────────────
     resolver_mode: str | None = None
     resolver_servers: list[str] | None = None
@@ -1741,40 +1749,6 @@ async def get_settings_defaults(current_user: CurrentUser) -> dict[str, Any]:
     return _column_defaults()
 
 
-def _caller_within_scope(request: Request, cidrs: list[str]) -> bool:
-    """Is the address this request came from inside ``cidrs``? (#1009)
-
-    Uses the same spoofing-resistant value the login throttle and the audit
-    trail use, so a client cannot talk its way past the check with a header.
-
-    Returns True when the address is UNKNOWN. This gate exists to catch an
-    operator typo, not to be a security control — the restriction it guards
-    is enforced by nftables on the host regardless — and refusing every
-    request whose source we cannot read would make the setting unreachable
-    from a deployment shape that hides it. A pre-flight that fails closed on
-    "I could not tell" is one operators learn to force past by reflex, which
-    costs more than it buys.
-    """
-    from ipaddress import ip_address, ip_network  # noqa: PLC0415
-
-    raw = get_trusted_client_ip(request)
-    if not raw:
-        return True
-    try:
-        addr = ip_address(raw)
-    except ValueError:
-        return True
-    for cidr in cidrs:
-        try:
-            if addr in ip_network(str(cidr).strip(), strict=False):
-                return True
-        except ValueError:
-            # Already validated on the way in; a bad entry here cannot make
-            # the caller "covered", so skip it rather than fail the check.
-            continue
-    return False
-
-
 @router.put("", response_model=SettingsResponse)
 async def update_settings(
     body: SettingsUpdate, request: Request, current_user: CurrentUser, db: DB
@@ -1790,9 +1764,10 @@ async def update_settings(
 
     settings = await _get_or_create(db)
     changes = body.model_dump(exclude_none=True)
-    # #1009 — an acknowledgement, not a column. Pop before anything reads
-    # ``changes`` as the set of fields to write or to audit.
+    # #1009 / #1013 — acknowledgements, not columns. Pop before anything
+    # reads ``changes`` as the set of fields to write or to audit.
     changes.pop("ssh_lockdown_force", None)
+    changes.pop("acknowledge_console_only", None)
 
     # CROSS-FIELD merged-state guard for the DNS resolver (#158). The
     # model_validator already rejects override + explicitly-empty servers in
@@ -2090,21 +2065,70 @@ async def update_settings(
         settings.ssh_allowed_source_networks or []
     )
     _lockdown_newly_enforced = _resulting_lockdown and (not _lockdown_was_on or _scope_changing)
+    _caller_ip = get_trusted_client_ip(request)
+    # The membership test below is ``services.appliance.access.covers``. A
+    # ``_caller_within_scope`` helper used to live in this file and was one of
+    # TWO implementations of the same question (#1013), the other being the Web
+    # UI guard's. They agreed on families and disagreed on the case neither
+    # could read: this one counted an unknown address as COVERED and proceeded,
+    # that one counted it as excluded and warned. The shared one counts it as
+    # not covered, which flips this guard in that case — #1009's reason for the
+    # old direction (a gate blocking on "I could not tell" gets forced past by
+    # reflex) was an argument about frequency, and the frequency is near zero:
+    # ``get_trusted_client_ip`` falls back to the ASGI peer address, which
+    # every real HTTP request has.
+    #
+    # #1013 — the escalation, checked BEFORE the per-door guard because it is
+    # the more serious finding and its message subsumes the other's. The Web
+    # UI half is read from storage: this endpoint cannot change it, which is
+    # exactly why neither guard could see the whole picture before.
+    #
+    # Gated on the same transition as the guard below, and for the same
+    # reason: an operator already in this state who adds an authorized key has
+    # not made it worse, and warning them again teaches the tick.
+    _doors_after = effective_doors(
+        settings,
+        _caller_ip,
+        ssh_lockdown=_resulting_lockdown,
+        ssh_cidrs=list(_resulting_scope),
+    )
+    _console_only = _lockdown_newly_enforced and _doors_after.console_only
+    if _console_only and not body.acknowledge_console_only:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=console_only_detail(_doors_after),
+        )
     if (
         _lockdown_newly_enforced
         and _resulting_scope
-        and not body.ssh_lockdown_force
-        and not _caller_within_scope(request, _resulting_scope)
+        # ``_console_only`` here means the acknowledgement above was given.
+        # Accepting "only the console reaches this fleet" already contains
+        # "my SSH access may close", so a second tick for the smaller
+        # statement would be the reflex-training pattern this guard's own
+        # comment warns about. It cannot widen anything: when the escalation
+        # did not fire, this term is False.
+        and not (body.ssh_lockdown_force or _console_only)
+        and not covers(_caller_ip, _resulting_scope)
     ):
+        # Reaching here proves the Web UI still admits this caller: the
+        # condition above IS "the SSH door would not admit you", and had the
+        # Web UI door not admitted you either, the escalation would already
+        # have raised. So this states the surviving path rather than hedging.
+        _web = _doors_after.web_ui
+        _web_desc = (
+            "restricted to " + ", ".join(_web.allowed_cidrs)
+            if _web.restricted
+            else "not source-restricted"
+        )
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=(
                 "Your own address is not inside the allowed networks, so "
                 "enforcing this restriction may close your SSH access to every "
-                "appliance. The console always recovers it; turning the "
-                "restriction back off here only works if you can still reach "
-                "this UI, which a Web UI source restriction may also be "
-                "limiting. Re-send with ssh_lockdown_force to proceed."
+                "appliance. You would still reach this UI to turn it back off "
+                f"(the Web UI is {_web_desc}), and the appliance console "
+                "recovers it either way. Re-send with ssh_lockdown_force to "
+                "proceed."
             ),
         )
     if _ssh_field_in_request and not validate_lockout_safe(

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -2114,6 +2114,15 @@ async def update_settings(
         # condition above IS "the SSH door would not admit you", and had the
         # Web UI door not admitted you either, the escalation would already
         # have raised. So this states the surviving path rather than hedging.
+        #
+        # This direction is sound in a way the mirror-image sentence on the
+        # firewall path is NOT, and the asymmetry is deliberate: the request
+        # arrived over the Web UI, from this address, just now — so "you can
+        # still reach this UI" is a statement about the very session making
+        # it. Asserting the reverse ("you can still SSH") would need an
+        # assumption about where the operator SSHes from, which #1009 says
+        # explicitly may differ. See SSH_REACHABILITY_CAVEAT in
+        # ``services/appliance/access``.
         _web = _doors_after.web_ui
         _web_desc = (
             "restricted to " + ", ".join(_web.allowed_cidrs)

--- a/backend/app/services/ai/tools/ssh.py
+++ b/backend/app/services/ai/tools/ssh.py
@@ -10,6 +10,14 @@ the SNMP community / syslog CA PEM.
 There is NO ``propose_*`` write tool — SSH config is changed through the
 Appliance → SSH form, same as SNMP / syslog (those writes carry a lockout-
 safety cross-check the form path enforces).
+
+Also home to ``find_remote_access_doors`` (#1013), which reports the SSH
+allow-list together with the Web UI one. Those are two independent settings
+that compose into a console-only lockout, and no tool could see both: the Web
+UI half sits on ``find_web_ui_access``, tagged ``module="appliance.firewall"``,
+so with that module off the copilot cannot see it at all — while the SSH half
+is plain host-config and always visible. It lives here rather than in
+``tools/firewall.py`` so it inherits that always-visible shape.
 """
 
 from __future__ import annotations
@@ -22,6 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.auth import User
 from app.models.settings import PlatformSettings
 from app.services.ai.tools.base import register_tool
+from app.services.appliance.access import effective_doors
 from app.services.appliance.ssh import is_valid_public_key, key_fingerprint
 
 
@@ -97,4 +106,78 @@ async def find_ssh_settings(
         or any(
             is_valid_public_key(str(k.get("public_key") or "")) for k in keys if isinstance(k, dict)
         ),
+    }
+
+
+class FindRemoteAccessDoorsArgs(BaseModel):
+    """No arguments — both restrictions are singleton settings."""
+
+    pass
+
+
+@register_tool(
+    name="find_remote_access_doors",
+    description=(
+        "Return BOTH appliance source restrictions together: the Web UI "
+        "allow-list (web_ui_allowed_cidrs) and the SSH allow-list, with "
+        "whether each is actually in force. Use to answer 'is this fleet at "
+        "risk of a console-only lockout?', 'which networks can reach the "
+        "appliance at all?', 'are both remote doors restricted?'. The two are "
+        "independent settings that compose: when BOTH are restricted, only an "
+        "address inside BOTH lists can reach the fleet remotely, and an "
+        "address in neither is left with the physical/serial console. Whether "
+        "a PARTICULAR address is admitted is not answered here — that depends "
+        "on the source address of the request, which a chat client does not "
+        "have; the Fleet screens compute it live."
+    ),
+    args_model=FindRemoteAccessDoorsArgs,
+    category="admin",
+    # Default enabled (NN #13) — read-only, no secrets, no off-prem calls,
+    # and the composition it reports is the one thing neither existing tool
+    # could show. module=None deliberately: find_web_ui_access is tagged
+    # ``appliance.firewall``, so gating this the same way would hide the SSH
+    # half too — exactly the blindness #1013 is about.
+    default_enabled=True,
+    module=None,
+)
+async def find_remote_access_doors(
+    db: AsyncSession, user: User, args: FindRemoteAccessDoorsArgs
+) -> dict[str, Any]:
+    settings = await db.get(PlatformSettings, 1)
+    # ``caller_ip=None`` is honest rather than a placeholder: there is no
+    # request address here, so every ``admits`` below reflects only whether
+    # the door is restricted at all.
+    report = effective_doors(settings, None)
+    web, ssh = report.web_ui, report.ssh
+    if web.restricted and ssh.restricted:
+        summary = (
+            "Both remote doors are source-restricted — the Web UI to "
+            f"{', '.join(web.allowed_cidrs)} and SSH to "
+            f"{', '.join(ssh.allowed_cidrs)}. Only an address inside both "
+            "lists can reach this fleet remotely; anything else is left with "
+            "the appliance console."
+        )
+    elif web.restricted:
+        summary = (
+            f"The Web UI is restricted to {', '.join(web.allowed_cidrs)}; SSH "
+            "is open from any source, so a wrong Web UI list stays recoverable."
+        )
+    elif ssh.restricted:
+        summary = (
+            f"SSH is restricted to {', '.join(ssh.allowed_cidrs)}; the Web UI "
+            "is open from any source, so a wrong SSH list stays recoverable."
+        )
+    else:
+        summary = "Neither remote door is source-restricted."
+    return {
+        "web_ui": {
+            "restricted": web.restricted,
+            "allowed_cidrs": list(web.allowed_cidrs),
+        },
+        "ssh": {
+            "restricted": ssh.restricted,
+            "allowed_cidrs": list(ssh.allowed_cidrs),
+        },
+        "both_restricted": web.restricted and ssh.restricted,
+        "summary": summary,
     }

--- a/backend/app/services/ai/tools/ssh.py
+++ b/backend/app/services/ai/tools/ssh.py
@@ -27,6 +27,7 @@ from typing import Any
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
 from app.models.settings import PlatformSettings
 from app.services.ai.tools.base import register_tool
@@ -109,6 +110,29 @@ async def find_ssh_settings(
     }
 
 
+def _superadmin_gate(user: User) -> dict[str, Any] | None:
+    """Gate for :func:`find_remote_access_doors` only.
+
+    It reports the Web UI allow-list, and ``find_web_ui_access`` — the only
+    other tool that returns that list — is superadmin-gated. A tool is gated
+    at the level of the most restricted datum it returns, so widening that
+    list to every copilot user as a side effect of joining it to the SSH one
+    would be a real (if quiet) change in who can read it.
+
+    Deliberately NOT applied to ``find_ssh_settings`` above: that shipped
+    ungated by decision (#157) and tightening it is a separate call, not
+    something to fold into a lockout fix.
+    """
+    if not is_effective_superadmin(user):
+        return {
+            "error": (
+                "Appliance source restrictions are restricted to superadmin "
+                "users. Ask your platform admin to run the query."
+            )
+        }
+    return None
+
+
 class FindRemoteAccessDoorsArgs(BaseModel):
     """No arguments — both restrictions are singleton settings."""
 
@@ -143,6 +167,8 @@ class FindRemoteAccessDoorsArgs(BaseModel):
 async def find_remote_access_doors(
     db: AsyncSession, user: User, args: FindRemoteAccessDoorsArgs
 ) -> dict[str, Any]:
+    if (err := _superadmin_gate(user)) is not None:
+        return err
     settings = await db.get(PlatformSettings, 1)
     # ``caller_ip=None`` is honest rather than a placeholder: there is no
     # request address here, so every ``admits`` below reflects only whether

--- a/backend/app/services/appliance/access.py
+++ b/backend/app/services/appliance/access.py
@@ -1,0 +1,225 @@
+"""Which remote doors still admit the operator (#1013).
+
+The appliance has two independent source restrictions, each of which can
+close a way in:
+
+  * the **Web UI** allow-list (``platform_settings.web_ui_allowed_cidrs``,
+    #285 Phase 6) — nftables :80/:443 on every node plus
+    ``loadBalancerSourceRanges`` on the MetalLB VIP;
+  * the **SSH** allow-list (``ssh_allowed_source_networks`` in force only
+    under ``ssh_lockdown``, #1009) — the nft drop-in that scopes the sshd
+    port, once the port-22 floor is retired.
+
+Each shipped with its own anti-lockout guard, and each guard could only see
+its own door. So an operator could pass both, one at a time — scope the Web
+UI to the management network, then scope SSH to the same one — and end up
+reachable through neither, with only the console left. Nothing at any point
+said the other door was also closing, because nothing could.
+
+This module is the thing both write paths call, so they cannot disagree
+about the answer. It is pure: no session, no request, no settings write.
+Callers pass the state that would result from the change they are about to
+make, and get back a per-door verdict plus the one question that matters —
+:attr:`AccessReport.console_only`.
+
+WHAT COUNTS AS A DOOR. Only a *remote* path governed by a source
+restriction. The console is not a door here: it is the floor the escalation
+warns you are being left with. SSH being unusable for a reason other than
+its allow-list (password auth off with no authorized keys) is not modelled
+either, because :func:`app.services.appliance.ssh.validate_lockout_safe`
+refuses that combination outright — it cannot be a resulting state.
+
+THE AMBIGUOUS CASE, AND WHY IT RESOLVES THE WAY IT DOES. Before this module
+the two guards scored an unreadable source address in **opposite**
+directions: the Web UI one counted it as *not covered* (warn), the SSH one
+as *covered* (proceed). Both had a written rationale, and two guards doing
+the same job on the same box disagreeing about the same input is not
+defensible as a pair. :func:`covers` settles it one way — an address we
+cannot read is **not** covered — for three reasons:
+
+  1. The costs are asymmetric. A warning the operator did not need costs a
+     checkbox; a warning they needed and did not get costs a trip to the
+     console, or on a VM with no console at all, a rebuild.
+  2. #1009's argument for the other direction was that a gate blocking on
+     "I could not tell" is one operators force past by reflex. That is an
+     argument about frequency, and the frequency here is near zero:
+     ``get_trusted_client_ip`` falls back to the ASGI peer address, which
+     is populated for every real HTTP request. It is absent only where
+     there is no client at all — which is not a shape in which an operator
+     has a session to be locked out of.
+  3. It makes the conservative choice the *same* choice in both the
+     single-door guards and the console-only escalation, so there is one
+     rule to state rather than three.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+from app.models.settings import PlatformSettings
+
+#: Door identifiers. Stable strings — they reach the API response and the UI.
+WEB_UI = "web_ui"
+SSH = "ssh"
+
+
+def covers(address: str | None, cidrs: Iterable[str]) -> bool:
+    """Is ``address`` inside any of ``cidrs``?
+
+    The ONE implementation of that question (it was two, differing in the
+    ambiguous case — see the module docstring). Everything about the answer
+    is deliberate:
+
+    * A missing or unparseable ``address`` is **not** covered. We cannot
+      confirm the door admits it, and an unconfirmable door is not a door.
+    * A malformed entry in ``cidrs`` is skipped rather than fatal. Both
+      lists are validated on the way in, and a bad entry cannot make the
+      caller covered — failing the whole check on one would turn a stale
+      row into a lockout warning on every save.
+    * Families do not cross: an IPv6 caller is not covered by an IPv4-only
+      list, which is what nftables will do with the same pair.
+    """
+    if not address:
+        return False
+    try:
+        addr = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    for entry in cidrs:
+        try:
+            net = ipaddress.ip_network(str(entry).strip(), strict=False)
+        except (ValueError, TypeError):
+            continue
+        if addr.version == net.version and addr in net:
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class Door:
+    """One remote path, and whether it would still let ``caller_ip`` in."""
+
+    name: str
+    #: Is a source restriction in force for this door right now?
+    restricted: bool
+    #: The networks it is scoped to (empty when unrestricted).
+    allowed_cidrs: tuple[str, ...]
+    #: Would the caller reach it? Always True when unrestricted.
+    admits: bool
+
+
+@dataclass(frozen=True)
+class AccessReport:
+    caller_ip: str | None
+    web_ui: Door
+    ssh: Door
+
+    @property
+    def doors(self) -> tuple[Door, ...]:
+        return (self.web_ui, self.ssh)
+
+    @property
+    def admitting(self) -> tuple[str, ...]:
+        """Names of the doors that would still admit the caller."""
+        return tuple(d.name for d in self.doors if d.admits)
+
+    @property
+    def console_only(self) -> bool:
+        """No remote door would admit the caller — the console is all that
+        is left. This is the single question both write paths escalate on."""
+        return not self.admitting
+
+
+def _door(name: str, cidrs: Sequence[str], caller_ip: str | None) -> Door:
+    # Blank entries are dropped, so a list of nothing but whitespace reads as
+    # unrestricted — which suppresses a warning rather than raising a false
+    # one. Both lists are CIDR-validated on write, so that state is not
+    # reachable through the API; this only keeps the report total.
+    scoped = [str(c).strip() for c in cidrs if str(c).strip()]
+    if not scoped:
+        # Unrestricted. Open to every source, so it admits the caller even
+        # when we could not read the caller's address at all.
+        return Door(name=name, restricted=False, allowed_cidrs=(), admits=True)
+    return Door(
+        name=name,
+        restricted=True,
+        allowed_cidrs=tuple(scoped),
+        admits=covers(caller_ip, scoped),
+    )
+
+
+def effective_doors(
+    settings: PlatformSettings | None,
+    caller_ip: str | None,
+    *,
+    web_ui_cidrs: Sequence[str] | None = None,
+    ssh_lockdown: bool | None = None,
+    ssh_cidrs: Sequence[str] | None = None,
+) -> AccessReport:
+    """Build the door report for ``caller_ip``.
+
+    Each keyword overrides the corresponding stored value, so a write path
+    can ask about the state its request WOULD produce rather than the one on
+    disk. ``None`` means "use what is stored" — unambiguous, because a
+    cleared list is ``[]`` and a cleared flag is ``False``.
+
+    The SSH door mirrors :func:`app.services.appliance.ssh.effective_ssh_scope`:
+    a configured allow-list restricts nothing until ``ssh_lockdown`` is on,
+    and lockdown with an empty list is refused at the PUT, so "restricted"
+    here means exactly "lockdown on AND a non-empty scope".
+    """
+    stored_web = list(settings.web_ui_allowed_cidrs or []) if settings else []
+    stored_lockdown = bool(settings.ssh_lockdown) if settings else False
+    stored_ssh = list(settings.ssh_allowed_source_networks or []) if settings else []
+
+    web = list(web_ui_cidrs) if web_ui_cidrs is not None else stored_web
+    lockdown = stored_lockdown if ssh_lockdown is None else bool(ssh_lockdown)
+    ssh_scope = list(ssh_cidrs) if ssh_cidrs is not None else stored_ssh
+
+    return AccessReport(
+        caller_ip=caller_ip,
+        web_ui=_door(WEB_UI, web, caller_ip),
+        ssh=_door(SSH, ssh_scope if lockdown else [], caller_ip),
+    )
+
+
+#: The 422 an operator sees when the change they are making would leave the
+#: console as the only way in. Deliberately NOT satisfied by either
+#: per-setting override: those acknowledge losing one door while the other
+#: stays open, which is a materially smaller thing to accept, and an
+#: operator may have ticked one for an unrelated reason.
+CONSOLE_ONLY_DETAIL = (
+    "Refusing to close the last remote way in. After this change neither the "
+    "Web UI source restriction nor the SSH source restriction would admit "
+    "your address ({caller}), so the appliance console would be the only way "
+    "to reach this fleet — and a VM with no console attached would need a "
+    "rebuild. Web UI allows {web}; SSH allows {ssh}. Add your network to one "
+    "of them, or re-send with acknowledge_console_only=true."
+)
+
+
+def console_only_detail(report: AccessReport) -> str:
+    """Render :data:`CONSOLE_ONLY_DETAIL` for ``report``.
+
+    Both write paths raise the SAME text, because it describes one state of
+    the appliance rather than one setting — an operator who meets it from
+    the SSH screen and an operator who meets it from the firewall screen are
+    being told about the same two lists.
+    """
+
+    def _fmt(door: Door) -> str:
+        # A door that is not restricted always admits, so a console-only
+        # report has both doors restricted and this arm is unreachable from
+        # the escalation path. It exists so the renderer stays total for a
+        # caller that formats a report for some other reason.
+        if not door.restricted:
+            return "any source"
+        return ", ".join(door.allowed_cidrs)
+
+    return CONSOLE_ONLY_DETAIL.format(
+        caller=report.caller_ip or "unknown",
+        web=_fmt(report.web_ui),
+        ssh=_fmt(report.ssh),
+    )

--- a/backend/app/services/appliance/access.py
+++ b/backend/app/services/appliance/access.py
@@ -192,11 +192,33 @@ def effective_doors(
 #: operator may have ticked one for an unrelated reason.
 CONSOLE_ONLY_DETAIL = (
     "Refusing to close the last remote way in. After this change neither the "
-    "Web UI source restriction nor the SSH source restriction would admit "
-    "your address ({caller}), so the appliance console would be the only way "
-    "to reach this fleet — and a VM with no console attached would need a "
+    "Web UI source restriction nor the SSH source restriction would admit the "
+    "address you are connecting from ({caller}). Unless you can reach one of "
+    "those networks another way, the appliance console becomes the only way "
+    "into this fleet — and a VM with no console attached would need a "
     "rebuild. Web UI allows {web}; SSH allows {ssh}. Add your network to one "
     "of them, or re-send with acknowledge_console_only=true."
+)
+
+#: What these guards can and cannot honestly assert.
+#:
+#: Every verdict here is about ONE address: the source of the HTTP request
+#: being made. That is exactly the right address for the Web UI door — the
+#: operator is using it, over that door, right now — and it is only a PROXY
+#: for the SSH door, because browsing from one network and SSHing from
+#: another is legitimate (#1009 says so where it justifies the per-door
+#: warning being advisory rather than a refusal).
+#:
+#: So the copy is asymmetric on purpose. A message may state that the SSH
+#: list *includes the address you are connecting from* — a fact — but not
+#: that you will therefore be able to SSH, which needs an assumption about
+#: where you SSH from. Going the other way, "you can still reach this UI" is
+#: sound and is stated plainly. The escalation names the address and the
+#: assumption rather than asserting the consequence outright, which keeps it
+#: honest without softening it: it fires on the cautious side either way,
+#: since it is an acknowledgeable warning and not a refusal.
+SSH_REACHABILITY_CAVEAT = (
+    "which includes the address you are connecting from now (you may SSH " "from elsewhere)"
 )
 
 

--- a/backend/tests/test_appliance_access_doors.py
+++ b/backend/tests/test_appliance_access_doors.py
@@ -41,16 +41,26 @@ def _reset_module_cache():
     invalidate_cache()
 
 
-async def _admin(db: AsyncSession, ip: str | None = None) -> dict:
+async def _user(db: AsyncSession, *, superadmin: bool = True) -> User:
     u = User(
         username=f"u-{uuid.uuid4().hex[:8]}",
         email=f"{uuid.uuid4().hex[:8]}@x.com",
         display_name="T",
         hashed_password=hash_password("x"),
-        is_superadmin=True,
+        is_superadmin=superadmin,
     )
     db.add(u)
     await db.flush()
+    # ``is_effective_superadmin`` falls through to the RBAC wildcard for a
+    # non-superadmin and touches ``user.groups``, which lazy-loads — and a
+    # lazy load inside an async call raises MissingGreenlet rather than
+    # returning False, so the gate would look broken instead of denying.
+    await db.refresh(u, ["groups"])
+    return u
+
+
+async def _admin(db: AsyncSession, ip: str | None = None) -> dict:
+    u = await _user(db)
     h = {"Authorization": f"Bearer {create_access_token(str(u.id))}"}
     if ip:
         h["X-Real-IP"] = ip
@@ -586,7 +596,8 @@ async def test_the_copilot_tool_reports_both_lists_together(
     )
     await db_session.flush()
 
-    out = await find_remote_access_doors(db_session, None, FindRemoteAccessDoorsArgs())
+    admin = await _user(db_session)
+    out = await find_remote_access_doors(db_session, admin, FindRemoteAccessDoorsArgs())
     assert out["both_restricted"] is True
     assert out["web_ui"]["allowed_cidrs"] == ["10.0.0.0/8"]
     assert out["ssh"]["allowed_cidrs"] == ["192.168.0.0/24"]
@@ -614,8 +625,86 @@ async def test_the_copilot_tool_reports_a_configured_but_unenforced_ssh_list(
     )
     await db_session.flush()
 
-    out = await find_remote_access_doors(db_session, None, FindRemoteAccessDoorsArgs())
+    admin = await _user(db_session)
+    out = await find_remote_access_doors(db_session, admin, FindRemoteAccessDoorsArgs())
     assert out["both_restricted"] is False
     assert out["ssh"]["restricted"] is False
     assert out["ssh"]["allowed_cidrs"] == []
     assert "recoverable" in out["summary"]
+
+
+@pytest.mark.asyncio
+async def test_the_copilot_tool_is_superadmin_gated(db_session: AsyncSession) -> None:
+    """It reports the Web UI allow-list, and ``find_web_ui_access`` — the only
+    other tool returning that list — is superadmin-gated. Joining it to the
+    SSH one must not widen who can read it."""
+    from app.services.ai.tools.ssh import (  # noqa: PLC0415
+        FindRemoteAccessDoorsArgs,
+        find_remote_access_doors,
+    )
+
+    db_session.add(PlatformSettings(id=1, web_ui_allowed_cidrs=["10.0.0.0/8"]))
+    plain = await _user(db_session, superadmin=False)
+    await db_session.flush()
+
+    out = await find_remote_access_doors(db_session, plain, FindRemoteAccessDoorsArgs())
+    assert "error" in out
+    assert "web_ui" not in out
+
+
+# ── what the refusals may honestly assert ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_per_door_refusal_states_the_ssh_list_not_ssh_reachability(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """Every verdict here is about ONE address — the source of this HTTP
+    request. That is the right address for the Web UI door and only a PROXY
+    for the SSH door, since browsing from one network and SSHing from another
+    is legitimate (#1009 says so where it makes the per-door warning advisory
+    rather than a refusal). So the message may state that the SSH list
+    includes this address; it may not promise the operator can SSH.
+    """
+    from app.services.appliance.access import SSH_REACHABILITY_CAVEAT  # noqa: PLC0415
+
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(
+        PlatformSettings(
+            id=1,
+            ssh_allowed_source_networks=["203.0.113.0/24"],
+            ssh_lockdown=True,
+        )
+    )
+    await db_session.commit()
+
+    r = await client.put(f"{FW}/web-ui-access", headers=h, json={"allowed_cidrs": ["10.0.0.0/8"]})
+    assert r.status_code == 422, r.text
+    detail = r.json()["detail"]
+    assert "203.0.113.0/24" in detail
+    assert SSH_REACHABILITY_CAVEAT in detail
+
+
+@pytest.mark.asyncio
+async def test_the_escalation_names_the_address_and_its_assumption(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """Same discipline the other way: the escalation is a warning, not a
+    refusal, so it errs cautious — but it says which address it judged and
+    that reaching those networks another way would change the answer, rather
+    than asserting the consequence outright."""
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(
+        PlatformSettings(
+            id=1,
+            ssh_allowed_source_networks=["10.0.0.0/8"],
+            ssh_lockdown=True,
+        )
+    )
+    await db_session.commit()
+
+    r = await client.put(f"{FW}/web-ui-access", headers=h, json={"allowed_cidrs": ["10.0.0.0/8"]})
+    assert r.status_code == 422, r.text
+    detail = r.json()["detail"]
+    assert "203.0.113.9" in detail
+    assert "another way" in detail

--- a/backend/tests/test_appliance_access_doors.py
+++ b/backend/tests/test_appliance_access_doors.py
@@ -1,0 +1,621 @@
+"""Cross-setting lockout guard (#1013).
+
+Two independent source restrictions — the Web UI allow-list (#285 Phase 6)
+and the SSH allow-list (#1009) — each shipped with an anti-lockout guard that
+could only see its own door. So an operator could pass both, one at a time,
+and end up reachable through neither. These tests pin the escalation that
+now sees both, the acknowledgement it demands, and the fail direction the two
+guards had been disagreeing about.
+
+The ASGI transport reports the caller as 127.0.0.1; sending ``X-Real-IP``
+overrides that, which is also what discriminates the trusted client-IP helper
+from the spoofable one.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.feature_module import FeatureModule
+from app.models.settings import PlatformSettings
+from app.services.appliance.access import SSH, WEB_UI, covers, effective_doors
+from app.services.feature_modules import invalidate_cache
+
+FW = "/api/v1/appliance/firewall"
+SETTINGS = "/api/v1/settings"
+
+#: A valid ed25519 public key, so an SSH save can carry an unrelated edit.
+_PUBKEY = "ssh-ed25519 " "AAAAC3NzaC1lZDI1NTE5AAAAIAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4f test"
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_cache():
+    invalidate_cache()
+    yield
+    invalidate_cache()
+
+
+async def _admin(db: AsyncSession, ip: str | None = None) -> dict:
+    u = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@x.com",
+        display_name="T",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(u)
+    await db.flush()
+    h = {"Authorization": f"Bearer {create_access_token(str(u.id))}"}
+    if ip:
+        h["X-Real-IP"] = ip
+    return h
+
+
+# ── the primitive ───────────────────────────────────────────────────
+
+
+def test_an_address_we_cannot_read_is_not_covered() -> None:
+    """The direction the two guards used to disagree about.
+
+    Web UI counted an unreadable address as excluded (warn); SSH counted it
+    as covered (proceed). One rule now, and it is the conservative one: a
+    door we cannot confirm admits you is not a door.
+    """
+    assert covers(None, ["10.0.0.0/8"]) is False
+    assert covers("", ["10.0.0.0/8"]) is False
+    assert covers("not-an-ip", ["10.0.0.0/8"]) is False
+
+
+def test_families_do_not_cross() -> None:
+    """What nftables will do with the same pair."""
+    assert covers("2001:db8::1", ["10.0.0.0/8"]) is False
+    assert covers("10.1.2.3", ["2001:db8::/32"]) is False
+    assert covers("2001:db8::1", ["2001:db8::/32"]) is True
+
+
+def test_a_malformed_entry_is_skipped_not_fatal() -> None:
+    """A bad entry cannot make the caller covered, so failing the whole
+    check on one would turn a stale row into a warning on every save."""
+    assert covers("10.1.2.3", ["nonsense", "10.0.0.0/8"]) is True
+    assert covers("10.1.2.3", ["nonsense"]) is False
+
+
+def test_an_unrestricted_door_admits_even_an_unreadable_caller() -> None:
+    """Open means open. The conservative reading of an unknown address
+    applies to membership of a list, not to the absence of one."""
+    report = effective_doors(None, None)
+    assert report.web_ui.admits and not report.web_ui.restricted
+    assert report.ssh.admits and not report.ssh.restricted
+    assert report.console_only is False
+
+
+# ── the resolver ────────────────────────────────────────────────────
+
+
+def test_ssh_is_unrestricted_until_lockdown_is_on() -> None:
+    """Mirrors ``effective_ssh_scope``: a configured allow-list restricts
+    nothing until the flag turns it into enforcement."""
+    cfg = PlatformSettings(id=1, ssh_allowed_source_networks=["10.0.0.0/8"], ssh_lockdown=False)
+    report = effective_doors(cfg, "203.0.113.9")
+    assert report.ssh.restricted is False
+    assert report.ssh.admits is True
+    assert report.console_only is False
+
+
+def test_console_only_needs_both_doors_shut() -> None:
+    cfg = PlatformSettings(
+        id=1,
+        web_ui_allowed_cidrs=["10.0.0.0/8"],
+        ssh_allowed_source_networks=["10.0.0.0/8"],
+        ssh_lockdown=True,
+    )
+    inside = effective_doors(cfg, "10.1.2.3")
+    assert inside.admitting == (WEB_UI, SSH)
+    assert inside.console_only is False
+
+    outside = effective_doors(cfg, "203.0.113.9")
+    assert outside.admitting == ()
+    assert outside.console_only is True
+
+
+def test_one_door_open_is_not_console_only() -> None:
+    cfg = PlatformSettings(
+        id=1,
+        web_ui_allowed_cidrs=["203.0.113.0/24"],
+        ssh_allowed_source_networks=["10.0.0.0/8"],
+        ssh_lockdown=True,
+    )
+    report = effective_doors(cfg, "203.0.113.9")
+    assert report.admitting == (WEB_UI,)
+    assert report.console_only is False
+
+
+def test_overrides_describe_the_resulting_state_not_the_stored_one() -> None:
+    """What makes one resolver usable from both write paths."""
+    cfg = PlatformSettings(id=1, web_ui_allowed_cidrs=[], ssh_lockdown=False)
+    assert effective_doors(cfg, "203.0.113.9").console_only is False
+    after = effective_doors(
+        cfg,
+        "203.0.113.9",
+        web_ui_cidrs=["10.0.0.0/8"],
+        ssh_lockdown=True,
+        ssh_cidrs=["10.0.0.0/8"],
+    )
+    assert after.console_only is True
+    # …and the stored row is untouched by asking.
+    assert cfg.web_ui_allowed_cidrs == []
+
+
+# ── the SSH write path ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ssh_lockdown_that_closes_the_last_door_is_escalated(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(PlatformSettings(id=1, web_ui_allowed_cidrs=["10.0.0.0/8"]))
+    await db_session.commit()
+
+    r = await client.put(
+        SETTINGS,
+        headers=h,
+        json={"ssh_lockdown": True, "ssh_allowed_source_networks": ["10.0.0.0/8"]},
+    )
+    assert r.status_code == 422, r.text
+    assert "last remote way in" in r.text
+    assert "acknowledge_console_only" in r.text
+    row = await db_session.get(PlatformSettings, 1)
+    await db_session.refresh(row)
+    assert row.ssh_lockdown is not True
+
+
+@pytest.mark.asyncio
+async def test_the_per_door_override_does_not_satisfy_the_escalation(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """The whole point of a second acknowledgement: ``ssh_lockdown_force``
+    accepts losing SSH while another door remains, which is a materially
+    smaller statement and may have been sent for an unrelated reason."""
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(PlatformSettings(id=1, web_ui_allowed_cidrs=["10.0.0.0/8"]))
+    await db_session.commit()
+
+    r = await client.put(
+        SETTINGS,
+        headers=h,
+        json={
+            "ssh_lockdown": True,
+            "ssh_allowed_source_networks": ["10.0.0.0/8"],
+            "ssh_lockdown_force": True,
+        },
+    )
+    assert r.status_code == 422, r.text
+    assert "last remote way in" in r.text
+
+
+@pytest.mark.asyncio
+async def test_the_escalation_acknowledgement_implies_the_smaller_one(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """Accepting "the console is my only way in" already contains "my SSH
+    access closes", so demanding a second tick would teach the tick."""
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(PlatformSettings(id=1, web_ui_allowed_cidrs=["10.0.0.0/8"]))
+    await db_session.commit()
+
+    r = await client.put(
+        SETTINGS,
+        headers=h,
+        json={
+            "ssh_lockdown": True,
+            "ssh_allowed_source_networks": ["10.0.0.0/8"],
+            "acknowledge_console_only": True,
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["ssh_lockdown"] is True
+
+
+@pytest.mark.asyncio
+async def test_the_acknowledgement_is_never_written_as_a_column(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(PlatformSettings(id=1, web_ui_allowed_cidrs=["10.0.0.0/8"]))
+    await db_session.commit()
+
+    r = await client.put(
+        SETTINGS,
+        headers=h,
+        json={
+            "ssh_lockdown": True,
+            "ssh_allowed_source_networks": ["10.0.0.0/8"],
+            "acknowledge_console_only": True,
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert "acknowledge_console_only" not in r.json()
+    row = await db_session.get(PlatformSettings, 1)
+    assert not hasattr(row, "acknowledge_console_only")
+
+
+@pytest.mark.asyncio
+async def test_no_escalation_while_the_web_ui_still_admits_you(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """The per-door guard still fires — one door is closing — but the
+    escalation must not, and the smaller tick must still be enough."""
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(PlatformSettings(id=1, web_ui_allowed_cidrs=["203.0.113.0/24"]))
+    await db_session.commit()
+
+    r = await client.put(
+        SETTINGS,
+        headers=h,
+        json={"ssh_lockdown": True, "ssh_allowed_source_networks": ["10.0.0.0/8"]},
+    )
+    assert r.status_code == 422, r.text
+    assert "last remote way in" not in r.text
+    assert "not inside the allowed networks" in r.text
+    # …and it names the door that survives rather than hedging about it.
+    assert "203.0.113.0/24" in r.text
+
+    forced = await client.put(
+        SETTINGS,
+        headers=h,
+        json={
+            "ssh_lockdown": True,
+            "ssh_allowed_source_networks": ["10.0.0.0/8"],
+            "ssh_lockdown_force": True,
+        },
+    )
+    assert forced.status_code == 200, forced.text
+
+
+@pytest.mark.asyncio
+async def test_an_unrelated_ssh_edit_while_already_locked_out_does_not_escalate(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """Gated on the transition, like the guard it sits above. An operator
+    already in this state who adds an authorized key has not made it worse,
+    and warning them again is how a tick stops being read."""
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(
+        PlatformSettings(
+            id=1,
+            web_ui_allowed_cidrs=["10.0.0.0/8"],
+            ssh_allowed_source_networks=["10.0.0.0/8"],
+            ssh_lockdown=True,
+        )
+    )
+    await db_session.commit()
+
+    r = await client.put(
+        SETTINGS,
+        headers=h,
+        json={"ssh_authorized_keys": [{"name": "k", "public_key": _PUBKEY}]},
+    )
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.asyncio
+async def test_turning_lockdown_off_never_escalates(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """The recovery path. Refusing it because the caller is outside the
+    scope they are removing would be exactly backwards."""
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(
+        PlatformSettings(
+            id=1,
+            web_ui_allowed_cidrs=["10.0.0.0/8"],
+            ssh_allowed_source_networks=["10.0.0.0/8"],
+            ssh_lockdown=True,
+        )
+    )
+    await db_session.commit()
+
+    r = await client.put(SETTINGS, headers=h, json={"ssh_lockdown": False})
+    assert r.status_code == 200, r.text
+    assert r.json()["ssh_lockdown"] is False
+
+
+# ── the Web UI write path ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_web_ui_restriction_that_closes_the_last_door_is_escalated(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(
+        PlatformSettings(id=1, ssh_allowed_source_networks=["10.0.0.0/8"], ssh_lockdown=True)
+    )
+    await db_session.commit()
+
+    r = await client.put(f"{FW}/web-ui-access", headers=h, json={"allowed_cidrs": ["10.0.0.0/8"]})
+    assert r.status_code == 422, r.text
+    assert "last remote way in" in r.json()["detail"]
+    cfg = await db_session.get(PlatformSettings, 1)
+    await db_session.refresh(cfg)
+    assert not cfg.web_ui_allowed_cidrs
+
+
+@pytest.mark.asyncio
+async def test_web_ui_override_lockout_does_not_satisfy_the_escalation(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(
+        PlatformSettings(id=1, ssh_allowed_source_networks=["10.0.0.0/8"], ssh_lockdown=True)
+    )
+    await db_session.commit()
+
+    r = await client.put(
+        f"{FW}/web-ui-access",
+        headers=h,
+        json={"allowed_cidrs": ["10.0.0.0/8"], "override_lockout": True},
+    )
+    assert r.status_code == 422, r.text
+    assert "last remote way in" in r.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_web_ui_escalation_acknowledgement_is_enough_on_its_own(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(
+        PlatformSettings(id=1, ssh_allowed_source_networks=["10.0.0.0/8"], ssh_lockdown=True)
+    )
+    await db_session.commit()
+
+    r = await client.put(
+        f"{FW}/web-ui-access",
+        headers=h,
+        json={"allowed_cidrs": ["10.0.0.0/8"], "acknowledge_console_only": True},
+    )
+    assert r.status_code == 200, r.text
+    cfg = await db_session.get(PlatformSettings, 1)
+    await db_session.refresh(cfg)
+    assert cfg.web_ui_allowed_cidrs == ["10.0.0.0/8"]
+
+
+@pytest.mark.asyncio
+async def test_reopening_the_web_ui_never_escalates(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(
+        PlatformSettings(
+            id=1,
+            web_ui_allowed_cidrs=["10.0.0.0/8"],
+            ssh_allowed_source_networks=["10.0.0.0/8"],
+            ssh_lockdown=True,
+        )
+    )
+    await db_session.commit()
+
+    r = await client.put(f"{FW}/web-ui-access", headers=h, json={"allowed_cidrs": []})
+    assert r.status_code == 200, r.text
+    assert r.json()["open"] is True
+
+
+# ── the address the guard judges ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_web_ui_guard_judges_the_trusted_address(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """It used to read ``client_ip``, which ``core/request_meta`` documents
+    as spoofable and unsuitable for a source-IP allowlist gate. It is also
+    simply the WRONG address behind a reverse proxy: uvicorn's
+    ``--forwarded-allow-ips *`` resolves the browser's own IP out of
+    X-Forwarded-For while nftables judges the packet source, which is the
+    proxy — so the guard would clear an operator about to be locked out.
+
+    Discriminating because the test transport's peer is 127.0.0.1: judging
+    the peer would call this covered, judging ``X-Real-IP`` does not.
+    """
+    h = await _admin(db_session, ip="203.0.113.9")
+    await db_session.commit()
+
+    r = await client.put(f"{FW}/web-ui-access", headers=h, json={"allowed_cidrs": ["127.0.0.0/8"]})
+    assert r.status_code == 422, r.text
+    assert "203.0.113.9" in r.json()["detail"]
+
+    # …and the other direction: a list covering the trusted address passes
+    # even though it excludes the peer.
+    ok = await client.put(
+        f"{FW}/web-ui-access", headers=h, json={"allowed_cidrs": ["203.0.113.0/24"]}
+    )
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["caller_ip"] == "203.0.113.9"
+    assert ok.json()["caller_covered"] is True
+
+
+# ── the read surface both screens share ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_remote_access_reports_both_doors(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """One shape read by BOTH lockout-sensitive screens, so the warning an
+    operator reads and the refusal they hit cannot disagree."""
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(
+        PlatformSettings(
+            id=1,
+            web_ui_allowed_cidrs=["203.0.113.0/24"],
+            ssh_allowed_source_networks=["10.0.0.0/8"],
+            ssh_lockdown=True,
+        )
+    )
+    await db_session.commit()
+
+    j = (await client.get("/api/v1/appliance/remote-access", headers=h)).json()
+    assert j["caller_ip"] == "203.0.113.9"
+    assert j["web_ui"] == {
+        "name": WEB_UI,
+        "restricted": True,
+        "allowed_cidrs": ["203.0.113.0/24"],
+        "admits": True,
+    }
+    assert j["ssh"]["restricted"] is True and j["ssh"]["admits"] is False
+    assert j["console_only"] is False
+
+
+@pytest.mark.asyncio
+async def test_remote_access_is_reachable_with_the_firewall_module_off(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """It lives on the always-mounted ``/appliance`` hub rather than under
+    ``/appliance/firewall``, because the SSH screen must be able to ask this
+    question when the ``appliance.firewall`` module is off."""
+    h = await _admin(db_session)
+    db_session.add(FeatureModule(id="appliance.firewall", enabled=False))
+    await db_session.commit()
+    invalidate_cache()
+
+    # The gate really is off…
+    blocked = await client.get(f"{FW}/web-ui-access", headers=h)
+    assert blocked.status_code == 404, blocked.text
+    # …and this still answers.
+    r = await client.get("/api/v1/appliance/remote-access", headers=h)
+    assert r.status_code == 200, r.text
+
+
+# ── the marker both UIs route on ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_each_refusal_names_its_own_acknowledgement_and_no_other(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """Both surfaces route a 422 by the acknowledgement FIELD it names, not
+    by its prose — a field name is the API contract and the sentence around
+    it is not. That only works if the markers are mutually exclusive, so it
+    is pinned here rather than left as a property of three English sentences
+    edited at different times.
+    """
+    h = await _admin(db_session, ip="203.0.113.9")
+    db_session.add(PlatformSettings(id=1))
+    await db_session.commit()
+
+    # Web UI, one door closing (SSH unrestricted).
+    per_door = await client.put(
+        f"{FW}/web-ui-access", headers=h, json={"allowed_cidrs": ["10.0.0.0/8"]}
+    )
+    assert per_door.status_code == 422
+    detail = per_door.json()["detail"]
+    assert "override_lockout" in detail
+    assert "acknowledge_console_only" not in detail
+
+    # SSH, one door closing (Web UI unrestricted).
+    ssh_per_door = await client.put(
+        SETTINGS,
+        headers=h,
+        json={"ssh_lockdown": True, "ssh_allowed_source_networks": ["10.0.0.0/8"]},
+    )
+    assert ssh_per_door.status_code == 422
+    ssh_detail = ssh_per_door.json()["detail"]
+    assert "ssh_lockdown_force" in ssh_detail
+    assert "acknowledge_console_only" not in ssh_detail
+
+    # …and the escalation, from BOTH paths, is the same text.
+    row = await db_session.get(PlatformSettings, 1)
+    row.web_ui_allowed_cidrs = ["10.0.0.0/8"]
+    await db_session.commit()
+    escalated = await client.put(
+        SETTINGS,
+        headers=h,
+        json={"ssh_lockdown": True, "ssh_allowed_source_networks": ["10.0.0.0/8"]},
+    )
+    assert escalated.status_code == 422
+    esc_detail = escalated.json()["detail"]
+    assert "acknowledge_console_only" in esc_detail
+    assert "override_lockout" not in esc_detail
+    assert "ssh_lockdown_force" not in esc_detail
+
+    row = await db_session.get(PlatformSettings, 1)
+    row.web_ui_allowed_cidrs = []
+    row.ssh_allowed_source_networks = ["10.0.0.0/8"]
+    row.ssh_lockdown = True
+    await db_session.commit()
+    from_firewall = await client.put(
+        f"{FW}/web-ui-access", headers=h, json={"allowed_cidrs": ["10.0.0.0/8"]}
+    )
+    assert from_firewall.status_code == 422
+    # One state of the appliance, so one sentence about it — an operator who
+    # meets it from either screen is being told about the same two lists.
+    assert from_firewall.json()["detail"] == esc_detail
+
+
+# ── the copilot's view ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_copilot_tool_reports_both_lists_together(
+    db_session: AsyncSession,
+) -> None:
+    """Neither existing tool could see the composition: ``find_web_ui_access``
+    is tagged ``module="appliance.firewall"`` and ``find_ssh_settings`` is
+    not, so with that module off the copilot could see one door and not the
+    other — the blindness this issue is about, in the chat surface."""
+    from app.services.ai.tools.ssh import (  # noqa: PLC0415
+        FindRemoteAccessDoorsArgs,
+        find_remote_access_doors,
+    )
+
+    db_session.add(
+        PlatformSettings(
+            id=1,
+            web_ui_allowed_cidrs=["10.0.0.0/8"],
+            ssh_allowed_source_networks=["192.168.0.0/24"],
+            ssh_lockdown=True,
+        )
+    )
+    await db_session.flush()
+
+    out = await find_remote_access_doors(db_session, None, FindRemoteAccessDoorsArgs())
+    assert out["both_restricted"] is True
+    assert out["web_ui"]["allowed_cidrs"] == ["10.0.0.0/8"]
+    assert out["ssh"]["allowed_cidrs"] == ["192.168.0.0/24"]
+    assert "console" in out["summary"]
+
+
+@pytest.mark.asyncio
+async def test_the_copilot_tool_reports_a_configured_but_unenforced_ssh_list(
+    db_session: AsyncSession,
+) -> None:
+    """``ssh_lockdown`` off means the list restricts nothing, so reporting it
+    as a restriction would tell the operator a door is shut that is open."""
+    from app.services.ai.tools.ssh import (  # noqa: PLC0415
+        FindRemoteAccessDoorsArgs,
+        find_remote_access_doors,
+    )
+
+    db_session.add(
+        PlatformSettings(
+            id=1,
+            web_ui_allowed_cidrs=["10.0.0.0/8"],
+            ssh_allowed_source_networks=["192.168.0.0/24"],
+            ssh_lockdown=False,
+        )
+    )
+    await db_session.flush()
+
+    out = await find_remote_access_doors(db_session, None, FindRemoteAccessDoorsArgs())
+    assert out["both_restricted"] is False
+    assert out["ssh"]["restricted"] is False
+    assert out["ssh"]["allowed_cidrs"] == []
+    assert "recoverable" in out["summary"]

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -942,8 +942,51 @@ Since [#1009](https://github.com/spatiumddi/spatiumddi/issues/1009) that SSH
 half is a default-on floor rather than a guarantee: **the two lockdowns
 compose.** An operator who scopes the Web UI *and* turns on `ssh_lockdown` with
 a scope that excludes them has closed both doors, and the console is what
-remains. Neither setting can see the other, so neither warns about the
-combination — each guards only its own.
+remains.
+
+### The cross-setting guard (#1013)
+
+Each guard used to see only its own door, so both could be passed one at a
+time and neither would mention the other. Both write paths now resolve the
+same question through `backend/app/services/appliance/access.py`: **after this
+change, does any remote door still admit the address I am talking to?**
+
+* When the answer is yes, nothing changes — each per-door guard behaves as it
+  did, and its 422 now *names* the surviving path instead of hedging about it
+  (reaching that refusal proves one door survives, so it can be stated).
+* When the answer is no, both paths raise the **same** 422 — one state of the
+  appliance, so one sentence about it — requiring
+  `acknowledge_console_only=true`. Deliberately **not** satisfied by
+  `override_lockout` / `ssh_lockdown_force`: those accept losing one door
+  while another remains, which is a materially smaller thing, and an operator
+  may have sent one for an unrelated reason. The implication runs the other
+  way only — accepting console-only already contains "this door closes on
+  me", so it is not asked for twice.
+
+Both screens also read `GET /appliance/remote-access` and show the *other*
+door's state at the point of decision. It sits on the always-mounted
+`/appliance` hub rather than under `/appliance/firewall`, because the SSH
+screen must be able to ask with the `appliance.firewall` module off.
+
+**An address we cannot read is not covered.** The two guards used to score
+that case in opposite directions — the Web UI one warned, the SSH one
+proceeded — which is not defensible as a pair. One rule now, and it is the
+conservative one: the costs are asymmetric (an unneeded warning costs a
+checkbox; a missing one costs a trip to the console), and #1009's argument for
+the other direction was about how often a gate that blocks on "I could not
+tell" gets forced past by reflex — a frequency claim, and the frequency is
+near zero, since the trusted client-IP helper falls back to the peer address
+that every real HTTP request has. The Web UI guard was additionally reading
+the **spoofable** helper, which behind a reverse proxy resolves the browser's
+own address out of `X-Forwarded-For` while nftables judges the packet source;
+it now reads the same trusted value the SSH guard does.
+
+**The console is the floor, and it is not universal.** `spatium-console` runs
+on `tty1` and `ttyS0`, and the installer's Done screen assumes one of them.
+A remote VM with no virtual serial port and no console access through its
+hypervisor has **no** floor: for that shape, an acknowledged console-only
+lockout is a rebuild, which is why the escalation says so in as many words
+rather than describing the console as a recovery path.
 
 ---
 

--- a/docs/design/FLEET_FIREWALL.md
+++ b/docs/design/FLEET_FIREWALL.md
@@ -412,6 +412,19 @@ A new top-level **Firewall** surface under the Fleet sidebar **Services** group 
 > the operator turns lockdown on. The belt-and-braces of line 266 survives in
 > the form that matters — a node whose drop-in never rendered still has the
 > baked sentinel.
+>
+> **What retiring the floor cost, and what paid for it —
+> [#1013](https://github.com/spatiumddi/spatiumddi/issues/1013).** §6.1's
+> LAN-wide floor is named in the risk register (R1, and by implication
+> everything below it) as the mitigation for *other* firewall mistakes,
+> including a bad Web-UI scope from #285 Phase 6. Making it retireable removed
+> that backstop for the one combination where both restrictions exclude the
+> operator, and the two settings' guards could not see each other. Both write
+> paths now resolve one shared question — after this change, does any remote
+> door still admit the caller? — and escalate to a distinct 422 with its own
+> acknowledgement when the answer is no. This section's guarantee therefore
+> holds in the form the register relied on for every install that has not
+> deliberately opted out of it *twice*, in writing.
 
 **6.1 Un-removable management floor.** SSH/22 + ICMP v4/v6 + loopback are emitted **first**, outside any operator-controllable block, AND baked in the base conf (`ssh-floor`). No policy, no `firewall_extra`, no `default_action=drop` can remove them. `compile_firewall` **asserts** the body contains an SSH accept and refuses to ship a body lacking it (returns last-good / floor-only + logs). The write-time lint additionally **rejects any rule whose resolved port atoms include 22 with `action=drop`** so an operator can't even author a self-lockout. `firewall_mgmt_lockdown` is honoured only when `firewall_mgmt_cidrs` is non-empty AND yields a non-empty `ip saddr {…} tcp dport 22 accept`; the backend 422s `lockdown=true` with empty `mgmt_cidrs`. The base-conf floor stays LAN-wide regardless — the irreducible recovery channel.
 

--- a/frontend/src/components/SSHSection.test.tsx
+++ b/frontend/src/components/SSHSection.test.tsx
@@ -38,8 +38,10 @@ vi.mock("@/lib/api", async () => {
  *  rendering rather than blanking it. */
 let doors: unknown;
 
+const invalidateQueries = vi.fn();
+
 vi.mock("@tanstack/react-query", () => ({
-  useQueryClient: () => ({ setQueryData: vi.fn() }),
+  useQueryClient: () => ({ setQueryData: vi.fn(), invalidateQueries }),
   useQuery: () => ({ data: doors }),
   useMutation: ({ mutationFn, onSuccess, onError }: never) => {
     const fn = mutationFn as (p: unknown) => Promise<unknown>;
@@ -67,8 +69,10 @@ function axios422(detail: string) {
 
 const LOCKOUT_DETAIL =
   "Your own address is not inside the allowed networks, so enforcing this " +
-  "restriction may close your SSH access to every appliance. Re-send with " +
-  "ssh_lockdown_force to proceed.";
+  "restriction may close your SSH access to every appliance. You would " +
+  "still reach this UI to turn it back off (the Web UI is not " +
+  "source-restricted), and the appliance console recovers it either way. " +
+  "Re-send with ssh_lockdown_force to proceed.";
 
 /** The #1013 escalation's detail, as ``console_only_detail`` renders it.
  *  Note it does NOT contain "not inside the allowed networks" — routing on
@@ -76,9 +80,10 @@ const LOCKOUT_DETAIL =
  *  wrong modal, whose tick the server then refuses. */
 const CONSOLE_ONLY_DETAIL =
   "Refusing to close the last remote way in. After this change neither the " +
-  "Web UI source restriction nor the SSH source restriction would admit your " +
-  "address (203.0.113.9), so the appliance console would be the only way to " +
-  "reach this fleet — and a VM with no console attached would need a " +
+  "Web UI source restriction nor the SSH source restriction would admit the " +
+  "address you are connecting from (203.0.113.9). Unless you can reach one " +
+  "of those networks another way, the appliance console becomes the only " +
+  "way into this fleet — and a VM with no console attached would need a " +
   "rebuild. Web UI allows 10.0.0.0/8; SSH allows 10.0.0.0/8. Add your " +
   "network to one of them, or re-send with acknowledge_console_only=true.";
 
@@ -358,5 +363,30 @@ describe("the other door (#1013)", () => {
     const first = update.mock.calls[0][0];
     const second = update.mock.calls[1][0];
     expect(second).toEqual({ ...first, acknowledge_console_only: true });
+  });
+});
+
+describe("keeping the other screen honest", () => {
+  it("invalidates the door report after a successful save", async () => {
+    // The report is derived from BOTH settings, so an SSH save makes it
+    // stale. Left cached, the Firewall tab keeps rendering "the SSH
+    // allow-list does not exclude this address" after lockdown was just
+    // enabled against a scope that excludes the operator — the exact false
+    // assurance this guard exists to remove.
+    update.mockResolvedValueOnce(
+      values({
+        ssh_allowed_source_networks: ["10.0.0.0/8"],
+        ssh_lockdown: true,
+      }),
+    );
+    const { enforce } = setup({ ssh_allowed_source_networks: ["10.0.0.0/8"] });
+    fireEvent.click(enforce);
+    fireEvent.click(screen.getByRole("button", { name: /save ssh settings/i }));
+
+    await waitFor(() =>
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["appliance", "remote-access"],
+      }),
+    );
   });
 });

--- a/frontend/src/components/SSHSection.test.tsx
+++ b/frontend/src/components/SSHSection.test.tsx
@@ -32,8 +32,15 @@ vi.mock("@/lib/api", async () => {
   };
 });
 
+/** What ``applianceApi.getRemoteAccess`` resolves to for a given test. Set
+ *  before render; ``undefined`` models the report being unreadable (a 403 on
+ *  a deploy where the caller lacks appliance-read), which must leave the form
+ *  rendering rather than blanking it. */
+let doors: unknown;
+
 vi.mock("@tanstack/react-query", () => ({
   useQueryClient: () => ({ setQueryData: vi.fn() }),
+  useQuery: () => ({ data: doors }),
   useMutation: ({ mutationFn, onSuccess, onError }: never) => {
     const fn = mutationFn as (p: unknown) => Promise<unknown>;
     return {
@@ -62,6 +69,32 @@ const LOCKOUT_DETAIL =
   "Your own address is not inside the allowed networks, so enforcing this " +
   "restriction may close your SSH access to every appliance. Re-send with " +
   "ssh_lockdown_force to proceed.";
+
+/** The #1013 escalation's detail, as ``console_only_detail`` renders it.
+ *  Note it does NOT contain "not inside the allowed networks" — routing on
+ *  prose rather than on the acknowledgement field would send this one to the
+ *  wrong modal, whose tick the server then refuses. */
+const CONSOLE_ONLY_DETAIL =
+  "Refusing to close the last remote way in. After this change neither the " +
+  "Web UI source restriction nor the SSH source restriction would admit your " +
+  "address (203.0.113.9), so the appliance console would be the only way to " +
+  "reach this fleet — and a VM with no console attached would need a " +
+  "rebuild. Web UI allows 10.0.0.0/8; SSH allows 10.0.0.0/8. Add your " +
+  "network to one of them, or re-send with acknowledge_console_only=true.";
+
+function report(over: { webUiAdmits?: boolean } = {}) {
+  return {
+    caller_ip: "203.0.113.9",
+    web_ui: {
+      name: "web_ui",
+      restricted: true,
+      allowed_cidrs: ["10.0.0.0/8"],
+      admits: over.webUiAdmits ?? false,
+    },
+    ssh: { name: "ssh", restricted: false, allowed_cidrs: [], admits: true },
+    console_only: false,
+  };
+}
 
 function values(over: Partial<PlatformSettings> = {}): PlatformSettings {
   return {
@@ -98,6 +131,7 @@ function setup(over: Partial<PlatformSettings> = {}) {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  doors = undefined;
 });
 
 describe("the enforcement toggle", () => {
@@ -202,5 +236,127 @@ describe("the self-lockout acknowledgement", () => {
     expect(
       screen.queryByRole("button", { name: /enforce anyway/i }),
     ).toBeNull();
+  });
+});
+
+describe("the other door (#1013)", () => {
+  async function saveFrom(over: Partial<PlatformSettings>) {
+    const { enforce } = setup(over);
+    fireEvent.click(enforce);
+    fireEvent.click(screen.getByRole("button", { name: /save ssh settings/i }));
+  }
+
+  it("warns at the point of decision when the Web UI already excludes you", () => {
+    doors = report();
+    setup({ ssh_allowed_source_networks: ["10.0.0.0/8"] });
+    expect(screen.getByText(/also/i)).toBeTruthy();
+    expect(screen.getByText(/only way in/i, { exact: false })).toBeTruthy();
+  });
+
+  it("says nothing when the Web UI still admits you", () => {
+    doors = report({ webUiAdmits: true });
+    setup({ ssh_allowed_source_networks: ["10.0.0.0/8"] });
+    expect(screen.queryByText(/only way in/i)).toBeNull();
+  });
+
+  it("renders normally when the door report cannot be read", () => {
+    // A 403 (no appliance-read) or a non-appliance deploy must leave the
+    // form usable rather than blanking the panel.
+    doors = undefined;
+    const { enforce } = setup({ ssh_allowed_source_networks: ["10.0.0.0/8"] });
+    expect(enforce.disabled).toBe(false);
+    expect(screen.queryByText(/only way in/i)).toBeNull();
+  });
+
+  it("routes the escalation to its OWN modal, not the per-door one", async () => {
+    // Both 422s arrive as the same status with a different sentence. Routing
+    // on prose would open the lockout modal here, whose tick sends
+    // ssh_lockdown_force — which the server refuses for this case, so the
+    // operator would meet the same refusal again with no way past it.
+    update.mockRejectedValueOnce(axios422(CONSOLE_ONLY_DETAIL));
+    await saveFrom({ ssh_allowed_source_networks: ["10.0.0.0/8"] });
+
+    await screen.findByText(/last remote way in/i);
+    expect(
+      screen.getByRole("button", { name: /close the last remote door/i }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /enforce anyway/i }),
+    ).toBeNull();
+  });
+
+  it("re-sends with the escalation acknowledgement, and only that one", async () => {
+    update.mockRejectedValueOnce(axios422(CONSOLE_ONLY_DETAIL));
+    update.mockResolvedValueOnce(
+      values({
+        ssh_allowed_source_networks: ["10.0.0.0/8"],
+        ssh_lockdown: true,
+      }),
+    );
+    await saveFrom({ ssh_allowed_source_networks: ["10.0.0.0/8"] });
+    await screen.findByText(/last remote way in/i);
+
+    fireEvent.click(
+      screen.getByLabelText(
+        /only the appliance console will reach this fleet/i,
+      ),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /close the last remote door/i }),
+    );
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(2));
+    expect(update.mock.calls[1][0].acknowledge_console_only).toBe(true);
+    // The smaller tick is NOT sent along: the server does not accept it for
+    // this case, and sending both would hide that if it ever changed.
+    expect(update.mock.calls[1][0].ssh_lockdown_force).toBeUndefined();
+  });
+
+  it("never latches the escalation acknowledgement onto a later save", async () => {
+    update.mockRejectedValueOnce(axios422(CONSOLE_ONLY_DETAIL));
+    update.mockRejectedValueOnce(axios422("something else entirely"));
+    await saveFrom({ ssh_allowed_source_networks: ["10.0.0.0/8"] });
+    await screen.findByText(/last remote way in/i);
+    fireEvent.click(
+      screen.getByLabelText(
+        /only the appliance console will reach this fleet/i,
+      ),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /close the last remote door/i }),
+    );
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(2));
+
+    update.mockResolvedValueOnce(values());
+    fireEvent.click(screen.getByRole("button", { name: /save ssh settings/i }));
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(3));
+    expect(update.mock.calls[2][0].acknowledge_console_only).toBeUndefined();
+  });
+
+  it("still carries every settings field on the escalation re-send", async () => {
+    // The payload was written out once per acknowledgement path; a third
+    // copy is how a field lands on Save and goes missing on the path that
+    // only runs after a warning.
+    update.mockRejectedValueOnce(axios422(CONSOLE_ONLY_DETAIL));
+    update.mockResolvedValueOnce(values());
+    await saveFrom({
+      ssh_allowed_source_networks: ["10.0.0.0/8"],
+      ssh_port: 2222,
+      ssh_allow_root_login: true,
+    });
+    await screen.findByText(/last remote way in/i);
+    fireEvent.click(
+      screen.getByLabelText(
+        /only the appliance console will reach this fleet/i,
+      ),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /close the last remote door/i }),
+    );
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(2));
+
+    const first = update.mock.calls[0][0];
+    const second = update.mock.calls[1][0];
+    expect(second).toEqual({ ...first, acknowledge_console_only: true });
   });
 });

--- a/frontend/src/components/SSHSection.tsx
+++ b/frontend/src/components/SSHSection.tsx
@@ -148,6 +148,13 @@ export function SSHSection({
     mutationFn: (patch: Partial<PlatformSettings>) => settingsApi.update(patch),
     onSuccess: (updated) => {
       qc.setQueryData(["settings"], updated);
+      // #1013 — the door report is derived from BOTH settings, so an SSH
+      // save makes it stale. Without this the Firewall tab keeps rendering
+      // a cached "SSH still admits you" advisory after lockdown was just
+      // enabled against a scope that excludes the operator — the exact
+      // false assurance this guard exists to remove. The Web UI card
+      // invalidates the same key for the mirror-image reason.
+      qc.invalidateQueries({ queryKey: ["appliance", "remote-access"] });
       setKeys((updated.ssh_authorized_keys || []).map((k) => ({ ...k })));
       setPasswordAuth(updated.ssh_password_auth_enabled);
       setAllowRoot(updated.ssh_allow_root_login);
@@ -528,10 +535,11 @@ export function SSHSection({
               The Web UI is <span className="font-medium">also</span>{" "}
               source-restricted &mdash; to{" "}
               <code>{doors.web_ui.allowed_cidrs.join(", ")}</code>, which does
-              not cover your address (
+              not cover the address you are connecting from (
               <code>{doors.caller_ip ?? "unknown"}</code>). Enforcing an SSH
-              scope that excludes you as well would leave the appliance console
-              as the only way in. Change it under Fleet &rarr; Firewall &rarr;
+              scope that excludes that address as well leaves the appliance
+              console as the only way in, unless you can reach one of those
+              networks another way. Change it under Fleet &rarr; Firewall &rarr;
               Web UI access, or add your network to the list above.
             </span>
           </div>

--- a/frontend/src/components/SSHSection.tsx
+++ b/frontend/src/components/SSHSection.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, Plus, Trash2 } from "lucide-react";
 
 import {
+  applianceApi,
   formatApiError,
   settingsApi,
   type PlatformSettings,
@@ -124,6 +125,24 @@ export function SSHSection({
   const [saveErr, setSaveErr] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<number | null>(null);
   const [confirmLockout, setConfirmLockout] = useState<string | null>(null);
+  const [confirmConsoleOnly, setConfirmConsoleOnly] = useState<string | null>(
+    null,
+  );
+
+  // #1013 — the OTHER door. Enforcing the SSH restriction is only a
+  // console-only lockout when the Web UI allow-list also excludes you, and
+  // this screen could not see that. ``retry: false`` because the answer is
+  // an advisory panel: a deploy where the caller lacks appliance-read (or
+  // has no appliance at all) should render the form, not retry a 403.
+  const { data: doors } = useQuery({
+    queryKey: ["appliance", "remote-access"],
+    queryFn: applianceApi.getRemoteAccess,
+    retry: false,
+    staleTime: 30_000,
+  });
+  const webUiExcludesMe = Boolean(
+    doors && doors.web_ui.restricted && !doors.web_ui.admits,
+  );
 
   const mutation = useMutation({
     mutationFn: (patch: Partial<PlatformSettings>) => settingsApi.update(patch),
@@ -145,10 +164,21 @@ export function SSHSection({
       // detail, so matching on it below would never fire and the
       // acknowledgement would be unreachable from the UI entirely.
       const msg = formatApiError(err, "Failed to save");
-      // The self-lockout pre-flight is a question, not a failure — surface
-      // it as a confirmation the operator can accept, with the server's own
-      // wording rather than a paraphrase that could drift from it.
-      if (msg.includes("not inside the allowed networks")) {
+      // Both self-lockout pre-flights are questions, not failures — surface
+      // each as a confirmation the operator can accept, carrying the
+      // server's own wording rather than a paraphrase that could drift.
+      //
+      // Routed on the ACKNOWLEDGEMENT FIELD each 422 names, not on its
+      // prose: the field name is the API contract and the sentence around
+      // it is not. The console-only escalation (#1013) is checked first
+      // because it is the stricter of the two and its own tick is the one
+      // the server will accept.
+      if (msg.includes("acknowledge_console_only")) {
+        setConfirmConsoleOnly(msg);
+        setSaveErr(null);
+        return;
+      }
+      if (msg.includes("ssh_lockdown_force")) {
         setConfirmLockout(msg);
         setSaveErr(null);
         return;
@@ -157,8 +187,15 @@ export function SSHSection({
     },
   });
 
-  function handleSave() {
-    const patch: Partial<PlatformSettings> = {
+  // ONE builder for the save payload. It was written out twice — once here
+  // and once in the confirm modal's re-send — which is two chances for a
+  // field added to one to be missing from the other, on the path that only
+  // runs after a lockout warning. A third acknowledgement (#1013) made that
+  // three copies, so it became a function.
+  function buildPatch(
+    extra?: Partial<PlatformSettings>,
+  ): Partial<PlatformSettings> {
+    return {
       ssh_authorized_keys: keys.map((k) => ({
         name: k.name.trim(),
         public_key: k.public_key.trim(),
@@ -169,14 +206,18 @@ export function SSHSection({
       ssh_port: port,
       ssh_allowed_source_networks: sources.map((s) => s.trim()).filter(Boolean),
       ssh_lockdown: lockdown,
+      ...extra,
     };
+  }
+
+  function handleSave() {
     // No acknowledgement here, ever. The server refuses turning enforcement
-    // on from an address the allowlist does not cover; the ONLY path that
-    // sends ``ssh_lockdown_force`` is the confirm modal's own re-send, so
-    // each forced save is one the operator has just read and accepted. A
-    // remembered flag would latch on a save that failed for some other
-    // reason and silently force every later one.
-    mutation.mutate(patch);
+    // on from an address the allowlist does not cover; the ONLY paths that
+    // send ``ssh_lockdown_force`` / ``acknowledge_console_only`` are the
+    // confirm modals' own re-sends, so each forced save is one the operator
+    // has just read and accepted. A remembered flag would latch on a save
+    // that failed for some other reason and silently force every later one.
+    mutation.mutate(buildPatch());
   }
 
   function addKey() {
@@ -476,6 +517,25 @@ export function SSHSection({
               : "Add at least one network above first — enforcing an empty list would close SSH from everywhere."}
           </div>
         )}
+        {/* #1013 — the other door, shown at the point of decision. Both
+            restrictions are independent and each screen used to see only its
+            own, so an operator could close them one at a time and meet the
+            consequence at neither. */}
+        {doors && webUiExcludesMe && (
+          <div className="mt-2 flex items-start gap-2 rounded-md border border-rose-500/40 bg-rose-500/5 p-2 text-xs">
+            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-rose-600 dark:text-rose-400" />
+            <span>
+              The Web UI is <span className="font-medium">also</span>{" "}
+              source-restricted &mdash; to{" "}
+              <code>{doors.web_ui.allowed_cidrs.join(", ")}</code>, which does
+              not cover your address (
+              <code>{doors.caller_ip ?? "unknown"}</code>). Enforcing an SSH
+              scope that excludes you as well would leave the appliance console
+              as the only way in. Change it under Fleet &rarr; Firewall &rarr;
+              Web UI access, or add your network to the list above.
+            </span>
+          </div>
+        )}
       </div>
 
       <div className="mt-4 flex items-center gap-3 border-t pt-4">
@@ -516,23 +576,28 @@ export function SSHSection({
           setConfirmLockout(null);
           // Re-issue the save with the acknowledgement attached, rather than
           // remembering it and asking the operator to press Save again.
-          mutation.mutate({
-            ssh_authorized_keys: keys.map((k) => ({
-              name: k.name.trim(),
-              public_key: k.public_key.trim(),
-              comment: k.comment.trim(),
-            })),
-            ssh_password_auth_enabled: passwordAuth,
-            ssh_allow_root_login: allowRoot,
-            ssh_port: port,
-            ssh_allowed_source_networks: sources
-              .map((x) => x.trim())
-              .filter(Boolean),
-            ssh_lockdown: lockdown,
-            ssh_lockdown_force: true,
-          });
+          mutation.mutate(buildPatch({ ssh_lockdown_force: true }));
         }}
         onClose={() => setConfirmLockout(null)}
+      />
+
+      {/* #1013 — the escalation. Deliberately its own modal with its own
+          tick rather than a stronger sentence in the one above: what is
+          being accepted is a different, larger thing, and the server will
+          not take the smaller acknowledgement for it either. */}
+      <ConfirmModal
+        open={confirmConsoleOnly !== null}
+        title="Leave the console as the only way in?"
+        tone="destructive"
+        message={confirmConsoleOnly ?? ""}
+        confirmLabel="Close the last remote door"
+        requireCheckboxLabel="I understand only the appliance console will reach this fleet"
+        loading={mutation.isPending}
+        onConfirm={() => {
+          setConfirmConsoleOnly(null);
+          mutation.mutate(buildPatch({ acknowledge_console_only: true }));
+        }}
+        onClose={() => setConfirmConsoleOnly(null)}
       />
     </div>
   );

--- a/frontend/src/components/WebUIAccessCard.test.tsx
+++ b/frontend/src/components/WebUIAccessCard.test.tsx
@@ -58,6 +58,14 @@ vi.mock("@tanstack/react-query", () => ({
       isPending: false,
       isError: state.isError,
       error: state.error,
+      // Modelled, not stubbed: the component calls reset() to clear a stale
+      // refusal when the list changes, and a no-op stub would let the
+      // latching test pass while the real thing still latched.
+      reset: () => {
+        state.isError = false;
+        state.error = null;
+        rerender?.();
+      },
       mutate: () =>
         fn().then(
           (r) => (onSuccess as ((r: unknown) => void) | undefined)?.(r),
@@ -92,16 +100,17 @@ const LOCKOUT_DETAIL =
   "Refusing to restrict the Web UI: your current source IP (203.0.113.9) is " +
   "not covered by the allow-list, so this would lock you out of the very " +
   "session making the change. Add your IP / network to the list, or pass " +
-  "override_lockout=true — you would still reach this fleet over SSH (not " +
-  "source-restricted) and at the appliance console.";
+  "override_lockout=true. SSH is not source-restricted, and the appliance " +
+  "console recovers this either way.";
 
 /** Note it contains NEITHER "lock you out" NOR "override_lockout" — routing
  *  on prose would send this to the wrong tick. */
 const CONSOLE_ONLY_DETAIL =
   "Refusing to close the last remote way in. After this change neither the " +
-  "Web UI source restriction nor the SSH source restriction would admit your " +
-  "address (203.0.113.9), so the appliance console would be the only way to " +
-  "reach this fleet — and a VM with no console attached would need a " +
+  "Web UI source restriction nor the SSH source restriction would admit the " +
+  "address you are connecting from (203.0.113.9). Unless you can reach one " +
+  "of those networks another way, the appliance console becomes the only " +
+  "way into this fleet — and a VM with no console attached would need a " +
   "rebuild. Web UI allows 10.0.0.0/8; SSH allows 10.0.0.0/8. Add your " +
   "network to one of them, or re-send with acknowledge_console_only=true.";
 
@@ -213,5 +222,77 @@ describe("the acknowledgement routing", () => {
       override_lockout: false,
       acknowledge_console_only: true,
     });
+  });
+});
+
+describe("an acknowledgement belongs to the list that earned it", () => {
+  async function acknowledgeThen(edit: () => void) {
+    setWebUIAccess.mockRejectedValueOnce(axios422(CONSOLE_ONLY_DETAIL));
+    openModal();
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "10.0.0.0/8" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    await screen.findByText(/closes the last remote way in/i);
+    fireEvent.click(screen.getByRole("checkbox"));
+    edit();
+  }
+
+  it("drops the escalation tick when the list is retyped", async () => {
+    // Acknowledge for list A, edit to list B, Save: the flag must not carry
+    // over, or list B is applied past a guard the server never evaluated.
+    await acknowledgeThen(() =>
+      fireEvent.change(screen.getByRole("textbox"), {
+        target: { value: "192.168.0.0/16" },
+      }),
+    );
+    setWebUIAccess.mockResolvedValueOnce(access);
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => expect(setWebUIAccess).toHaveBeenCalledTimes(2));
+    expect(setWebUIAccess.mock.calls[1][0]).toEqual({
+      allowed_cidrs: ["192.168.0.0/16"],
+      override_lockout: false,
+      acknowledge_console_only: false,
+    });
+  });
+
+  it("clears the stale refusal with it", async () => {
+    // The warning described list A. Leaving it on screen next to list B
+    // would offer a tick for a state nothing has evaluated.
+    await acknowledgeThen(() =>
+      fireEvent.change(screen.getByRole("textbox"), {
+        target: { value: "192.168.0.0/16" },
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText(/closes the last remote way in/i)).toBeNull(),
+    );
+  });
+
+  it("drops it when the list is cleared with the button", async () => {
+    await acknowledgeThen(() =>
+      fireEvent.click(screen.getByRole("button", { name: /open to all/i })),
+    );
+    setWebUIAccess.mockResolvedValueOnce(access);
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => expect(setWebUIAccess).toHaveBeenCalledTimes(2));
+    expect(setWebUIAccess.mock.calls[1][0].acknowledge_console_only).toBe(
+      false,
+    );
+  });
+
+  it("drops it when Add my IP changes the list", async () => {
+    await acknowledgeThen(() =>
+      fireEvent.click(screen.getByRole("button", { name: /add my ip/i })),
+    );
+    setWebUIAccess.mockResolvedValueOnce(access);
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => expect(setWebUIAccess).toHaveBeenCalledTimes(2));
+    expect(setWebUIAccess.mock.calls[1][0].acknowledge_console_only).toBe(
+      false,
+    );
   });
 });

--- a/frontend/src/components/WebUIAccessCard.test.tsx
+++ b/frontend/src/components/WebUIAccessCard.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Web UI source restriction — the two acknowledgement paths (#285, #1013).
+ *
+ * The failure mode this pins is a modal or a checkbox that never appears:
+ * both 422s arrive as the same status with a different sentence, and if the
+ * component routes on prose rather than on the acknowledgement field each one
+ * names, the operator is offered a tick the server will refuse. `tsc` is
+ * happy either way, and so is a reading of the diff — the identical defect on
+ * the SSH side was found by review, not by the compiler.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+const setWebUIAccess = vi.fn();
+const access = {
+  allowed_cidrs: [] as string[],
+  open: true,
+  caller_ip: "203.0.113.9",
+  caller_covered: true,
+};
+
+vi.mock("@/lib/api", async () => {
+  // The REAL formatApiError: a stub would return whatever err.message the
+  // component read and hide the defect this file exists for.
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    firewallApi: {
+      getWebUIAccess: () => Promise.resolve(access),
+      setWebUIAccess: (b: unknown) => setWebUIAccess(b),
+    },
+    applianceApi: { getRemoteAccess: () => Promise.resolve(doors) },
+  };
+});
+
+/** What the door report resolves to; `undefined` models it being unreadable
+ *  (a 403 on a deploy where the caller lacks appliance-read), which must
+ *  leave the card rendering rather than blanking it. */
+let doors: unknown;
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  useQuery: ({ queryKey }: { queryKey: unknown[] }) => ({
+    data: queryKey[0] === "appliance" ? doors : access,
+  }),
+  useMutation: ({ mutationFn, onSuccess }: never) => {
+    const fn = mutationFn as () => Promise<unknown>;
+    return {
+      isPending: false,
+      isError: state.isError,
+      error: state.error,
+      mutate: () =>
+        fn().then(
+          (r) => (onSuccess as ((r: unknown) => void) | undefined)?.(r),
+          (e) => {
+            state.isError = true;
+            state.error = e;
+            rerender?.();
+          },
+        ),
+    };
+  },
+}));
+
+/** The mutation mock has to survive a re-render to expose isError/error the
+ *  way React Query would, so the state lives outside it. */
+const state: { isError: boolean; error: unknown } = {
+  isError: false,
+  error: null,
+};
+let rerender: (() => void) | undefined;
+
+const { WebUIAccessCard } = await import("./WebUIAccessCard");
+
+function axios422(detail: string) {
+  return Object.assign(new Error("Request failed with status code 422"), {
+    isAxiosError: true,
+    response: { status: 422, data: { detail } },
+  });
+}
+
+const LOCKOUT_DETAIL =
+  "Refusing to restrict the Web UI: your current source IP (203.0.113.9) is " +
+  "not covered by the allow-list, so this would lock you out of the very " +
+  "session making the change. Add your IP / network to the list, or pass " +
+  "override_lockout=true — you would still reach this fleet over SSH (not " +
+  "source-restricted) and at the appliance console.";
+
+/** Note it contains NEITHER "lock you out" NOR "override_lockout" — routing
+ *  on prose would send this to the wrong tick. */
+const CONSOLE_ONLY_DETAIL =
+  "Refusing to close the last remote way in. After this change neither the " +
+  "Web UI source restriction nor the SSH source restriction would admit your " +
+  "address (203.0.113.9), so the appliance console would be the only way to " +
+  "reach this fleet — and a VM with no console attached would need a " +
+  "rebuild. Web UI allows 10.0.0.0/8; SSH allows 10.0.0.0/8. Add your " +
+  "network to one of them, or re-send with acknowledge_console_only=true.";
+
+function report(over: { sshAdmits?: boolean; sshRestricted?: boolean } = {}) {
+  return {
+    caller_ip: "203.0.113.9",
+    web_ui: {
+      name: "web_ui",
+      restricted: false,
+      allowed_cidrs: [],
+      admits: true,
+    },
+    ssh: {
+      name: "ssh",
+      restricted: over.sshRestricted ?? true,
+      allowed_cidrs: ["10.0.0.0/8"],
+      admits: over.sshAdmits ?? false,
+    },
+    console_only: false,
+  };
+}
+
+function openModal() {
+  const { rerender: r } = render(<WebUIAccessCard />);
+  rerender = () => r(<WebUIAccessCard />);
+  fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  doors = undefined;
+  state.isError = false;
+  state.error = null;
+  rerender = undefined;
+});
+
+describe("the other door (#1013)", () => {
+  it("warns in the modal when SSH already excludes you", () => {
+    doors = report();
+    openModal();
+    expect(screen.getByText(/SSH is also source-restricted/i)).toBeTruthy();
+  });
+
+  it("says nothing when SSH still admits you", () => {
+    doors = report({ sshAdmits: true });
+    openModal();
+    expect(screen.queryByText(/SSH is also source-restricted/i)).toBeNull();
+  });
+
+  it("renders normally when the door report cannot be read", () => {
+    doors = undefined;
+    openModal();
+    expect(screen.getByText(/Allowed source ranges/i)).toBeTruthy();
+    expect(screen.queryByText(/SSH is also source-restricted/i)).toBeNull();
+  });
+});
+
+describe("the acknowledgement routing", () => {
+  async function saveWith(detail: string) {
+    setWebUIAccess.mockRejectedValueOnce(axios422(detail));
+    openModal();
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "10.0.0.0/8" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+  }
+
+  it("offers the per-door tick for the per-door 422", async () => {
+    await saveWith(LOCKOUT_DETAIL);
+    await screen.findByText(/cut off this session/i);
+    expect(screen.queryByText(/last remote way in/i)).toBeNull();
+  });
+
+  it("offers the escalation tick for the escalation 422", async () => {
+    await saveWith(CONSOLE_ONLY_DETAIL);
+    await screen.findByText(/closes the last remote way in/i);
+    // …and NOT the smaller one, whose flag the server refuses for this case.
+    expect(screen.queryByText(/cut off this session/i)).toBeNull();
+  });
+
+  it("keeps Save disabled until the escalation is ticked", async () => {
+    await saveWith(CONSOLE_ONLY_DETAIL);
+    await screen.findByText(/closes the last remote way in/i);
+    const save = screen.getByRole("button", {
+      name: /^save$/i,
+    }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    await waitFor(() =>
+      expect(
+        (screen.getByRole("button", { name: /^save$/i }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(false),
+    );
+  });
+
+  it("sends the escalation flag once ticked, and not the smaller one", async () => {
+    await saveWith(CONSOLE_ONLY_DETAIL);
+    await screen.findByText(/closes the last remote way in/i);
+    fireEvent.click(screen.getByRole("checkbox"));
+    setWebUIAccess.mockResolvedValueOnce(access);
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => expect(setWebUIAccess).toHaveBeenCalledTimes(2));
+    expect(setWebUIAccess.mock.calls[1][0]).toEqual({
+      allowed_cidrs: ["10.0.0.0/8"],
+      override_lockout: false,
+      acknowledge_console_only: true,
+    });
+  });
+});

--- a/frontend/src/components/WebUIAccessCard.tsx
+++ b/frontend/src/components/WebUIAccessCard.tsx
@@ -81,8 +81,8 @@ export function WebUIAccessCard() {
                   — not in the allow-list (you reached this page another way).
                   {doors
                     ? sshExcludesMe
-                      ? " SSH is also restricted and excludes you, so only the appliance console reaches this fleet."
-                      : " SSH still admits you, and the appliance console recovers this either way."
+                      ? " SSH is also restricted and excludes this address, so unless you can reach one of those networks another way, only the appliance console reaches this fleet."
+                      : " The SSH allow-list does not exclude this address, and the appliance console recovers this either way."
                     : " The console always recovers this; SSH does too unless the SSH source restriction is also on and excludes you."}
                 </span>
               )}
@@ -170,11 +170,18 @@ function WebUIAccessModal({
   const lockoutError =
     !consoleOnlyError && errText.includes("override_lockout");
   const sshExcludesMe = Boolean(sshDoor?.restricted && !sshDoor.admits);
+  /** Both ticks, and the refusal that asked for them, belong to one list. */
+  const resetAcknowledgements = () => {
+    setOverride(false);
+    setAckConsoleOnly(false);
+    save.reset();
+  };
   const addMyIp = () => {
     if (!current.caller_ip) return;
     const entry =
       current.caller_ip + (current.caller_ip.includes(":") ? "/128" : "/32");
     setText((t) => (t.trim() ? `${t.trim()}\n${entry}` : entry));
+    resetAcknowledgements();
   };
   return (
     <Modal title="Web UI source restriction" onClose={onClose}>
@@ -193,8 +200,9 @@ function WebUIAccessModal({
             <span className="font-medium">SSH is also source-restricted</span> —
             to <code>{sshDoor?.allowed_cidrs.join(", ")}</code>, which does not
             cover <code>{current.caller_ip ?? "your address"}</code>. A list
-            here that excludes you as well would leave the appliance console as
-            the only way in.
+            here that excludes that address as well leaves the appliance console
+            as the only way in, unless you can reach one of those networks
+            another way.
           </p>
         )}
         <label className="block">
@@ -203,7 +211,16 @@ function WebUIAccessModal({
           </span>
           <textarea
             value={text}
-            onChange={(e) => setText(e.target.value)}
+            onChange={(e) => {
+              setText(e.target.value);
+              // #1013 — an acknowledgement belongs to the list that earned
+              // it. Left latched, an operator could accept the escalation
+              // for list A, retype list B, and save it past a guard the
+              // server never got to evaluate. Clearing the error with them
+              // returns the modal to a clean state so the next Save is
+              // judged on what is actually in the box.
+              resetAcknowledgements();
+            }}
             rows={5}
             placeholder={"192.168.0.0/24\n10.0.0.0/8\n2001:db8::/64"}
             className="mt-1 w-full rounded-md border bg-background px-2 py-1.5 font-mono text-xs"
@@ -220,7 +237,10 @@ function WebUIAccessModal({
           </button>
           <button
             type="button"
-            onClick={() => setText("")}
+            onClick={() => {
+              setText("");
+              resetAcknowledgements();
+            }}
             className="rounded-md border px-2.5 py-1 text-xs hover:bg-accent"
           >
             Open to all (clear)
@@ -243,8 +263,8 @@ function WebUIAccessModal({
             <span>
               Your current source IP isn&rsquo;t covered by this list &mdash;
               saving would cut off this session&rsquo;s path to the Web UI. Tick
-              to apply anyway; another remote door still admits you, and the
-              appliance console recovers this either way.
+              to apply anyway; the SSH allow-list does not exclude this address,
+              and the appliance console recovers it either way.
             </span>
           </label>
         )}

--- a/frontend/src/components/WebUIAccessCard.tsx
+++ b/frontend/src/components/WebUIAccessCard.tsx
@@ -1,0 +1,303 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Globe, Loader2, Lock } from "lucide-react";
+
+import {
+  applianceApi,
+  firewallApi,
+  formatApiError,
+  type FirewallWebUIAccess,
+  type RemoteDoor,
+} from "@/lib/api";
+import { Modal } from "@/components/ui/modal";
+import { cn } from "@/lib/utils";
+
+/**
+ * Web UI source restriction (#285 Phase 6) + the cross-setting lockout
+ * escalation (#1013).
+ *
+ * Lifted out of ``pages/appliance/FirewallTab.tsx`` so it can be rendered on
+ * its own in a test — the same shape ``SSHSection`` already has, and for the
+ * same reason: this card owns two acknowledgement paths whose failure mode is
+ * that a modal never opens, which neither review nor ``tsc`` can see.
+ */
+export function WebUIAccessCard() {
+  const qc = useQueryClient();
+  const { data: w } = useQuery({
+    queryKey: ["firewall", "web-ui-access"],
+    queryFn: firewallApi.getWebUIAccess,
+  });
+  // #1013 — the OTHER door. Restricting the Web UI is only a console-only
+  // lockout when the SSH allow-list also excludes you, and this screen could
+  // not see that. ``retry: false``: it is an advisory panel, so a 403 should
+  // leave the card rendering rather than retrying.
+  const { data: doors } = useQuery({
+    queryKey: ["appliance", "remote-access"],
+    queryFn: applianceApi.getRemoteAccess,
+    retry: false,
+    staleTime: 30_000,
+  });
+  const [editing, setEditing] = useState(false);
+  if (!w) return null;
+  const excluded = !w.open && !w.caller_covered;
+  const sshExcludesMe = Boolean(
+    doors && doors.ssh.restricted && !doors.ssh.admits,
+  );
+  return (
+    <div
+      className={cn(
+        "rounded-md border p-3",
+        w.open
+          ? "border-border"
+          : excluded
+            ? "border-rose-500/40 bg-rose-500/5"
+            : "border-sky-500/40 bg-sky-500/5",
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-2">
+          {w.open ? (
+            <Globe className="mt-0.5 h-5 w-5 text-muted-foreground" />
+          ) : (
+            <Lock className="mt-0.5 h-5 w-5 text-sky-600 dark:text-sky-400" />
+          )}
+          <div>
+            <div className="text-sm font-medium">
+              Web UI access:{" "}
+              {w.open
+                ? "Open to all"
+                : `Restricted to ${w.allowed_cidrs.length} range${
+                    w.allowed_cidrs.length === 1 ? "" : "s"
+                  }`}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {w.open
+                ? "The Web UI (HTTP/HTTPS) is reachable from any source IP. Restrict it to specific networks to lock it down without an external firewall."
+                : "Only these source ranges reach the Web UI — both each appliance's node IP (nftables :80/:443) and the control-plane VIP (MetalLB)."}{" "}
+              Your IP: <code>{w.caller_ip ?? "unknown"}</code>
+              {excluded && (
+                <span className="font-medium text-rose-600 dark:text-rose-400">
+                  {" "}
+                  — not in the allow-list (you reached this page another way).
+                  {doors
+                    ? sshExcludesMe
+                      ? " SSH is also restricted and excludes you, so only the appliance console reaches this fleet."
+                      : " SSH still admits you, and the appliance console recovers this either way."
+                    : " The console always recovers this; SSH does too unless the SSH source restriction is also on and excludes you."}
+                </span>
+              )}
+            </div>
+            {!w.open && (
+              <div className="mt-2 flex flex-wrap gap-1">
+                {w.allowed_cidrs.map((c) => (
+                  <span
+                    key={c}
+                    className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px]"
+                  >
+                    {c}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="shrink-0">
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Edit…
+          </button>
+        </div>
+      </div>
+      {editing && (
+        <WebUIAccessModal
+          current={w}
+          sshDoor={doors?.ssh}
+          onClose={() => setEditing(false)}
+          onSaved={() => {
+            setEditing(false);
+            qc.invalidateQueries({ queryKey: ["firewall", "web-ui-access"] });
+            // The door report is derived from BOTH settings, so a Web UI
+            // change makes it stale on the SSH screen too.
+            qc.invalidateQueries({ queryKey: ["appliance", "remote-access"] });
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function parseCidrLines(text: string): string[] {
+  return text
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function WebUIAccessModal({
+  current,
+  sshDoor,
+  onClose,
+  onSaved,
+}: {
+  current: FirewallWebUIAccess;
+  /** #1013 — the other door; undefined if the report could not be read. */
+  sshDoor: RemoteDoor | undefined;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [text, setText] = useState(current.allowed_cidrs.join("\n"));
+  const [override, setOverride] = useState(false);
+  const [ackConsoleOnly, setAckConsoleOnly] = useState(false);
+  const save = useMutation({
+    mutationFn: () =>
+      firewallApi.setWebUIAccess({
+        allowed_cidrs: parseCidrLines(text),
+        override_lockout: override,
+        acknowledge_console_only: ackConsoleOnly,
+      }),
+    onSuccess: onSaved,
+  });
+  const cidrs = parseCidrLines(text);
+  const errText = save.isError ? formatApiError(save.error) : "";
+  // Each 422 is routed on the ACKNOWLEDGEMENT FIELD it names, not on its
+  // prose: the field name is the API contract and the sentence around it is
+  // not. Reveal each tick only when the server has asked for it, so the
+  // operator makes an explicit choice rather than pre-arming one.
+  const consoleOnlyError = errText.includes("acknowledge_console_only");
+  const lockoutError =
+    !consoleOnlyError && errText.includes("override_lockout");
+  const sshExcludesMe = Boolean(sshDoor?.restricted && !sshDoor.admits);
+  const addMyIp = () => {
+    if (!current.caller_ip) return;
+    const entry =
+      current.caller_ip + (current.caller_ip.includes(":") ? "/128" : "/32");
+    setText((t) => (t.trim() ? `${t.trim()}\n${entry}` : entry));
+  };
+  return (
+    <Modal title="Web UI source restriction" onClose={onClose}>
+      <div className="space-y-3 text-sm">
+        <p className="text-xs text-muted-foreground">
+          One CIDR (or bare IP) per line — IPv4 and IPv6 both accepted. Leave
+          empty to open the Web UI to everyone. This governs both the per-node
+          HTTP/HTTPS door (nftables) and the control-plane VIP
+          (loadBalancerSourceRanges). A mistake here is always recoverable from
+          the console, and over SSH unless the SSH source restriction (Appliance
+          → Fleet → SSH) also excludes you.
+        </p>
+        {/* #1013 — the other door, at the point of decision. */}
+        {sshExcludesMe && (
+          <p className="rounded-md border border-rose-500/40 bg-rose-500/5 p-2 text-xs">
+            <span className="font-medium">SSH is also source-restricted</span> —
+            to <code>{sshDoor?.allowed_cidrs.join(", ")}</code>, which does not
+            cover <code>{current.caller_ip ?? "your address"}</code>. A list
+            here that excludes you as well would leave the appliance console as
+            the only way in.
+          </p>
+        )}
+        <label className="block">
+          <span className="text-xs text-muted-foreground">
+            Allowed source ranges
+          </span>
+          <textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            rows={5}
+            placeholder={"192.168.0.0/24\n10.0.0.0/8\n2001:db8::/64"}
+            className="mt-1 w-full rounded-md border bg-background px-2 py-1.5 font-mono text-xs"
+          />
+        </label>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={addMyIp}
+            disabled={!current.caller_ip}
+            className="rounded-md border px-2.5 py-1 text-xs hover:bg-accent disabled:opacity-50"
+          >
+            + Add my IP ({current.caller_ip ?? "unknown"})
+          </button>
+          <button
+            type="button"
+            onClick={() => setText("")}
+            className="rounded-md border px-2.5 py-1 text-xs hover:bg-accent"
+          >
+            Open to all (clear)
+          </button>
+        </div>
+        {cidrs.length > 0 && (
+          <p className="text-xs text-muted-foreground">
+            Will restrict the Web UI to {cidrs.length} range
+            {cidrs.length === 1 ? "" : "s"}.
+          </p>
+        )}
+        {lockoutError && (
+          <label className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 p-2 text-xs">
+            <input
+              type="checkbox"
+              checked={override}
+              onChange={(e) => setOverride(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              Your current source IP isn&rsquo;t covered by this list &mdash;
+              saving would cut off this session&rsquo;s path to the Web UI. Tick
+              to apply anyway; another remote door still admits you, and the
+              appliance console recovers this either way.
+            </span>
+          </label>
+        )}
+        {/* The escalation gets its own tick rather than a sterner sentence in
+            the one above: what is being accepted is a larger thing, and the
+            server will not take the smaller acknowledgement for it. */}
+        {consoleOnlyError && (
+          <label className="flex items-start gap-2 rounded-md border border-rose-500/50 bg-rose-500/10 p-2 text-xs">
+            <input
+              type="checkbox"
+              checked={ackConsoleOnly}
+              onChange={(e) => setAckConsoleOnly(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="font-medium">
+                This closes the last remote way in.
+              </span>{" "}
+              Neither this list nor the SSH allow-list would admit your address,
+              so the appliance console becomes the only way to reach this fleet
+              &mdash; and a VM with no console attached would need a rebuild.
+              Tick to apply anyway.
+            </span>
+          </label>
+        )}
+        {save.isError && (
+          <p className="text-xs text-destructive">
+            {formatApiError(save.error)}
+          </p>
+        )}
+        <div className="flex justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={
+              save.isPending ||
+              (lockoutError && !override) ||
+              (consoleOnlyError && !ackConsoleOnly)
+            }
+            onClick={() => save.mutate()}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
+          >
+            {save.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            Save
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3674,6 +3674,8 @@ export interface PlatformSettings {
   /** Write-only acknowledgement for the self-lockout pre-flight —
    *  never returned by the API. */
   ssh_lockdown_force?: boolean;
+  /** Accept losing EVERY remote door, leaving only the console (#1013). */
+  acknowledge_console_only?: boolean;
   /** Appliance DNS resolver (issue #158). No secrets — resolver IPs /
    *  search domains are not sensitive, so read + write shapes match.
    *  ``automatic`` defers to per-link NetworkManager / DHCP DNS;
@@ -10972,8 +10974,38 @@ export interface ApplianceInfo {
   self_appliance: SelfApplianceInfo | null;
 }
 
+/**
+ * One remote way in, and whether it admits the caller (#1013).
+ *
+ * The appliance has two source restrictions — the Web UI allow-list and the
+ * SSH allow-list — and each used to be editable from a screen that could not
+ * see the other, so both could be closed one at a time.
+ */
+export interface RemoteDoor {
+  name: "web_ui" | "ssh";
+  restricted: boolean;
+  allowed_cidrs: string[];
+  admits: boolean;
+}
+
+export interface RemoteAccess {
+  caller_ip: string | null;
+  web_ui: RemoteDoor;
+  ssh: RemoteDoor;
+  /** Neither door admits you — the console is all that is left. */
+  console_only: boolean;
+}
+
 export const applianceApi = {
   getInfo: () => api.get<ApplianceInfo>("/appliance/info").then((r) => r.data),
+  /**
+   * Read by BOTH lockout-sensitive screens (Firewall → Web UI access, and
+   * SSH → source restriction) so each can show the state of the OTHER door.
+   * Lives on the always-mounted hub, not under /appliance/firewall, because
+   * the SSH screen must be able to ask with that module off.
+   */
+  getRemoteAccess: () =>
+    api.get<RemoteAccess>("/appliance/remote-access").then((r) => r.data),
 };
 
 // ── Fleet firewall (issue #285 Phase 3) ──────────────────────────────
@@ -11173,7 +11205,10 @@ export const firewallApi = {
     api.get<FirewallWebUIAccess>(`${_FW}/web-ui-access`).then((r) => r.data),
   setWebUIAccess: (body: {
     allowed_cidrs: string[];
+    /** Accept losing THIS door while another remains open. */
     override_lockout?: boolean;
+    /** Accept losing EVERY remote door, leaving only the console (#1013). */
+    acknowledge_console_only?: boolean;
   }) =>
     api
       .put<FirewallWebUIAccess>(`${_FW}/web-ui-access`, body)

--- a/frontend/src/pages/appliance/FirewallTab.tsx
+++ b/frontend/src/pages/appliance/FirewallTab.tsx
@@ -19,7 +19,6 @@ import {
   AlertTriangle,
   CheckCircle2,
   Eye,
-  Globe,
   Layers,
   Loader2,
   Lock,
@@ -46,10 +45,10 @@ import {
   type FirewallRuleInput,
   type FirewallScopeKind,
   type FirewallSourceKind,
-  type FirewallWebUIAccess,
 } from "@/lib/api";
 import { Modal } from "@/components/ui/modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { WebUIAccessCard } from "@/components/WebUIAccessCard";
 import { useSessionState } from "@/lib/useSessionState";
 import { cn } from "@/lib/utils";
 
@@ -583,221 +582,6 @@ function EnforcementCard() {
 }
 
 // ── Web UI source restriction (Phase 6) ─────────────────────────────
-
-function WebUIAccessCard() {
-  const qc = useQueryClient();
-  const { data: w } = useQuery({
-    queryKey: ["firewall", "web-ui-access"],
-    queryFn: firewallApi.getWebUIAccess,
-  });
-  const [editing, setEditing] = useState(false);
-  if (!w) return null;
-  const excluded = !w.open && !w.caller_covered;
-  return (
-    <div
-      className={cn(
-        "rounded-md border p-3",
-        w.open
-          ? "border-border"
-          : excluded
-            ? "border-rose-500/40 bg-rose-500/5"
-            : "border-sky-500/40 bg-sky-500/5",
-      )}
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex items-start gap-2">
-          {w.open ? (
-            <Globe className="mt-0.5 h-5 w-5 text-muted-foreground" />
-          ) : (
-            <Lock className="mt-0.5 h-5 w-5 text-sky-600 dark:text-sky-400" />
-          )}
-          <div>
-            <div className="text-sm font-medium">
-              Web UI access:{" "}
-              {w.open
-                ? "Open to all"
-                : `Restricted to ${w.allowed_cidrs.length} range${
-                    w.allowed_cidrs.length === 1 ? "" : "s"
-                  }`}
-            </div>
-            <div className="text-xs text-muted-foreground">
-              {w.open
-                ? "The Web UI (HTTP/HTTPS) is reachable from any source IP. Restrict it to specific networks to lock it down without an external firewall."
-                : "Only these source ranges reach the Web UI — both each appliance's node IP (nftables :80/:443) and the control-plane VIP (MetalLB)."}{" "}
-              Your IP: <code>{w.caller_ip ?? "unknown"}</code>
-              {excluded && (
-                <span className="font-medium text-rose-600 dark:text-rose-400">
-                  {" "}
-                  — not in the allow-list (you reached this page another way).
-                  The console always recovers this; SSH does too unless the SSH
-                  source restriction is also on and excludes you.
-                </span>
-              )}
-            </div>
-            {!w.open && (
-              <div className="mt-2 flex flex-wrap gap-1">
-                {w.allowed_cidrs.map((c) => (
-                  <span
-                    key={c}
-                    className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px]"
-                  >
-                    {c}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-        <div className="shrink-0">
-          <button
-            type="button"
-            onClick={() => setEditing(true)}
-            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
-          >
-            Edit…
-          </button>
-        </div>
-      </div>
-      {editing && (
-        <WebUIAccessModal
-          current={w}
-          onClose={() => setEditing(false)}
-          onSaved={() => {
-            setEditing(false);
-            qc.invalidateQueries({ queryKey: ["firewall", "web-ui-access"] });
-          }}
-        />
-      )}
-    </div>
-  );
-}
-
-function parseCidrLines(text: string): string[] {
-  return text
-    .split(/[\s,]+/)
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
-
-function WebUIAccessModal({
-  current,
-  onClose,
-  onSaved,
-}: {
-  current: FirewallWebUIAccess;
-  onClose: () => void;
-  onSaved: () => void;
-}) {
-  const [text, setText] = useState(current.allowed_cidrs.join("\n"));
-  const [override, setOverride] = useState(false);
-  const save = useMutation({
-    mutationFn: () =>
-      firewallApi.setWebUIAccess({
-        allowed_cidrs: parseCidrLines(text),
-        override_lockout: override,
-      }),
-    onSuccess: onSaved,
-  });
-  const cidrs = parseCidrLines(text);
-  // A 422 from the anti-lockout guard reads "lock you out" — reveal the
-  // override toggle only then, so the operator makes an explicit choice.
-  const lockoutError =
-    save.isError && formatApiError(save.error).includes("lock you out");
-  const addMyIp = () => {
-    if (!current.caller_ip) return;
-    const entry =
-      current.caller_ip + (current.caller_ip.includes(":") ? "/128" : "/32");
-    setText((t) => (t.trim() ? `${t.trim()}\n${entry}` : entry));
-  };
-  return (
-    <Modal title="Web UI source restriction" onClose={onClose}>
-      <div className="space-y-3 text-sm">
-        <p className="text-xs text-muted-foreground">
-          One CIDR (or bare IP) per line — IPv4 and IPv6 both accepted. Leave
-          empty to open the Web UI to everyone. This governs both the per-node
-          HTTP/HTTPS door (nftables) and the control-plane VIP
-          (loadBalancerSourceRanges). A mistake here is always recoverable from
-          the console — and over SSH too, unless the SSH source restriction
-          (Appliance → Fleet → SSH) is also on with a scope that excludes you.
-          The two are independent and neither can see the other.
-        </p>
-        <label className="block">
-          <span className="text-xs text-muted-foreground">
-            Allowed source ranges
-          </span>
-          <textarea
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            rows={5}
-            placeholder={"192.168.0.0/24\n10.0.0.0/8\n2001:db8::/64"}
-            className="mt-1 w-full rounded-md border bg-background px-2 py-1.5 font-mono text-xs"
-          />
-        </label>
-        <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            onClick={addMyIp}
-            disabled={!current.caller_ip}
-            className="rounded-md border px-2.5 py-1 text-xs hover:bg-accent disabled:opacity-50"
-          >
-            + Add my IP ({current.caller_ip ?? "unknown"})
-          </button>
-          <button
-            type="button"
-            onClick={() => setText("")}
-            className="rounded-md border px-2.5 py-1 text-xs hover:bg-accent"
-          >
-            Open to all (clear)
-          </button>
-        </div>
-        {cidrs.length > 0 && (
-          <p className="text-xs text-muted-foreground">
-            Will restrict the Web UI to {cidrs.length} range
-            {cidrs.length === 1 ? "" : "s"}.
-          </p>
-        )}
-        {lockoutError && (
-          <label className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 p-2 text-xs">
-            <input
-              type="checkbox"
-              checked={override}
-              onChange={(e) => setOverride(e.target.checked)}
-              className="mt-0.5"
-            />
-            <span>
-              Your current source IP isn't covered by this list — saving would
-              cut off this session's path to the Web UI. Tick to apply anyway
-              (you can still recover over SSH / the console).
-            </span>
-          </label>
-        )}
-        {save.isError && (
-          <p className="text-xs text-destructive">
-            {formatApiError(save.error)}
-          </p>
-        )}
-        <div className="flex justify-end gap-2 pt-1">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            disabled={save.isPending || (lockoutError && !override)}
-            onClick={() => save.mutate()}
-            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
-          >
-            {save.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-            Save
-          </button>
-        </div>
-      </div>
-    </Modal>
-  );
-}
 
 // ── Policies ─────────────────────────────────────────────────────────
 

--- a/scripts/lint_ssh_recovery_claims.py
+++ b/scripts/lint_ssh_recovery_claims.py
@@ -8,9 +8,11 @@ the moment they are deciding whether to restrict something.
 
 ``ssh_lockdown`` made that false in one specific case: it retires the port-22
 floor, so an operator who turns it on with a scope that excludes them, AND has
-also scoped the Web UI, is left with the console. The two settings are
-independent and neither can see the other (#1013), so neither warns — which
-makes this copy the only thing standing between the operator and a surprise.
+also scoped the Web UI, is left with the console. #1013 added a cross-setting
+guard that refuses that combination without an explicit acknowledgement, so the
+operator is no longer only warned by prose — but the prose still has to be
+true. A surface that promises SSH unconditionally contradicts the refusal they
+are about to meet, which is worse than saying nothing.
 
 Correcting those surfaces took four passes, and each one grepped for the
 PREVIOUS phrasing and so missed the next paraphrase:


### PR DESCRIPTION
Closes #1013

## The gap

The appliance has two independent ways in and a source allowlist for each — the Web UI ([#285](https://github.com/spatiumddi/spatiumddi/issues/285) Phase 6) and SSH ([#1009](https://github.com/spatiumddi/spatiumddi/issues/1009)). Each shipped with an anti-lockout guard that checked only whether the caller's address was inside **its own** list, so an operator could pass both, one at a time, and end up reachable through neither.

That is not an exotic sequence. "Lock this box down" means scoping the Web UI to the management network and then scoping SSH to the same one; if that CIDR is stale, both guards fire, both offer an override, and each override is individually reasonable. Nothing at any point said the other door was also closing.

Before #1009 it could not happen — the port-22 floor was un-removable, so SSH was the guaranteed recovery path the Web UI guard leaned on. Making that floor retireable is what the SSH allowlist needed in order to mean anything, and it removed the guarantee.

## The fix

Both write paths resolve one shared question through `backend/app/services/appliance/access.py`: **after this change, does any remote door still admit the address I am talking to?**

- **No** → both raise the *same* 422 (one state of the appliance, so one sentence about it) requiring `acknowledge_console_only=true`. Deliberately **not** satisfied by the per-door `override_lockout` / `ssh_lockdown_force`: those accept losing one door while another remains, and an operator may have ticked one for an unrelated reason. The implication runs one way only, so the smaller tick is never demanded twice.
- **Yes** → each per-door guard behaves as before, and its 422 now names the other list instead of hedging.

Both screens read a new `GET /appliance/remote-access` and show the *other* door at the point of decision. It sits on the always-mounted `/appliance` hub rather than under `/appliance/firewall`, because the SSH screen must be able to ask with that module off.

## The three "worth settling" items

**Fail direction.** Unified on *an address we cannot read is not covered*. The two guards had been scoring that case in opposite directions. The costs are asymmetric — an unneeded warning costs a checkbox, a missing one costs a trip to the console — and #1009's argument for the other direction ("a gate that blocks on *I could not tell* gets forced past by reflex") was a claim about frequency, which is near zero: the trusted client-IP helper falls back to the ASGI peer address every real HTTP request has.

**Two implementations → one.** `_ip_in_cidrs` and `_caller_within_scope` are now `covers()`.

**The console is not universal.** `spatium-console` runs on `tty1` and `ttyS0`. A remote VM with neither has no floor at all, so an acknowledged lockout there is a rebuild — the escalation says that rather than describing the console as a recovery path, and `APPLIANCE.md` now states it.

## Found on the way

The Web UI guard was reading `client_ip`, which `core/request_meta` documents as spoofable and explicitly unsuitable for a source-IP allowlist gate. **No attacker needed:** behind a reverse proxy, uvicorn's `--forwarded-allow-ips *` resolves the browser's own IP out of `X-Forwarded-For` while nftables judges the packet source — the proxy. The guard would clear an operator about to be locked out.

## What the guards may honestly assert

Every verdict is about **one** address: the source of the HTTP request. That is the right address for the Web UI door — the operator is using it, over that door, right now — and only a *proxy* for the SSH door, since browsing from one network and SSHing from another is legitimate (#1009 says so where it makes the per-door warning advisory). So the copy is asymmetric on purpose: "you can still reach this UI" is asserted; the SSH list is reported as *including the address you are connecting from*, not as a promise that SSH will work.

## Verification

- **28 backend tests**, negative-controlled: 11 fail against the unpatched guards, including the trusted-IP one.
- **99 frontend tests** (was 80). 5 of 7 new `SSHSection` tests fail on unpatched code; mutating the routing back to prose-matching fails 3 `WebUIAccessCard` tests; reverting each review fix fails its own 5.
- Both 422s are routed in the UI by the **acknowledgement field** each names, not by prose — a field name is the API contract, the sentence around it is not — and a test pins that the three markers stay mutually exclusive. Every frontend fixture carrying a server message was verified **byte-identical against a live stack**.
- **Walked end-to-end on a live dev stack**, not just asserted: enable SSH lockdown excluding myself → per-door warning naming the Web UI → restrict the Web UI too → escalation → `override_lockout` refused → `acknowledge_console_only` accepted → recovery path needs neither.
- Full gate green: ruff, black, mypy, all four repo linters, plus 121 tests across the adjacent appliance/firewall/settings suites.

`WebUIAccessCard` was lifted out of `FirewallTab.tsx` into its own component so it can be rendered in a test — the failure mode both sides share is a modal or checkbox that never appears, which neither review nor `tsc` can see.

1 MCP tool (`find_remote_access_doors`, read-only, default on, superadmin-gated). The composition is the one thing neither existing tool could show, since `find_web_ui_access` is tagged `module="appliance.firewall"` and `find_ssh_settings` is not — with that module off the copilot saw one door and not the other. No migration, no new column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)