### PR TITLE
fix(docs): remove a stray docs/docs symlink that breaks the Pages build

### DIFF
--- a/docs/docs
+++ b/docs/docs
@@ -1,1 +1,0 @@
-/repo/docs


### PR DESCRIPTION
A one-file deletion. `docs/docs` is a dangling symlink to `/repo/docs` — a path
that only exists inside a build container — and it is currently **breaking the
project docs site**.

## What happened

While trying to run `test_outbound_hosts_documented.py` against a full checkout
(it skips inside the dev api container, which has no `docs/`), I ran:

```
ln -sfn /repo/docs /repo/backend/../docs
```

`/repo/backend/../docs` resolves to `/repo/docs`, which already existed as a
directory — so the link landed *inside* it as `/repo/docs/docs` rather than
beside it. A blind `git add -A` then swept it into #1024.

## The breakage

Jekyll calls `symlink_outside_site_source?` on every entry, which calls
`rb_check_realpath_internal` — and that raises `ENOENT` on a dangling link,
failing the whole build:

```
Error: No such file or directory @ rb_check_realpath_internal
  - /github/workspace/docs/docs
```

`pages build and deployment` has been failing on `main` since #1024 merged.
The **org-root site is unaffected** — `docs-publish.yml` rsyncs rather than
building, and it succeeded — so only the `/spatiumddi/` project site is down
until this lands.

## Scope

Nothing else in #1024 was stray. `git ls-files -s` reports this as the only
non-regular-file entry in the entire tree, and every other file that commit
added is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)