### PR TITLE
chore: track every non-Dependabot version pin in versions.json + bump the ones the sweep found behind (#975)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,12 +82,19 @@ updates:
       - dependency-name: "python"
         update-types:
           ["version-update:semver-minor", "version-update:semver-major"]
-      # Alpine 3.24 bumps the bundled Python 3.12→3.13, which breaks the agent
+      # Alpine 3.24 bumps the bundled Python 3.12→3.14.7, which breaks the agent
       # images: they install spatium_*_agent for 3.12, so on 3.24 the module
       # lands on the wrong Python path -> "ModuleNotFoundError: No module named
       # 'spatium_dns_agent'" -> CrashLoopBackOff (caught by agent-e2e on #672).
-      # Pin the agents to alpine 3.23.x until their Dockerfiles are updated for
-      # 3.13; patch bumps (3.23.x) still flow. The 3.24 move is a deliberate task.
+      # Pin the agents to alpine 3.23.x until their Dockerfiles are updated;
+      # patch bumps (3.23.x) still flow. The 3.24 move is a deliberate task.
+      #
+      # #975 — this comment said "3.12→3.13" until the sweep checked the Alpine
+      # package index: v3.24/main ships python3-3.14.7. That makes the blocker a
+      # 3.12 → 3.14 jump needing every agent's dependencies verified on 3.14,
+      # not the one-minor step the wrong number implied — a materially bigger
+      # task that had been under-scoped for as long as the comment stood.
+      # The full reason lives in versions.json under `alpine`.
       - dependency-name: "alpine"
         update-types:
           ["version-update:semver-minor", "version-update:semver-major"]

--- a/.github/scripts/ci-backend-must-run.txt
+++ b/.github/scripts/ci-backend-must-run.txt
@@ -46,6 +46,14 @@ scripts/export_openapi.py
 # rather than published as the file the next release balances the shards with.
 scripts/merge_test_durations.py
 
+# test_lint_versions.py (#975) loads the version-pin manifest guard and pins
+# its negative cases — a renamed pinned_in path erroring rather than skipping,
+# and an exact occurrence count catching a partial bump. scripts/ is not
+# denied, so the gate would run the suite anyway; the entry exists because the
+# scan test above requires every declared read to be covered here, and a
+# future widening of the deny-list must not silently drop this one.
+scripts/lint_versions.py
+
 # test_zone_name_scope.py (#986) loads the release-prep TLD regenerator and
 # pins that it uses the PRODUCT's payload guard rather than a second copy —
 # so a PR that gives the script its own parser has to run the test that says

--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
         with:
-          version: v3.20.2
+          version: v3.21.4
 
       - name: Create kind cluster
         # #983 — kind and the node image are BOTH pinned, and the node image

--- a/.github/workflows/build-appliance.yml
+++ b/.github/workflows/build-appliance.yml
@@ -149,7 +149,7 @@ jobs:
         # on PATH before the chart-bake step.
         uses: azure/setup-helm@v5
         with:
-          version: v3.20.2
+          version: v3.21.4
       - name: Fetch k3s binary + airgap tarball
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,19 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: python3 scripts/lint_migrations.py
 
+      # #975 — every version pin Dependabot cannot see (Helm's five copies,
+      # chart values.yaml, Dockerfile ARGs, the appliance bake arrays, CI
+      # script defaults, action `with:` inputs) is declared in the root
+      # versions.json, and this asserts the files still agree with it. Without
+      # it those pins drift silently: Dependabot moved the frontend image to
+      # nginx 1.31 on 2026-07-20 (#688) and the appliance chart's copy sat on
+      # 1.30.3 until #975, because only one of the two was Dependabot-visible
+      # and nothing connected them. stdlib-only; runs from repo root, so the
+      # ``working-directory: backend`` default is overridden here.
+      - name: Version-pin manifest linter
+        working-directory: ${{ github.workspace }}
+        run: python3 scripts/lint_versions.py
+
       # Guards the appliance host-side runner scripts (issues #550/#553):
       # every systemd ExecStart runner must be executable in the built
       # image (git +x OR chmod'd in mkosi.postinst) and bash -n clean.
@@ -279,7 +292,7 @@ jobs:
           --health-retries 5
 
       redis:
-        image: redis:8.8-alpine
+        image: redis:8.10.1-alpine
         ports:
           - 6379:6379
         options: >-
@@ -674,7 +687,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
         with:
-          version: v3.20.2
+          version: v3.21.4
 
       - name: Install kubeconform
         run: .github/scripts/install-kubeconform.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,7 +350,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: azure/setup-helm@v5
         with:
-          version: v3.20.2
+          version: v3.21.4
       - name: Log in to GHCR
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" \

--- a/.github/workflows/trivy-scheduled.yml
+++ b/.github/workflows/trivy-scheduled.yml
@@ -1,4 +1,4 @@
-name: Scheduled Image Vulnerability Scan
+name: Scheduled Dependency Health
 
 # Why this exists (issue #640, Gap 2):
 #
@@ -18,6 +18,13 @@ name: Scheduled Image Vulnerability Scan
 # Unlike ``make trivy`` (six agent images — the contributor pre-push gate),
 # this superset also covers ``backend/Dockerfile`` + ``frontend/Dockerfile``,
 # which had no Trivy coverage anywhere.
+#
+# #975 added a second, independent job: ``pin-drift``, which reports version
+# pins that have fallen behind upstream. The two answer different questions —
+# a CVE scan says "this image has a known vulnerability", drift says "this pin
+# is old", and a pin can be years stale with no CVE filed against it. They
+# share this workflow because they share a cadence and a reporting shape, not
+# because either depends on the other; neither job needs the other to run.
 
 on:
   schedule:
@@ -38,7 +45,8 @@ jobs:
   scan:
     name: Trivy — all shipped images
     # Forks inherit this workflow (#830); never run the publisher outside
-    # the canonical repo. (Single-job workflow.)
+    # the canonical repo. Repeated on every job here — a workflow-level guard
+    # does not exist, so each job that can file an issue carries its own.
     if: github.repository_owner == 'spatiumddi'
     runs-on: ubuntu-latest
     steps:
@@ -102,14 +110,28 @@ jobs:
             # CI's exact gate: HIGH,CRITICAL + fix-available only. exit-code 1
             # ⇒ findings, 0 ⇒ clean, ≥2 ⇒ scan error. Table → stdout, logs →
             # stderr (kept out of the report).
-            docker run --rm \
+            # #975 — the ``if`` form is load-bearing, not style. This step
+            # runs under ``bash -e`` (Actions' default shell), which
+            # ``set -uo pipefail`` at the top does NOT clear, so the previous
+            # ``docker run ...`` followed by ``rc=$?`` killed the whole step
+            # the moment Trivy exited 1 — i.e. on the FIRST image with
+            # findings, which is the only case this job exists for. Every
+            # branch below was unreachable, ``has_findings`` was never
+            # written, and the reporting step's fail-safe then left the
+            # tracking issue untouched with a warning. The scan could report
+            # "clean" and could never report a CVE. Commands in an ``if``
+            # condition are exempt from ``-e``; keep this shape.
+            if docker run --rm \
               -v /var/run/docker.sock:/var/run/docker.sock \
               -v "$cache":/root/.cache/ \
               aquasec/trivy:latest image \
               --severity HIGH,CRITICAL --ignore-unfixed --scanners vuln \
               --format table --exit-code 1 -q \
-              "trivy-scan-$name:scan" > "$RUNNER_TEMP/trivy-$name.txt" 2>"$RUNNER_TEMP/trivy-$name.log"
-            rc=$?
+              "trivy-scan-$name:scan" > "$RUNNER_TEMP/trivy-$name.txt" 2>"$RUNNER_TEMP/trivy-$name.log"; then
+              rc=0
+            else
+              rc=$?
+            fi
 
             if [ "$rc" -eq 0 ]; then
               echo "✅ clean"
@@ -244,4 +266,187 @@ jobs:
               core.info(`Closed tracking issue #${open.number} (now clean)`);
             } else {
               core.info('All images clean; no open tracking issue to close.');
+            }
+
+  # ── Version-pin drift (#975) ────────────────────────────────────────────────
+  # The other half of the same problem the scan above solves: the CVE scan
+  # tells us an image has a known vulnerability, this tells us a pin has gone
+  # stale — and the two failure modes are different. A pin can sit years
+  # behind with no CVE against it (kube-rbac-proxy v0.12.0 was a 2022 release)
+  # and nothing anywhere notices, because Dependabot cannot see any of the
+  # pins in versions.json: it has no Helm ecosystem, does not read ARG values,
+  # chart values.yaml, action `with:` inputs or the appliance bake arrays.
+  #
+  # Separate job, not a step on `scan`: this needs no Docker and no image
+  # build, so pinning it to that job's ~20 minutes would be waste, and a
+  # Docker build failure there must not take the drift report down with it.
+  #
+  # Deliberately never fails and never gates anything. `versions.json`'s
+  # `hold` field marks the pins that are behind ON PURPOSE (MetalLB on
+  # metallb#3063, Postgres 16 on #208, the Jekyll plugins on what the
+  # github-pages gem pins), and the report separates those from real drift —
+  # a known hold that reads as a failure every week is how a report stops
+  # being read.
+  pin-drift:
+    name: Version pins — upstream drift
+    if: github.repository_owner == 'spatiumddi'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Resolve every declared upstream
+        id: drift
+        env:
+          # Raises api.github.com's rate limit from 60/hr to 1000/hr. Most
+          # entries resolve through it, so unauthenticated runs would start
+          # reporting "check failed" rather than a version.
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          report="$RUNNER_TEMP/pin-drift.md"
+
+          # The ``if`` form, NOT ``cmd; rc=$?``. Actions runs this with
+          # ``bash -e``, and ``set -uo pipefail`` above does NOT clear that —
+          # so a bare failing command kills the step before any handler runs,
+          # and every line below would be dead code. Commands in an ``if``
+          # condition are exempt from ``-e``; this is the only shape that
+          # reliably captures a non-zero status here. (#975 — the sibling
+          # ``scan`` job had exactly this bug.)
+          if python3 scripts/lint_versions.py --check-upstream \
+               > "$report" 2>"$RUNNER_TEMP/pin-drift.err"; then
+            rc=0
+          else
+            rc=$?
+          fi
+
+          # The script is advisory and exits 0 even when components are behind,
+          # so a non-zero rc here means it could not run at all (an unparseable
+          # manifest, a missing interpreter). That is a real problem with the
+          # guard itself and must not be reported as "no drift" — the #1030
+          # lesson: an empty result and a clean result have to look different.
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::lint_versions.py --check-upstream failed (rc=$rc)"
+            sed 's/^/  /' "$RUNNER_TEMP/pin-drift.err" >&2
+            echo "status=error" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Version-pin drift"
+              echo ""
+              echo "⚠️ The drift check could not run (rc=$rc). See the run log."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Parse the machine-readable line the script prints last:
+          #   RESULT behind=N held=N failed=N total=N
+          #
+          # Reading `failed` is the load-bearing half. The PROSE line above it
+          # starts "0 behind upstream" when every single lookup failed — a
+          # rate-limited token, a GitHub outage, no egress — so a consumer that
+          # scraped only the first number would report the whole fleet current
+          # and CLOSE the drift issue on the one run that knew nothing. Any
+          # component we could not check makes the result indeterminate, which
+          # is a third state, not a clean bill of health.
+          result="$(grep -m1 '^RESULT ' "$report" || true)"
+          behind=""; failed=""
+          for field in $result; do
+            case "$field" in
+              behind=*) behind="${field#behind=}" ;;
+              failed=*) failed="${field#failed=}" ;;
+            esac
+          done
+
+          if [ -z "$behind" ] || [ -z "$failed" ]; then
+            echo "::warning::could not parse the RESULT line from the drift report"
+            echo "status=error" >> "$GITHUB_OUTPUT"
+          elif [ "$failed" -gt 0 ]; then
+            echo "::warning::$failed component(s) could not be checked — result is indeterminate"
+            echo "status=error" >> "$GITHUB_OUTPUT"
+          elif [ "$behind" -gt 0 ]; then
+            echo "status=behind" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=current" >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo "## Version-pin drift (\`versions.json\`)"
+            echo ""
+            cat "$report"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open, update or close the drift tracking issue
+        if: always()
+        uses: actions/github-script@v9
+        env:
+          DRIFT_STATUS: ${{ steps.drift.outputs.status }}
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const today = new Date().toISOString().slice(0, 10);
+
+            // Same fail-safe as the Trivy job: an indeterminate result leaves
+            // any existing issue exactly as it is. Closing on "we could not
+            // tell" would report stale pins as current.
+            const status = process.env.DRIFT_STATUS;
+            if (status !== 'behind' && status !== 'current') {
+              core.warning(
+                `Drift check produced no definitive result (status=${JSON.stringify(status)}); ` +
+                `leaving any tracking issue untouched.`);
+              return;
+            }
+
+            const label = 'dependencies';
+            const title = 'Version pins behind upstream (versions.json)';
+            const marker = '<!-- versions-pin-drift -->';
+
+            const open = (await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: label, per_page: 100,
+            })).data.filter(i => !i.pull_request).find(i => (i.body || '').includes(marker));
+
+            if (status === 'behind') {
+              let table = '(report file missing — see the run log)';
+              const path = `${process.env.RUNNER_TEMP}/pin-drift.md`;
+              if (fs.existsSync(path)) table = fs.readFileSync(path, 'utf8');
+              let body =
+                `${marker}\n\n` +
+                `One or more pins in [\`versions.json\`](../blob/main/versions.json) are ` +
+                `behind upstream. Rows marked 🔒 are held on purpose — their reason is ` +
+                `the \`hold\` field on that component, and they are NOT what this issue ` +
+                `is about.\n\n` +
+                `- Check run: ${runUrl}\n- Last updated: ${today}\n\n` +
+                `${table}\n\n---\n` +
+                `Reproduce locally with \`make versions-upstream\`. Bumping a component ` +
+                `is one edit to \`versions.json\` plus whatever \`make versions-check\` ` +
+                `then reports. This issue auto-closes when every non-held pin is current.`;
+              if (body.length > 60000) body = body.slice(0, 60000) + '\n\n_…truncated._';
+
+              if (open) {
+                await github.rest.issues.update({ owner, repo, issue_number: open.number, body });
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: open.number,
+                  body: `🔁 Still behind as of ${today} — ${runUrl}`,
+                });
+                core.info(`Updated drift issue #${open.number}`);
+              } else {
+                const created = await github.rest.issues.create({
+                  owner, repo, title, labels: [label], body,
+                });
+                core.info(`Opened drift issue #${created.data.number}`);
+              }
+            } else if (open) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: open.number,
+                body: `✅ Every non-held pin is current as of ${today} — ${runUrl}. Closing.`,
+              });
+              await github.rest.issues.update({
+                owner, repo, issue_number: open.number, state: 'closed',
+              });
+              core.info(`Closed drift issue #${open.number} (now current)`);
+            } else {
+              core.info('Every non-held pin is current; no open drift issue to close.');
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -375,9 +375,9 @@ the formatter handles the rest.
   two different versions because only one of its copies was
   Dependabot-visible: the appliance chart's nginx had fallen a
   minor behind the frontend image's, with nothing connecting
-  them. Root `versions.json` now declares all 27, and
+  them. Root `versions.json` now declares all 28, and
   `scripts/lint_versions.py` asserts each still appears in each
-  file that carries it — 86 assertions, run in CI's
+  file that carries it — 89 assertions, run in CI's
   unconditional Backend Lint job and by `make ci`.
   **Bumping is one edit**, because every site's expected string
   is a template over the component's `version` field.
@@ -441,8 +441,8 @@ the formatter handles the rest.
   `jekyll` 4.3.4 → 4.4.1; `haproxy:2.9-alpine`, a short-lived
   non-LTS branch with no release since March 2025, → 3.4. Behind
   upstream: Helm v3.20.2 → v3.21.4 across all five copies,
-  `redis` 8.8 → 8.10.1 across fifteen, the appliance chart's
-  nginx 1.30.3 → 1.31.5, kube-state-metrics v2.18.0 → v2.20.0,
+  `redis` 8.8 → 8.10.1 across every one of them, the appliance
+  chart's nginx 1.30.3 → 1.31.5, kube-state-metrics → v2.20.0,
   node-exporter v1.11.1 → v1.12.1, GoBGP 4.7.0 → 4.9.0
   (`make trivy IMAGE=looking-glass` clean), and the Patroni
   overlay's etcd v3.5.30 → v3.5.33 on all three services. Every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,6 +365,113 @@ the formatter handles the rest.
   trigger table and kept — the Code Quality bot threads are acted
   on.
 
+- **Every version pin Dependabot cannot see now lives in one
+  manifest, and CI fails when a copy drifts (#975).** Dependabot
+  covers four ecosystems here; it has no Helm ecosystem and does
+  not read Dockerfile `ARG` values, chart `values.yaml`, action
+  `with:` inputs, CI script defaults or the appliance bake
+  arrays. Those pins were spread across nine file types, several
+  behind upstream, two past end-of-life, and one component sat on
+  two different versions because only one of its copies was
+  Dependabot-visible: the appliance chart's nginx had fallen a
+  minor behind the frontend image's, with nothing connecting
+  them. Root `versions.json` now declares all 27, and
+  `scripts/lint_versions.py` asserts each still appears in each
+  file that carries it — 86 assertions, run in CI's
+  unconditional Backend Lint job and by `make ci`.
+  **Bumping is one edit**, because every site's expected string
+  is a template over the component's `version` field.
+  **The literals stay in the files rather than being read from
+  the manifest at build time.** A build-time read that yields an
+  empty string is the failure class this repo has hit repeatedly
+  (#1028, #1029, #1030): an action input resolving to `""` falls
+  back to the action's own default — for `azure/setup-helm`,
+  `latest` — with no error anywhere. The lint gives the same
+  single-source guarantee with no new build-time failure mode.
+  **The one Dependabot-owned pin that IS listed is nginx's
+  `FROM`**, deliberately: pairing it with the copies Dependabot
+  cannot see is what turns the next bot bump into a failing lint
+  instead of a silent minor of drift.
+  **`count` is the load-bearing field.** The Patroni overlay runs
+  three etcd services and three Redis containers; a substring
+  check with no count passes a bump that moved two of three and
+  left a mixed-version cluster.
+  A weekly `pin-drift` job in `trivy-scheduled.yml` resolves each
+  declared upstream and files the delta, separating pins that are
+  behind ON PURPOSE from real drift — the `hold` field carries
+  each reason, so a known hold never reads as neglect.
+  `make versions-upstream` runs it locally.
+  **Six defects in the guard itself, found by /code-review before
+  it shipped, and every one of them was the guard failing open.**
+  `--check` — the mode the script's own docstring documents — was
+  not a flag: argparse resolves an unambiguous prefix, so it ran
+  `--check-upstream`, the advisory network mode that always exits
+  0. Following the documentation turned the check off. It is a
+  real flag now and `allow_abbrev=False` stops the next one.
+  An unknown key was silently ignored, so `"counts": 3` left
+  `count` unset and downgraded an exact assertion to "at least
+  one" — a 2-of-3 partial bump passed; unknown keys are refused
+  at every level. The weekly job scraped the first number off a
+  prose line that opens "0 behind upstream" *when every lookup
+  failed*, so a rate-limited run would have reported the fleet
+  current and CLOSED the drift issue; the script now prints a
+  machine-readable `RESULT` line carrying `failed`, and any
+  component that could not be checked makes the verdict
+  indeterminate rather than clean. Technitium is pinned by tag
+  AND digest and only the tag was asserted, so bumping `version`
+  alone passed while the build stayed on the old image — the
+  digest is a manifest field now, asserted offline and resolved
+  against Docker Hub weekly. `ghcr.io/cloudnative-pg/postgresql`
+  was the one bake-array/chart-values pair still unguarded, and
+  the worst one to lose: the appliance never pulls, so a
+  divergence there is ImagePullBackOff on an air-gapped box. And
+  `docs/DEVELOPMENT.md` referred twice to a section that did not
+  exist, now written as §9.
+
+- **The pins the sweep found behind, bumped (#975).** Out of
+  support: `ruby:3.2-slim` (EOL 2026-03-31) → 3.4, and with it
+  `webrick` 1.8.1 → 1.9.2 — 1.8.1 predates the request-smuggling
+  fix in 1.8.2 (CVE-2024-47220) and was the only known-vulnerable
+  web server in the tree, seen by no lockfile and no bot;
+  `jekyll` 4.3.4 → 4.4.1; `haproxy:2.9-alpine`, a short-lived
+  non-LTS branch with no release since March 2025, → 3.4. Behind
+  upstream: Helm v3.20.2 → v3.21.4 across all five copies,
+  `redis` 8.8 → 8.10.1 across fifteen, the appliance chart's
+  nginx 1.30.3 → 1.31.5, kube-state-metrics v2.18.0 → v2.20.0,
+  node-exporter v1.11.1 → v1.12.1, GoBGP 4.7.0 → 4.9.0
+  (`make trivy IMAGE=looking-glass` clean), and the Patroni
+  overlay's etcd v3.5.30 → v3.5.33 on all three services. Every
+  non-held pin is now current.
+  **The HAProxy jump is the one an existing deployment must read
+  before upgrading**, because that overlay's `haproxy.cfg` is
+  operator-supplied and 3.x turned keywords deprecated across the
+  2.x series into hard failures. The canonical Patroni config was
+  validated unchanged on both 2.9 and 3.4, so a config of that
+  shape needs no edit; `BAREMETAL.md` now says so and gives the
+  one-line `haproxy -c` command to check a config that is not.
+  **MetalLB stays on 0.15.3**, re-verified rather than assumed:
+  metallb/metallb#3063 is still open, so the hold and its three
+  vendored sub-pins (frr-k8s, frr, kube-rbac-proxy) stand and are
+  now recorded with the reason.
+  **Three things the sweep got right that the issue text had
+  wrong.** `haproxy:lts-alpine` and `haproxy:3.4-alpine` resolve
+  to the same digest, so 3.4 IS the LTS branch — 3.2 is not.
+  Alpine 3.24 ships Python **3.14.7**, not the 3.13 the
+  `dependabot.yml` comment had claimed for as long as the hold
+  existed, which makes the agent-image blocker a 3.12 → 3.14 jump
+  needing every dependency re-verified, not the one-minor step
+  the wrong number implied. And `patroni-spatiumddi:latest` is
+  not an unpinned pull — the HA overlay BUILDS it inline from
+  `postgres:16-alpine`, so it names a purely local image; what is
+  genuinely unpinned there is the `pip install patroni[etcd3]`
+  beside it, now documented in `BAREMETAL.md`.
+  **Found while writing the manifest:** the backend test shards'
+  own Redis service in `ci.yml` was still on 8.8 — a real pin, in
+  the file the sweep was being written in, that the hand-written
+  issue table had missed. It is in the manifest now, along with
+  the prose in four docs pages that named a version as fact.
+
+
 ### Security
 
 - **The two source restrictions composed into a console-only
@@ -520,6 +627,30 @@ the formatter handles the rest.
   `platform_settings.ntp_pool_servers` as an empty list, so the
   control plane's first config push does not put the pool back.
   `sources.d` and `conf.d` are left in place as the way back.
+
+- **The weekly CVE scan could report "clean" and could never
+  report a CVE (#975).** Found while adding a second job to the
+  same workflow. GitHub Actions runs a `run:` block under
+  `bash -e`, and the `set -uo pipefail` at the top of the scan
+  step does **not** clear that flag — so the bare
+  `docker run ... trivy --exit-code 1` followed by `rc=$?` killed
+  the whole step the moment Trivy found something. That is the
+  first image with findings, which is the only case the job
+  exists for: every branch after it was dead code,
+  `has_findings` was never written, and the reporting step's own
+  fail-safe then correctly refused to touch the tracking issue on
+  an indeterminate result — logging a warning nobody reads on a
+  scheduled run. A clean week and a week full of criticals
+  produced the same visible outcome: no issue.
+  Both status captures now use the `if` form, whose condition is
+  exempt from `-e`. Verified by executing the shipped `run:`
+  bodies under `bash -e` against a stub where `docker build`
+  succeeds and the scan exits 1 — the fixed step reaches its
+  handler and writes `has_findings=1`, the unpatched one exits 1
+  having written nothing. The first attempt at that harness
+  proved nothing, because a stub that failed `docker build` too
+  took the build-failure path and never reached the scan.
+
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -401,8 +401,8 @@ the formatter handles the rest.
   behind ON PURPOSE from real drift — the `hold` field carries
   each reason, so a known hold never reads as neglect.
   `make versions-upstream` runs it locally.
-  **Six defects in the guard itself, found by /code-review before
-  it shipped, and every one of them was the guard failing open.**
+  **Seven defects in the guard itself, found by /code-review and
+  CodeQL before it shipped, and every one was it failing open.**
   `--check` — the mode the script's own docstring documents — was
   not a flag: argparse resolves an unambiguous prefix, so it ran
   `--check-upstream`, the advisory network mode that always exits
@@ -426,7 +426,12 @@ the formatter handles the rest.
   the worst one to lose: the appliance never pulls, so a
   divergence there is ImagePullBackOff on an air-gapped box. And
   `docs/DEVELOPMENT.md` referred twice to a section that did not
-  exist, now written as §9.
+  exist, now written as §9. And the GitHub token was scoped to a
+  URL SUBSTRING — `"api.github.com" in url` is equally true of
+  `https://evil.example/api.github.com/x`, which is the token
+  handed to whoever owns that domain. It is matched on the parsed
+  hostname now, against an allowlist of the four endpoints this
+  script has any business reaching, https only.
 
 - **The pins the sweep found behind, bumped (#975).** Out of
   support: `ruby:3.2-slim` (EOL 2026-03-31) → 3.4, and with it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,8 @@ Always read the relevant spec doc(s) before writing code for a feature area.
 | `docs/DEVELOPMENT.md` | Coding standards, test requirements, CI pipeline |
 | `docs/OBSERVABILITY.md` | Logging (centralized + UI viewer), metrics, health dashboard, alerting |
 | `docs/TROUBLESHOOTING.md` | Recovery recipes: accidentally deleted agent rows, password reset, subnet delete refused |
-| `docs/THIRD_PARTY.md` | Catalogue of every bundled/shipped third-party component — engine, library, OS package — with license, the artifact it ships in, and the rationale. Operator-facing companion to the root `NOTICE` (which stays authoritative for license text). **When you add a shipped component, update BOTH** |
+| `docs/THIRD_PARTY.md` | Catalogue of every bundled/shipped third-party component — engine, library, OS package — with license, the artifact it ships in, and the rationale. Operator-facing companion to the root `NOTICE` (which stays authoritative for license text). **When you add a shipped component, update BOTH** — and if you add a version pin, `versions.json` too (see below) |
+| `versions.json` | Root manifest of every version pin **neither Dependabot nor a lockfile owns** — Helm, chart `values.yaml`, Dockerfile `ARG`s, action `with:` inputs, CI script defaults, the appliance bake arrays. One entry per component: the canonical `version`, every file carrying a copy (with an exact occurrence count where the copies must be exhaustive), the `upstream` to check it against, and — for pins deliberately behind — a `hold` field carrying the reason. `scripts/lint_versions.py` fails CI when a file and the manifest disagree, so a bump is one edit plus whatever the lint reports ([#975](https://github.com/spatiumddi/spatiumddi/issues/975)) |
 | `docs/PRIVACY.md` | The privacy statement — no telemetry, no analytics, no phone-home — plus the **normative table of every outbound connection** the backend can make, its default, and what it sends. `backend/tests/test_outbound_hosts_documented.py` fails CI when a hostname literal in `backend/app` is absent from it. **When you add an outbound call, update this page in the same PR** (see non-negotiable #17) |
 | `docs/features/IPAM.md` | IP Space/Block/Subnet/Address management, VLAN/VXLAN, custom fields, import/export, tree UI |
 | `docs/features/DHCP.md` | DHCP servers, scopes, pools, static assignments, DDNS, caching, Windows DHCP (Path A) |
@@ -2557,7 +2558,17 @@ make migrate                           # apply
 # Lint, typecheck, test
 make lint                              # ruff + black + mypy, eslint + prettier
 make ci                                # the lint/build/chart/perf jobs CI runs (backend-lint + frontend-lint + frontend-build
-                                       #   + charts-lint + perf-test). Run before pushing.
+                                       #   + charts-lint + perf-test + versions-check). Run before pushing.
+make versions-check                    # Version-pin manifest (#975) — asserts every pin declared in the root versions.json
+                                       #   still appears, at that version, in each file carrying a copy of it. Bumping a
+                                       #   component is ONE edit (its `version` field) plus whatever this then reports.
+                                       #   Covers what Dependabot cannot see: Helm's five copies, chart values.yaml,
+                                       #   Dockerfile ARGs, action `with:` inputs, CI script defaults, the appliance bake
+                                       #   arrays, and the version column of docs/THIRD_PARTY.md. Part of `make ci`.
+make versions-upstream                 #   ...the other half: resolve each declared upstream and print a current-vs-latest
+                                       #   table. Advisory + network-bound, so NOT part of `make ci`; the weekly
+                                       #   trivy-scheduled workflow runs it and files the delta. `hold` entries in the
+                                       #   manifest carry the reason a pin is behind on purpose, and report separately.
 make trivy                             # container-image CVE scan — run before pushing ANY agent Dockerfile change.
 make openapi VERSION=2026.08.22-1      # export the OpenAPI contract the release attaches (#903). Byte-identical
                                        #   to the release asset at the same tag; runs --network none, so it also proves

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: charts-lint perf-test help up down dev build build-supervisor migrate lint test lint-backend lint-frontend test-backend test-cov test-durations \
+.PHONY: charts-lint perf-test versions-check versions-upstream help up down dev build build-supervisor migrate lint test lint-backend lint-frontend test-backend test-cov test-durations \
         openapi \
         lint-untyped-routes \
         lint-untyped-routes-baseline \
@@ -81,6 +81,8 @@ help:
 	@echo "  make docs        Serve the documentation site locally on :4000 (Jekyll)"
 	@echo "  make docs-down   Stop the local documentation site"
 	@echo "  make docs-verify Check every docs SVG diagram for overflow / clipping"
+	@echo "  make versions-check     Assert every pin matches versions.json (part of make ci)"
+	@echo "  make versions-upstream  Current-vs-latest table for every pinned component"
 	@echo "  make appliance      Build the OS-appliance qcow2 (Phase 1 — Debian 13 amd64)"
 	@echo "  make appliance-iso  Wrap the Phase 1 raw image as a hybrid USB/CD ISO (Phase 2)"
 	@echo ""
@@ -410,7 +412,7 @@ lint-untyped-routes-baseline: $(UNTYPED_LIST)
 
 FORCE:
 
-ci: ci-backend-lint ci-frontend-lint ci-frontend-build charts-lint perf-test
+ci: ci-backend-lint ci-frontend-lint ci-frontend-build charts-lint perf-test versions-check
 	@echo ""
 	@echo "✓ All CI checks passed — safe to push."
 
@@ -436,7 +438,7 @@ ci-frontend-build:
 # Charts — Lint & Template (#966): the same script CI's job runs, inside a
 # helm container so a dev box with no helm / kubeconform can run it. Renders
 # land in ./.charts-render/ (gitignored) for inspection.
-HELM_IMAGE ?= alpine/helm:3.20.2
+HELM_IMAGE ?= alpine/helm:3.21.4
 charts-lint:
 	@echo "→ Charts — Lint & Template (matches .github/workflows/ci.yml)"
 	@mkdir -p .charts-render
@@ -444,6 +446,23 @@ charts-lint:
 	  $(HELM_IMAGE) -c 'apk add -q --no-cache bash curl python3 py3-yaml \
 	    && .github/scripts/install-kubeconform.sh \
 	    && .github/scripts/charts-render-check.sh'
+
+# Version-pin manifest (#975). Asserts that every pin declared in the root
+# versions.json still appears, at that version, in each file that carries a
+# copy of it — Helm's five literals, chart values, Dockerfile ARGs, the
+# appliance bake arrays, CI script defaults. Same check CI's Backend Lint job
+# runs; stdlib-only, no network, no container.
+#
+# ``versions-upstream`` is the other half: it resolves each declared upstream
+# and prints a current-vs-latest table. Advisory and network-bound, so it is
+# deliberately NOT part of `make ci` — the weekly trivy-scheduled workflow
+# runs it and files the delta.
+versions-check:
+	@echo "→ Version-pin manifest (matches .github/workflows/ci.yml)"
+	@python3 scripts/lint_versions.py
+
+versions-upstream:
+	@python3 scripts/lint_versions.py --check-upstream
 
 # Perf — Tests (#968): hermetic, stdlib-only tests under perf/.
 perf-test:

--- a/agent/looking-glass/images/gobgp/Dockerfile
+++ b/agent/looking-glass/images/gobgp/Dockerfile
@@ -8,7 +8,7 @@
 # global default-export-policy is always "reject-route" and no
 # export-policy-list is ever populated, so the daemon can receive routes
 # from every configured peer but can never advertise one back.
-ARG GOBGP_VERSION=4.7.0
+ARG GOBGP_VERSION=4.9.0
 
 FROM alpine:3.23 AS agent-build
 RUN apk add --no-cache python3 py3-pip py3-wheel
@@ -55,16 +55,27 @@ RUN apk add --no-cache git
 WORKDIR /src
 RUN git clone --depth 1 --branch "v${GOBGP_VERSION}" https://github.com/osrg/gobgp .
 # Bump vulnerable transitive deps above the versions gobgp pins so Trivy
-# (HIGH/CRITICAL) stays green. gobgp v4.7.0 pins golang.org/x/net v0.48,
-# which carries several HIGH CVEs (html XSS, IDNA punycode privilege
-# escalation, HTTP/2 DoS — fixed in 0.55); x/text v0.38 carries
-# CVE-2026-56852 (norm.Iter infinite loop, fixed in 0.39); grpc-go
-# v1.79.3 carries GHSA-hrxh-6v49-42gf (xDS RBAC + HTTP/2, fixed in
-# 1.82.1) and, at v1.83.0, CVE-2026-84304 (HIGH, fixed in 1.83.1).
-# Re-check + drop/bump these pins when GoBGP's own go.mod moves past
-# them. Dependabot does not see these — they are `go get` arguments in a
-# Dockerfile, not a tracked manifest — so `make trivy IMAGE=looking-glass`
-# is what surfaces the next one.
+# (HIGH/CRITICAL) stays green. The CVEs these clear: golang.org/x/net below
+# 0.55 carries several HIGH (html XSS, IDNA punycode privilege escalation,
+# HTTP/2 DoS); x/text below 0.39 carries CVE-2026-56852 (norm.Iter infinite
+# loop); grpc-go below 1.82.1 carries GHSA-hrxh-6v49-42gf (xDS RBAC +
+# HTTP/2) and 1.83.0 carries CVE-2026-84304 (HIGH, fixed in 1.83.1).
+#
+# EVERY ONE OF THESE MUST BE AN UPGRADE, NEVER A DOWNGRADE. ``go get pkg@vX``
+# sets exactly that version, so once GoBGP's own go.mod moves past one of
+# these the line silently pulls the dependency BACKWARDS — reintroducing the
+# CVE it was added to clear, while the build stays green and the comment
+# still says it is a fix. Check upstream's go.mod on every GOBGP_VERSION bump
+# and drop or raise each pin. Deliberately written without naming the pinned
+# GoBGP version: a comment naming the pinned release goes stale on
+# the next bump and then asserts something false (#975 found it had).
+#
+# At v4.9.0 upstream pins x/net v0.55.0 (indirect), x/text v0.37.0 and
+# grpc v1.82.1 — so all three below are still upgrades.
+#
+# Dependabot does not see these: they are `go get` arguments in a Dockerfile,
+# not a tracked manifest, which is why they live in versions.json's orbit and
+# why `make trivy IMAGE=looking-glass` is what surfaces the next one.
 RUN go get \
       golang.org/x/net@v0.57.0 \
       golang.org/x/text@v0.40.0 \

--- a/appliance/README.md
+++ b/appliance/README.md
@@ -206,7 +206,7 @@ NotFound: content digest sha256:… : not found
 `BAKE_SAVE_PLATFORM` (which the cross target sets) adds
 `docker save --platform` and an unconditional `docker pull --platform` for
 third-party images. That second half matters as much as the first: on a
-dev laptop `redis:8.8-alpine` and `nginx:…` are usually already present
+dev laptop `redis:8.10.1-alpine` and `nginx:…` are usually already present
 **as arm64** from the dev compose stack, they satisfy
 `docker image inspect`, and without the pin they would be baked silently —
 the appliance's Redis then crash-loops with `exec format error`.

--- a/appliance/scripts/bake-images.sh
+++ b/appliance/scripts/bake-images.sh
@@ -91,12 +91,12 @@ IMAGES=(
 # ``charts/spatiumddi-appliance/values.yaml`` ``observability.*``
 # image refs.
 OBSERVABILITY_IMAGES=(
-    "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0"
-    "quay.io/prometheus/node-exporter:v1.11.1"
+    "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.20.0"
+    "quay.io/prometheus/node-exporter:v1.12.1"
     # Agent landing page — always-on nginx serving the rendered
     # /var/lib/spatiumddi/agent-landing/index.html on :80. Pinned to
-    # 1.30.3-alpine matching values.yaml's ``agentLanding.image.tag``.
-    "nginx:1.30.3-alpine"
+    # 1.31.5-alpine matching values.yaml's ``agentLanding.image.tag``.
+    "nginx:1.31.5-alpine"
     # Phase 11 (#183) — Redis datastore for the control plane.
     # Tag follows the umbrella chart's ``redis.image.tag`` default.
     # NOTE: the standalone ``postgres:16-alpine`` image is intentionally
@@ -106,7 +106,7 @@ OBSERVABILITY_IMAGES=(
     # + operator are baked in CNPG_IMAGES below. The chart's standalone
     # StatefulSet path stays for non-appliance docker/k8s users, but the
     # appliance never renders it, so its image is dead weight in the ISO.
-    "redis:8.8-alpine"
+    "redis:8.10.1-alpine"
 )
 
 # #272 Phase 5 — MetalLB (control-plane HTTPS VIP + Phase 10 DNS/DHCP

--- a/backend/tests/test_ci_backend_relevant.py
+++ b/backend/tests/test_ci_backend_relevant.py
@@ -52,6 +52,7 @@ _KNOWN_REPO_ROOT_READS: dict[str, str] = {
     "test_test_impact_selection.py": ".github/scripts/select_impacted_tests.py",
     "test_outbound_hosts_documented.py": "docs/PRIVACY.md",
     "test_zone_name_scope.py": "scripts/refresh_iana_tlds.py",
+    "test_lint_versions.py": "scripts/lint_versions.py",
     "test_dhcp_packet_loss.py": "agent/dhcp/spatium_dhcp_agent/metrics.py",
     "test_ntp_initial_seed.py": ("appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot"),
 }

--- a/backend/tests/test_lint_versions.py
+++ b/backend/tests/test_lint_versions.py
@@ -1,0 +1,412 @@
+"""The version-pin manifest guard (#975).
+
+``scripts/lint_versions.py`` is what makes ``versions.json`` a source of truth
+rather than a 28th copy of every version string. These tests exercise it
+against synthetic manifests in ``tmp_path`` rather than against the real tree:
+the real tree is asserted by the script itself, which runs unconditionally in
+CI's Backend Lint job, and a test that re-read the real files would silently
+become a no-op in the dev container (which copies only ``backend/`` into the
+image) — the skip-shaped hole that has bitten this repo before.
+
+The cases that earn their keep are the negative ones. A guard is only worth
+having if it fails when it should, and this repo has now been bitten four
+times by one that did not (#1028, #1029, #1030, and #882's rotation): the
+recurring shape is a check that evaluates nothing and prints the same line it
+prints on success.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import types
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "lint_versions.py"
+
+# The dev container copies only ``backend/`` into the image, so this skips
+# there and runs for real in CI, which tests from a full checkout. Same
+# convention as test_ci_backend_relevant.py. A deleted script is caught loudly
+# by the workflow step that invokes it, not by a silent skip here.
+pytestmark = pytest.mark.skipif(
+    not _SCRIPT.exists(),
+    reason="version-pin linter not present in this checkout",
+)
+
+
+def _load() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("lint_versions", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def lint() -> types.ModuleType:
+    return _load()
+
+
+def _write(tmp_path: pathlib.Path, manifest: dict, files: dict[str, str]) -> pathlib.Path:
+    for rel, body in files.items():
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+    path = tmp_path / "versions.json"
+    path.write_text(json.dumps(manifest))
+    return path
+
+
+def _run(lint: types.ModuleType, path: pathlib.Path) -> int:
+    return lint.main(["--manifest", str(path)])
+
+
+# ── the happy path, and that it says how much it checked ─────────────────────
+
+
+def test_agreeing_pins_pass(
+    lint: types.ModuleType, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write(
+        tmp_path,
+        {
+            "components": {
+                "helm": {
+                    "version": "v3.21.4",
+                    "pinned_in": [
+                        {"path": "Makefile", "match": "alpine/helm:{version_no_v}"},
+                        {"path": "ci.yml", "match": "version: {version}"},
+                    ],
+                }
+            }
+        },
+        {"Makefile": "HELM_IMAGE ?= alpine/helm:3.21.4\n", "ci.yml": "  version: v3.21.4\n"},
+    )
+    assert _run(lint, path) == 0
+    out = capsys.readouterr().out
+    # "0 assertions" must not be able to print the same line as "all passed",
+    # so the count is part of the success message (#1030).
+    assert "2 pin assertion(s)" in out
+
+
+def test_version_no_v_is_substituted(lint: types.ModuleType, tmp_path: pathlib.Path) -> None:
+    """A release tag carries a leading ``v``; the image tag it produces does not.
+
+    Without this the manifest would need a second copy of the number for helm
+    (``v3.21.4`` in four workflows, ``3.21.4`` in the Makefile) — and a second
+    copy is the thing the file exists to remove.
+    """
+    path = _write(
+        tmp_path,
+        {
+            "components": {
+                "h": {
+                    "version": "v3.21.4",
+                    "pinned_in": [{"path": "f", "match": "x:{version_no_v}"}],
+                }
+            }
+        },
+        {"f": "x:3.21.4"},
+    )
+    assert _run(lint, path) == 0
+
+
+# ── the drift the guard exists for ───────────────────────────────────────────
+
+
+def test_a_stale_literal_fails(
+    lint: types.ModuleType, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write(
+        tmp_path,
+        {
+            "components": {
+                "nginx": {"version": "1.31.5-alpine", "pinned_in": [{"path": "values.yaml"}]}
+            }
+        },
+        {"values.yaml": "    tag: 1.30.3-alpine\n"},
+    )
+    assert _run(lint, path) == 1
+    err = capsys.readouterr().err
+    assert "nginx" in err and "values.yaml" in err
+
+
+def test_partial_bump_of_a_multi_copy_file_fails(
+    lint: types.ModuleType, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Two of three bumped is the failure an "at least one" rule cannot see.
+
+    The Patroni overlay runs three etcd services and three Redis containers.
+    Bumping two leaves a mixed-version cluster — and a substring check with no
+    count passes it, because the version IS present. This is the reason
+    ``count`` exists.
+    """
+    manifest = {
+        "components": {
+            "etcd": {
+                "version": "v3.5.33",
+                "pinned_in": [{"path": "ha.yaml", "match": "etcd:{version}", "count": 3}],
+            }
+        }
+    }
+    partly_bumped = "  a: etcd:v3.5.33\n  b: etcd:v3.5.33\n  c: etcd:v3.5.30\n"
+    path = _write(tmp_path, manifest, {"ha.yaml": partly_bumped})
+    assert _run(lint, path) == 1
+    assert "2×, expected 3×" in capsys.readouterr().err
+
+    # Negative control: the same assertion passes once the third moves.
+    (tmp_path / "ha.yaml").write_text(partly_bumped.replace("v3.5.30", "v3.5.33"))
+    assert _run(lint, path) == 0
+
+
+def test_a_renamed_file_is_an_error_not_a_skip(
+    lint: types.ModuleType, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A pin whose file moved is drift, and must not report as a pass.
+
+    This is the whole failure class in one case: skipping what cannot be
+    found turns a rename into a clean run, and the pin is then unguarded with
+    nothing anywhere saying so.
+    """
+    path = _write(
+        tmp_path,
+        {
+            "components": {
+                "k3s": {"version": "v1.36.4+k3s1", "pinned_in": [{"path": "gone/Makefile"}]}
+            }
+        },
+        {},
+    )
+    assert _run(lint, path) == 1
+    assert "does not exist" in capsys.readouterr().err
+
+
+# ── the manifest itself must be unusable-loudly, never vacuously-fine ────────
+
+
+@pytest.mark.parametrize(
+    ("manifest_text", "why"),
+    [
+        ("{}", "no components key at all"),
+        ('{"components": {}}', "an empty components map would assert nothing"),
+        ("not json", "an unparseable manifest"),
+        ('{"components": {"x": {"pinned_in": [{"path": "f"}]}}}', "a component with no version"),
+        (
+            '{"components": {"x": {"version": "1", "pinned_in": []}}}',
+            "a component that asserts nothing",
+        ),
+        (
+            '{"components": {"x": {"version": "1", "pinned_in": [{"path": "f", "count": 0}]}}}',
+            "a count of zero would assert the pin is ABSENT",
+        ),
+    ],
+)
+def test_unusable_manifest_fails(
+    lint: types.ModuleType, tmp_path: pathlib.Path, manifest_text: str, why: str
+) -> None:
+    path = tmp_path / "versions.json"
+    path.write_text(manifest_text)
+    (tmp_path / "f").write_text("1")
+    assert _run(lint, path) == 1, f"should have failed: {why}"
+
+
+def test_missing_manifest_fails(lint: types.ModuleType, tmp_path: pathlib.Path) -> None:
+    assert _run(lint, tmp_path / "nope.json") == 1
+
+
+# ── the upstream comparator ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("pinned", "upstream", "same", "why"),
+    [
+        ("v1.36.4+k3s1", "v1.36.4+k3s1", True, "identical"),
+        ("v0.15.3", "metallb-chart-0.16.1", False, "chart tags carry a repo prefix"),
+        ("0.29.0", "cloudnative-pg-v0.29.0", True, "prefixed tag, same version"),
+        ("10.4.1", "frr-10.7.1", False, "prefixed tag, behind"),
+        (
+            "v0.0.21",
+            "frr-k8s-chart-0.0.26",
+            False,
+            "the '8' in 'k8s' must not be read as the version",
+        ),
+        ("v0.0.21", "frr-k8s-chart-0.0.21", True, "same, with the same 'k8s' trap"),
+        ("8.10.1-alpine", "8.10.1-alpine", True, "base-OS suffix on both sides"),
+        ("16-alpine", "18-alpine", False, "no dotted run — fall back to digits"),
+        ("3.4-slim", "3.4-slim", True, "slim suffix"),
+        ("latest", "latest", True, "no digits at all"),
+    ],
+)
+def test_comparable_handles_every_tag_shape(
+    lint: types.ModuleType, pinned: str, upstream: str, same: bool, why: str
+) -> None:
+    assert (lint._comparable(pinned) == lint._comparable(upstream)) is same, why
+
+
+def test_upstream_kind_none_reports_no_upstream(lint: types.ModuleType) -> None:
+    """Entries lock-stepped to another component declare no upstream.
+
+    ``kind-node`` follows k3s's Kubernetes minor and ``patroni-image`` is an
+    image this repo does not publish. Both must render as "no upstream", never
+    as a failed lookup — a report where a deliberate non-answer looks like an
+    error is one people stop reading.
+    """
+    assert lint.resolve_upstream({"upstream": {"kind": "none"}}, None) is None
+    assert lint.resolve_upstream({}, None) is None
+
+
+def test_upstream_table_separates_holds_from_real_drift(lint: types.ModuleType) -> None:
+    rows = [
+        {"name": "a", "current": "1", "latest": "2", "behind": True, "hold": None, "error": None},
+        {
+            "name": "b",
+            "current": "1",
+            "latest": "2",
+            "behind": True,
+            "hold": "on purpose",
+            "error": None,
+        },
+        {"name": "c", "current": "2", "latest": "2", "behind": False, "hold": None, "error": None},
+        {
+            "name": "d",
+            "current": "1",
+            "latest": None,
+            "behind": False,
+            "hold": None,
+            "error": "boom",
+        },
+    ]
+    table = lint.format_upstream_table(rows)
+    lines = {row.split("|")[1].strip(): row for row in table.splitlines()}
+    assert "⬆️ behind" in lines["`a`"]
+    assert "held on purpose" in lines["`b`"]
+    assert "current" in lines["`c`"]
+    assert "check failed" in lines["`d`"]
+
+
+# ── the review findings, each pinned so it cannot come back ─────────────────
+
+
+def test_check_is_a_real_flag_and_runs_the_offline_mode(
+    lint: types.ModuleType, tmp_path: pathlib.Path
+) -> None:
+    """``--check`` must be the offline assertion, not a prefix of something else.
+
+    argparse resolves any unambiguous PREFIX of a long option, so with only
+    ``--check-upstream`` defined, ``--check`` — the mode this script's own
+    docstring documents — silently became the advisory NETWORK mode, which
+    always exits 0. Following the documentation turned the guard off.
+    """
+    path = _write(
+        tmp_path,
+        {"components": {"x": {"version": "9.9.9", "pinned_in": [{"path": "f"}]}}},
+        {"f": "nothing like it here"},
+    )
+    # Offline mode is the one that can FAIL; the upstream mode never does.
+    assert lint.main(["--manifest", str(path), "--check"]) == 1
+
+
+def test_undefined_options_are_rejected_rather_than_abbreviated(
+    lint: types.ModuleType, tmp_path: pathlib.Path
+) -> None:
+    path = _write(
+        tmp_path, {"components": {"x": {"version": "1", "pinned_in": [{"path": "f"}]}}}, {"f": "1"}
+    )
+    with pytest.raises(SystemExit):
+        lint.main(["--manifest", str(path), "--check-up"])
+
+
+@pytest.mark.parametrize(
+    ("manifest", "why"),
+    [
+        (
+            {"components": {"x": {"version": "1", "pinned_in": [{"path": "f", "counts": 3}]}}},
+            "a typo'd site key silently downgrades an exact count to 'at least one'",
+        ),
+        (
+            {"components": {"x": {"version": "1", "pinned_in": [{"path": "f"}], "notes": "x"}}},
+            "a typo'd component key is silently ignored",
+        ),
+        (
+            {"components": {"x": {"version": "1", "pinned_in": [{"path": "f"}]}}, "holdz": []},
+            "a typo'd top-level key is silently ignored",
+        ),
+    ],
+)
+def test_unknown_keys_are_refused(
+    lint: types.ModuleType, tmp_path: pathlib.Path, manifest: dict, why: str
+) -> None:
+    """A typo in the manifest is a guard that quietly stops guarding.
+
+    ``"counts": 3`` leaves ``count`` unset, so an exact-occurrence assertion
+    becomes "at least one" and a 2-of-3 partial bump passes — the same failure
+    the manifest exists to prevent, one level up.
+    """
+    path = _write(tmp_path, manifest, {"f": "1"})
+    assert _run(lint, path) == 1, f"should have been refused: {why}"
+
+
+def test_digest_pin_is_asserted_offline(lint: types.ModuleType, tmp_path: pathlib.Path) -> None:
+    """A tag+digest component asserts both halves in the file.
+
+    The offline lint cannot tell whether a digest BELONGS to a tag — that is
+    what ``--check-upstream`` resolves — but it must at least require the
+    literal to be present, or the field is decoration.
+    """
+    manifest = {
+        "components": {
+            "t": {
+                "version": "15.4.0",
+                "digest": "sha256:abc",
+                "pinned_in": [{"path": "Dockerfile", "match": "VERSION={version}"}],
+            }
+        }
+    }
+    path = _write(tmp_path, manifest, {"Dockerfile": "ARG VERSION=15.4.0\nARG DIGEST=sha256:abc\n"})
+    assert _run(lint, path) == 0
+
+    (tmp_path / "Dockerfile").write_text("ARG VERSION=15.4.0\nARG DIGEST=sha256:STALE\n")
+    assert _run(lint, path) == 1
+
+
+def test_upstream_summary_reports_failures_as_their_own_number(
+    lint: types.ModuleType, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ "Could not check" must never be readable as "nothing is behind".
+
+    The prose summary opens with "0 behind upstream" when EVERY lookup failed,
+    so a consumer scraping the first number reports the fleet current and
+    closes the drift issue on the one run that knew nothing. The machine-
+    readable RESULT line carries ``failed`` for exactly this reason, and the
+    workflow keys its indeterminate verdict off it.
+    """
+    manifest = {
+        "components": {
+            "a": {
+                "version": "1",
+                "pinned_in": [{"path": "f"}],
+                "upstream": {"kind": "github-release", "repo": "x/y"},
+            },
+            "b": {
+                "version": "1",
+                "pinned_in": [{"path": "f"}],
+                "upstream": {"kind": "github-release", "repo": "x/z"},
+            },
+        }
+    }
+
+    def boom(*_a: object, **_k: object) -> str:
+        raise OSError("network down")
+
+    monkeypatch.setattr(lint, "_latest_github", boom)
+    rows = lint.check_upstream(manifest, None)
+    assert all(r["error"] for r in rows)
+    assert not any(r["behind"] for r in rows), "a failed lookup must not read as 'behind'"
+
+    # And the reported shape a consumer parses.
+    behind = [r for r in rows if r["behind"] and not r["hold"]]
+    failed = [r for r in rows if r["error"]]
+    assert (len(behind), len(failed)) == (0, 2)

--- a/backend/tests/test_lint_versions.py
+++ b/backend/tests/test_lint_versions.py
@@ -410,3 +410,41 @@ def test_upstream_summary_reports_failures_as_their_own_number(
     behind = [r for r in rows if r["behind"] and not r["hold"]]
     failed = [r for r in rows if r["error"]]
     assert (len(behind), len(failed)) == (0, 2)
+
+
+@pytest.mark.parametrize(
+    ("url", "allowed", "why"),
+    [
+        ("https://api.github.com/repos/x/y/releases/latest", True, "the real endpoint"),
+        ("https://hub.docker.com/v2/repositories/library/redis/tags", True, "docker hub"),
+        ("https://quay.io/api/v1/repository/coreos/etcd/tag/", True, "quay"),
+        ("https://rubygems.org/api/v1/versions/webrick/latest.json", True, "rubygems"),
+        (
+            "https://evil.example/api.github.com/repos/x/y",
+            False,
+            "the substring check this replaced would have sent the TOKEN here",
+        ),
+        ("https://api.github.com.evil.example/x", False, "suffix-attached lookalike host"),
+        ("http://api.github.com/x", False, "plaintext downgrade"),
+        ("file:///etc/passwd", False, "non-http scheme"),
+    ],
+)
+def test_only_allowlisted_https_hosts_are_fetched(
+    lint: types.ModuleType, url: str, allowed: bool, why: str
+) -> None:
+    """The token must be scoped by parsed HOSTNAME, never a URL substring.
+
+    ``"api.github.com" in url`` is also true of
+    ``https://evil.example/api.github.com/...`` — which is a credential
+    handed to whoever owns that domain. Flagged by CodeQL as incomplete URL
+    substring sanitization; the guard now parses the URL and matches the host
+    exactly, and refuses anything that is not https to a known endpoint.
+    """
+    import urllib.parse
+
+    parts = urllib.parse.urlsplit(url)
+    host = (parts.hostname or "").lower()
+    ok = parts.scheme == "https" and host in lint._ALLOWED_HOSTS
+    assert ok is allowed, why
+    if allowed:
+        assert (host == lint._GITHUB_API_HOST) == ("api.github.com" == host)

--- a/charts/spatiumddi-appliance/templates/agent-landing.yaml
+++ b/charts/spatiumddi-appliance/templates/agent-landing.yaml
@@ -13,7 +13,7 @@
        k3s; no LoadBalancer to fall back on (klipper-lb is disabled),
        so hostNetwork is the simplest path.
 
-       Image: stock ``nginx:1.30.3-alpine``, preloaded into containerd
+       Image: stock ``nginx:1.31.5-alpine``, preloaded into containerd
        at bake time alongside the SpatiumDDI service images. */}}
 {{- if .Values.agentLanding.enabled }}
 apiVersion: apps/v1

--- a/charts/spatiumddi-appliance/values.yaml
+++ b/charts/spatiumddi-appliance/values.yaml
@@ -356,7 +356,7 @@ observability:
     hostUsers:
     image:
       repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-      tag: v2.18.0
+      tag: v2.20.0
     # Resource cap — appliance VMs are typically 2-4 GB; KSM has a
     # bounded memory profile but a runaway pod shouldn't dent the
     # service pods' headroom.
@@ -374,7 +374,7 @@ observability:
     enabled: false
     image:
       repository: quay.io/prometheus/node-exporter
-      tag: v1.11.1
+      tag: v1.12.1
     resources:
       requests:
         cpu: 10m
@@ -450,7 +450,7 @@ agentLanding:
   priorityClassName: ""
   image:
     repository: nginx
-    tag: 1.30.3-alpine
+    tag: 1.31.5-alpine
   # #965 — token request so no pod in this chart is BestEffort (the CI
   # render check refuses one). A static nginx page needs nothing more.
   resources:

--- a/charts/spatiumddi/Chart.yaml
+++ b/charts/spatiumddi/Chart.yaml
@@ -29,7 +29,7 @@ maintainers:
   - name: SpatiumDDI Contributors
 # No subchart dependencies. Postgres + Redis ship as plain
 # StatefulSet + Service templates owned by this chart, using the
-# official ``postgres:16-alpine`` and ``redis:8.8-alpine`` images
+# official ``postgres:16-alpine`` and ``redis:8.10.1-alpine`` images
 # (the same ones docker-compose.yml uses). The bundled subcharts
 # previously came from the Bitnami chart family, but Bitnami pruned
 # the ``bitnami/*`` Docker Hub namespace in late 2025 in favour of

--- a/charts/spatiumddi/templates/redis.yaml
+++ b/charts/spatiumddi/templates/redis.yaml
@@ -3,7 +3,7 @@
 {{- $secretName := printf "%s-redis" (include "spatiumddi.fullname" .) -}}
 # ─────────────────────────────────────────────────────────────────────────────
 # In-chart Redis — single-node StatefulSet using the official
-# ``redis:8.8-alpine`` image. Sized for a small lab / single-VM
+# ``redis:8.10.1-alpine`` image. Sized for a small lab / single-VM
 # deployment. Real production HA installs flip ``redis.kind=sentinel``
 # (#272 Phase 3 — templates/redis-sentinel.yaml) or set
 # ``redis.enabled=false`` and point ``externalRedis`` at a

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -10,7 +10,7 @@
 #   ingress               Frontend ingress
 #   postgresql            In-chart Postgres StatefulSet using postgres:16-alpine
 #                         (matches docker-compose.yml). BYO via externalDatabase.
-#   redis                 In-chart Redis StatefulSet using redis:8.8-alpine.
+#   redis                 In-chart Redis StatefulSet using redis:8.10.1-alpine.
 #                         BYO via externalRedis.
 #   dnsAgents             Optional BIND9 agent StatefulSets (one per DNSServer row)
 #   dhcpAgents            Optional Kea agent StatefulSets (one per DHCPServer row)
@@ -652,7 +652,7 @@ externalDatabase:
 # Two in-chart shapes, picked via ``redis.kind``:
 #
 # * ``standalone`` (default) — single-node StatefulSet using the
-#   official ``redis:8.8-alpine`` image (matches docker-compose.yml).
+#   official ``redis:8.10.1-alpine`` image (matches docker-compose.yml).
 #   No HA, no failover.
 # * ``sentinel`` (#272 Phase 3) — a 3-replica StatefulSet where each
 #   pod runs a redis-server + a redis-sentinel sidecar. The sentinels
@@ -676,7 +676,7 @@ redis:
   kind: standalone
   image:
     repository: redis
-    tag: "8.8-alpine"
+    tag: "8.10.1-alpine"
     pullPolicy: IfNotPresent
   # Cap and eviction policy match docker-compose.yml's redis-server
   # CLI flags. Bump if your install needs a larger cache.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,7 +42,7 @@ services:
 
   # ── Redis ───────────────────────────────────────────────────────────────────
   redis:
-    image: redis:8.8-alpine
+    image: redis:8.10.1-alpine
     restart: unless-stopped
     networks:
       - spatiumddi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   # ── Redis ───────────────────────────────────────────────────────────────────
   redis:
-    image: redis:8.8-alpine
+    image: redis:8.10.1-alpine
     restart: unless-stopped
     networks:
       - spatiumddi

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -191,7 +191,7 @@ the canonical wording lives in `CLAUDE.md`.
 10. **Driver abstraction** — DHCP/DNS backend logic never leaks into the
     service layer (`backend/app/drivers/{dns,dhcp}/`).
 11. **Multi-arch builds** — all Docker images support `linux/amd64` and
-    `linux/arm64` (see §9).
+    `linux/arm64` (see §10).
 12. **K8s manifests stay current** — when you add or change a service,
     update `k8s/base/` and `k8s/README.md`.
 13. **MCP coverage for new features** — a new REST resource also gets
@@ -358,7 +358,7 @@ every push and pull request. Run it locally before pushing.
 make ci
 ```
 
-It chains five targets:
+It chains six targets:
 
 | `make` target | What it runs |
 |---|---|
@@ -367,6 +367,7 @@ It chains five targets:
 | `ci-frontend-build` | `npm run build` |
 | `charts-lint` | The `Charts — Lint & Template` gate, in a helm container (see the job table below) |
 | `perf-test` | `python -m pytest perf` in a python container |
+| `versions-check` | `python3 scripts/lint_versions.py` — asserts every pin in `versions.json` still matches the files that carry it (see §9). Stdlib-only, no container, no network |
 
 `make ci` requires the dev stack to be running (the backend checks
 execute inside the api container) and Node 20+ on the host. It does **not**
@@ -379,11 +380,11 @@ triggered on push to `main` and on every pull request:
 
 | Job | What it does |
 |---|---|
-| **Backend — Lint & Type Check** (`backend-lint`) | `pip install -e ".[dev]"` on Python 3.12, then `ruff check`, `black --check`, `mypy app`, **plus the migration-shape linter** (`python3 scripts/lint_migrations.py` — see §8). |
-| **Backend — Tests** (`backend-test`) | A required-check aggregator over **twelve** parallel `backend-test-shard` jobs. Each shard spins up `postgres:16-alpine` + `redis:8.8-alpine` services, runs `alembic upgrade head`, then `pytest -n auto --splits 12 --group N --store-durations --clean-durations` (pytest-split selects the shard's slice, **balanced by duration** from the committed `backend/.test_durations` — see §Shard balancing; `-n auto` parallelizes it across the runner's vCPUs, each xdist worker on its own `spatiumddi_test_gw<N>` DB). On a PR the `changes` job may first narrow the run to the test files the diff can affect (#1020 — see §Test-impact selection). The aggregator passes only if all twelve shards pass; on a full run it also merges the shards' measured durations into a `test-durations` artifact, and on a push to `main` it builds the `test-impact-map` artifact from the shards' coverage contexts. Coverage is otherwise **not** collected here (#1019). |
+| **Backend — Lint & Type Check** (`backend-lint`) | `pip install -e ".[dev]"` on Python 3.12, then `ruff check`, `black --check`, `mypy app`, **plus the migration-shape linter** (`python3 scripts/lint_migrations.py` — see §8) and the **version-pin manifest linter** (`python3 scripts/lint_versions.py` — see §9). |
+| **Backend — Tests** (`backend-test`) | A required-check aggregator over **twelve** parallel `backend-test-shard` jobs. Each shard spins up `postgres:16-alpine` + `redis:8.10.1-alpine` services, runs `alembic upgrade head`, then `pytest -n auto --splits 12 --group N --store-durations --clean-durations` (pytest-split selects the shard's slice, **balanced by duration** from the committed `backend/.test_durations` — see §Shard balancing; `-n auto` parallelizes it across the runner's vCPUs, each xdist worker on its own `spatiumddi_test_gw<N>` DB). On a PR the `changes` job may first narrow the run to the test files the diff can affect (#1020 — see §Test-impact selection). The aggregator passes only if all twelve shards pass; on a full run it also merges the shards' measured durations into a `test-durations` artifact, and on a push to `main` it builds the `test-impact-map` artifact from the shards' coverage contexts. Coverage is otherwise **not** collected here (#1019). |
 | **Frontend — Lint & Type Check** (`frontend-lint`) | Node 22, `npm install`, then `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test`. |
 | **Frontend — Build** (`frontend-build`) | Node 22, `npm install`, `npm run build`. |
-| **Charts — Lint & Template** (`charts-lint`) | Helm 3.20 + a checksum-pinned kubeconform. `helm lint --strict` both charts at defaults and with every role / feature toggle on, `helm template` six value sets (umbrella: defaults, all-on, external DB + Redis, the CNPG + Sentinel HA shape; appliance: defaults, all-on, the single-node full-stack shape), `kubeconform -strict` against the Kubernetes 1.36 + CRD-catalog schemas (kept at the version the appliance's k3s serves — it was five minors behind until #974), and `.github/scripts/chart-no-besteffort.py` on every render (#965 — no serving container may lack CPU + memory requests or limits; init containers are exempt, they finish before the pod serves) plus `chart-toggle-coverage.py`, which fails if a template is gated on a values key none of the value sets flips. Rendered manifests are uploaded as the `rendered-charts` artifact. Until #966 nothing on a PR parsed the appliance chart at all; it was first read by helm during the release. `make charts-lint` runs the same script in a helm container. |
+| **Charts — Lint & Template** (`charts-lint`) | Helm 3.21 + a checksum-pinned kubeconform. `helm lint --strict` both charts at defaults and with every role / feature toggle on, `helm template` six value sets (umbrella: defaults, all-on, external DB + Redis, the CNPG + Sentinel HA shape; appliance: defaults, all-on, the single-node full-stack shape), `kubeconform -strict` against the Kubernetes 1.36 + CRD-catalog schemas (kept at the version the appliance's k3s serves — it was five minors behind until #974), and `.github/scripts/chart-no-besteffort.py` on every render (#965 — no serving container may lack CPU + memory requests or limits; init containers are exempt, they finish before the pod serves) plus `chart-toggle-coverage.py`, which fails if a template is gated on a values key none of the value sets flips. Rendered manifests are uploaded as the `rendered-charts` artifact. Until #966 nothing on a PR parsed the appliance chart at all; it was first read by helm during the release. `make charts-lint` runs the same script in a helm container. |
 | **Perf — Tests** (`perf-test`) | Python 3.12 + pytest, `python -m pytest perf`. Hermetic (fake sockets, no network, no appliance). Tests only — `perf/` is outside the Backend Lint scope and carries pre-existing ruff/black drift (#968). `make perf-test` reproduces it. |
 
 Branch protection on `main` (the `protect-main` ruleset) requires every
@@ -613,7 +614,66 @@ python3 scripts/lint_migrations.py --show       # every finding, baselined or no
 
 ---
 
-## 9. Multi-Arch Image Builds
+## 9. Version Pins — `versions.json`
+
+Dependabot covers four ecosystems in this repo: `github-actions`,
+`docker` base images in the directories listed in
+[`.github/dependabot.yml`](../.github/dependabot.yml), `pip` and `npm`.
+Everything else is invisible to it. It has no Helm ecosystem, and it does
+not read Dockerfile `ARG` values, chart `values.yaml`, action `with:`
+inputs, CI shell-script defaults or the appliance bake arrays.
+
+Those pins are declared in **[`versions.json`](../versions.json)** at the
+repo root — one entry per component, carrying the canonical `version`,
+every file that holds a copy of it, the `upstream` to check it against,
+and (where a pin is deliberately behind) a `hold` field with the reason.
+
+```bash
+make versions-check       # offline; part of make ci and of CI's Backend Lint job
+make versions-upstream     # current-vs-latest table; advisory, needs network
+```
+
+### Bumping a component
+
+Edit the `version` field and run `make versions-check`. Every site's
+expected string is a **template** over that field, so the lint reports
+exactly which files still carry the old value — that list is the
+worklist. Nothing reads the manifest at build time, so the literals in
+each file stay real and greppable.
+
+### Adding a pin
+
+Add an entry with a `pinned_in` list. Two fields are easy to get wrong:
+
+- **`count`** is the *exact* number of occurrences required. Omit it and
+  the rule becomes "at least one" — which passes a bump that moved two
+  of three copies and left a mixed-version cluster. Use an exact count
+  wherever the copies must be exhaustive.
+- **`digest`**, for a component pinned by tag *and* digest. A digest does
+  not derive from a version, so the offline lint can only assert the
+  literal; `make versions-upstream` is what resolves the tag and reports
+  a pair that has come apart.
+
+Unknown keys are **refused** rather than ignored, because a typo such as
+`"counts": 3` would otherwise silently downgrade the guard.
+
+### What does not belong here
+
+Anything a lockfile or Dependabot already owns — `pyproject` /
+`package-lock` dependencies, `uses:` action refs, and `FROM` lines
+Dependabot actually bumps. Listing those twice re-creates the drift the
+file exists to remove.
+
+The **one deliberate exception** is a Dependabot-visible `FROM` that
+shares a component with a copy Dependabot cannot see. `nginx` is the
+worked example: the bot moved `frontend/Dockerfile` to 1.31 and the
+appliance chart's copy sat on 1.30.3 for seven weeks, because nothing
+connected them. Listing both means the next bot bump fails the lint until
+the other copies move with it.
+
+---
+
+## 10. Multi-Arch Image Builds
 
 Every Docker image must support **`linux/amd64` and `linux/arm64`**
 (non-negotiable #11). The release pipeline
@@ -625,7 +685,7 @@ multi-arch fan-out happens in CI on a tagged release.
 
 ---
 
-## 10. Branch & PR Conventions
+## 11. Branch & PR Conventions
 
 - **Branch from `main`.** The project uses one branch per issue, named
   `issue-NNN` (keep every phase of a multi-phase change on the same
@@ -656,7 +716,7 @@ multi-arch fan-out happens in CI on a tagged release.
 
 ---
 
-## 11. Security Disclosure
+## 12. Security Disclosure
 
 Do **not** file security vulnerabilities as public issues. Use
 [GitHub Security Advisories](https://github.com/spatiumddi/spatiumddi/security/advisories/new)

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -12,17 +12,17 @@
 #
 #   docker compose -f docker-compose.docs.yml up
 #   → http://localhost:4000
-FROM ruby:3.2-slim
+FROM ruby:3.4-slim
 
 # webrick is no longer a default gem on Ruby 3.x and jekyll serve needs it.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/* \
     && gem install --no-document \
-         jekyll:4.3.4 \
+         jekyll:4.4.1 \
          jekyll-optional-front-matter:0.3.2 \
          jekyll-relative-links:0.6.1 \
-         webrick:1.8.1 \
+         webrick:1.9.2 \
     && apt-get purge -y build-essential \
     && apt-get autoremove -y
 

--- a/docs/THIRD_PARTY.md
+++ b/docs/THIRD_PARTY.md
@@ -45,9 +45,19 @@ The "Where" column throughout this page refers to these:
 | **Appliance OS** | The bootable Debian image, including its baked k3s |
 | **Helm charts** | `charts/spatiumddi` (generic Kubernetes) and `charts/spatiumddi-appliance` (on-appliance k3s) |
 
-Versions below are the pins on `main` at the time of writing. They move; the
-**Pinned in** column names the file that is actually authoritative, and that is
-the one to check rather than trusting this table's numbers.
+Versions below are the pins on `main` at the time of writing, and the
+**Pinned in** column names the file each one lives in.
+
+Since [#975](https://github.com/spatiumddi/spatiumddi/issues/975) this table no
+longer drifts on its own: the pins that neither Dependabot nor a lockfile owns
+are declared in
+[`versions.json`](https://github.com/spatiumddi/spatiumddi/blob/main/versions.json),
+and `scripts/lint_versions.py` — which runs on every CI build — fails when the
+version column here disagrees with it. So the numbers below for k3s, MetalLB,
+CloudNativePG, GoBGP, Technitium, Redis, PostgreSQL, HAProxy, Alpine,
+node-exporter and kube-state-metrics are checked, not merely written down.
+Rows the lint does not cover (an Alpine package version such as BIND's, which
+moves with the base image) are still "at the time of writing".
 
 ## DNS, DHCP and routing engines
 
@@ -63,7 +73,7 @@ to their control channels, it does not link against them.
 | [PowerDNS dnsdist](https://dnsdist.org/) | Alpine `dnsdist` | GPL v2 | DNS agent image | `agent/dns/images/dnsdist/Dockerfile` |
 | [ISC Kea DHCP](https://www.isc.org/kea/) | Alpine `kea`, v4 + v6 | MPL 2.0 | DHCP agent image | `agent/dhcp/images/kea/Dockerfile` |
 | [radvd](https://radvd.litech.org/) | Alpine `radvd` | BSD-style | DHCP agent image | `agent/dhcp/images/kea/Dockerfile` |
-| [GoBGP](https://github.com/osrg/gobgp) | 4.7.0 (built from source) | Apache 2.0 | Looking Glass image | `agent/looking-glass/images/gobgp/Dockerfile` |
+| [GoBGP](https://github.com/osrg/gobgp) | 4.9.0 (built from source) | Apache 2.0 | Looking Glass image | `agent/looking-glass/images/gobgp/Dockerfile` |
 | [BIND `dig` / `nsupdate`](https://www.isc.org/bind/) | `bind-tools` | MPL 2.0 | DNS + supervisor + API images | several Dockerfiles |
 
 Notes worth carrying:
@@ -95,7 +105,7 @@ Notes worth carrying:
 | [FRRouting](https://frrouting.org/) | via MetalLB frr-k8s | GPL v2 | Helm chart (opt-in) | `charts/spatiumddi-metallb` values |
 | [CloudNativePG](https://cloudnative-pg.io/) | chart 0.29.0 (operator 1.30.0) | Apache 2.0 | Helm chart (opt-in) | `charts/spatiumddi-appliance/Chart.yaml` |
 | [Patroni](https://github.com/patroni/patroni) | `k8s/ha/` overlay | MIT | Bare-metal HA overlay | `k8s/ha/` |
-| [HAProxy](https://www.haproxy.org/) | 2.9-alpine | GPL v2 (+ LGPL libs) | Patroni HA overlay | `k8s/ha/` |
+| [HAProxy](https://www.haproxy.org/) | 3.4-alpine | GPL v2 (+ LGPL libs) | Patroni HA overlay | `k8s/ha/` |
 
 Three of these deserve a sentence, because their state is not what you would
 assume from their presence:
@@ -118,14 +128,14 @@ assume from their presence:
 | Component | Version | License | Where | Pinned in |
 |---|---|---|---|---|
 | [PostgreSQL](https://www.postgresql.org/) | 16-alpine | PostgreSQL License | Compose + Helm chart | `docker-compose.yml` |
-| [Redis](https://redis.io/) | 8.8-alpine | RSALv2 / SSPLv1 / AGPLv3 (Redis 8+) | Compose + Helm chart | `docker-compose.yml` |
-| [Prometheus node-exporter](https://github.com/prometheus/node_exporter) | v1.11.1, **default off** | Apache 2.0 | Appliance chart | `charts/spatiumddi-appliance/values.yaml` |
-| [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) | v2.18.0, **default off** | Apache 2.0 | Appliance chart | `charts/spatiumddi-appliance/values.yaml` |
+| [Redis](https://redis.io/) | 8.10.1-alpine | RSALv2 / SSPLv1 / AGPLv3 (Redis 8+) | Compose + Helm chart | `docker-compose.yml` |
+| [Prometheus node-exporter](https://github.com/prometheus/node_exporter) | v1.12.1, **default off** | Apache 2.0 | Appliance chart | `charts/spatiumddi-appliance/values.yaml` |
+| [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) | v2.20.0, **default off** | Apache 2.0 | Appliance chart | `charts/spatiumddi-appliance/values.yaml` |
 | [prometheus-client](https://github.com/prometheus/client_python) | see manifest | Apache 2.0 AND BSD 2-Clause | API image | `backend/pyproject.toml` |
 
 **On Redis's license:** Redis relicensed away from BSD at 7.4 (RSALv2 + SSPLv1)
 and added an AGPLv3 option at 8.0. SpatiumDDI ships the stock upstream
-`redis:8.8-alpine` image unmodified and talks to it as a network service over
+`redis:8.10.1-alpine` image unmodified and talks to it as a network service over
 its own protocol — no Redis code is linked into or vendored by SpatiumDDI.
 
 Operators who would rather not run that license family can point the deployment

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -33,7 +33,7 @@ mkosi bakes everything the appliance needs to come up fully air-gapped:
 
 - **k3s static binary** (~70 MB) at `/usr/local/bin/k3s`; `kubectl` / `crictl` / `ctr` symlink to it.
 - **k3s airgap images** (CoreDNS / local-path / pause / metrics-server) as zst-compressed tarballs at `/var/lib/rancher/k3s/agent/images/*.tar.zst`. k3s auto-imports them into containerd at boot.
-- **SpatiumDDI container images** as zst tarballs at `/usr/lib/spatiumddi/images/`. firstboot imports them into k3s containerd via `ctr -n k8s.io images import`. Includes api / frontend / worker / beat / migrate / dns-bind9 / dns-powerdns / dns-technitium / dhcp-kea / supervisor / nginx + postgres:16-alpine + redis:8.8-alpine for the Control plane role.
+- **SpatiumDDI container images** as zst tarballs at `/usr/lib/spatiumddi/images/`. firstboot imports them into k3s containerd via `ctr -n k8s.io images import`. Includes api / frontend / worker / beat / migrate / dns-bind9 / dns-powerdns / dns-technitium / dhcp-kea / supervisor / nginx + postgres:16-alpine + redis:8.10.1-alpine for the Control plane role.
 - **Helm chart tarballs** at `/usr/lib/spatiumddi/charts/`. The appliance chart drives Appliance installs (and the supervisor on the Control plane); the umbrella chart drives the Control plane. Built at release time + signed.
 - **bash-completion + `k` alias** for kubectl — operator SSHing in for triage drops straight into a usable shell.
 

--- a/docs/deployment/BAREMETAL.md
+++ b/docs/deployment/BAREMETAL.md
@@ -66,6 +66,34 @@ Notes before you use it:
   mounts `./haproxy.cfg`, which is **not** included in the repo — you must supply
   your own HAProxy config that fronts the three Patroni REST APIs (`pg1`/`pg2`/`pg3`
   on `:8008`) and routes `:5000` to the current primary.
+  **If you are upgrading an existing deployment**, note that the HAProxy image
+  moved from `2.9-alpine` to `3.4-alpine` in
+  [#975](https://github.com/spatiumddi/spatiumddi/issues/975) — 2.9 was a
+  short-lived non-LTS branch with no release since March 2025, and 3.4 is the
+  current LTS (`haproxy:lts-alpine` and `haproxy:3.4-alpine` are the same
+  image). Your `haproxy.cfg` is yours, so **we cannot validate it for you**:
+  HAProxy 3.x removed keywords that were deprecated through the 2.x series, and
+  a config that only warned on 2.9 can be a hard startup failure on 3.4. The
+  canonical Patroni configuration from the Patroni documentation — `mode tcp`,
+  `option httpchk`, `http-check expect status 200`, `default-server ... on-marked-down
+  shutdown-sessions` — was verified unchanged on both versions, so a config of
+  that shape needs no edit. Check yours before deploying:
+
+  ```bash
+  docker run --rm -v "$PWD/haproxy.cfg:/c.cfg:ro" haproxy:3.4-alpine \
+      haproxy -c -f /c.cfg
+  ```
+- The three Patroni services run **`patroni-spatiumddi:latest`, which is built by
+  this overlay, not pulled.** The `build.dockerfile_inline` block in the same file
+  layers Patroni onto `postgres:16-alpine` via pip, so the image exists only on the
+  host that ran `docker compose`; nothing publishes it and the name resolves in no
+  registry. Two consequences worth knowing: the `latest` tag is local and
+  meaningless as a version (recorded as such in
+  [`versions.json`](https://github.com/spatiumddi/spatiumddi/blob/main/versions.json),
+  so it stops reading like a pin somebody forgot), and **the Patroni version is
+  whatever pip resolves at build time** — pin it in the inline Dockerfile if you
+  need two hosts to agree, because `docker compose build` on different days will
+  not.
 - Point the application at HAProxy by setting `DATABASE_URL` to the HAProxy
   endpoint (e.g. `postgresql+asyncpg://spatiumddi:<password>@haproxy:5000/spatiumddi`)
   instead of the default single-node `postgres` host.

--- a/docs/deployment/KUBERNETES.md
+++ b/docs/deployment/KUBERNETES.md
@@ -25,7 +25,7 @@
 The umbrella chart is a single self-contained `application` chart — it has
 **no subchart dependencies**. PostgreSQL and Redis ship as plain
 `StatefulSet` + `Service` templates owned by the chart, using the official
-`postgres:16-alpine` and `redis:8.8-alpine` images (the same ones
+`postgres:16-alpine` and `redis:8.10.1-alpine` images (the same ones
 `docker-compose.yml` uses). The Bitnami subcharts the chart used historically
 were dropped after Bitnami pruned its public Docker Hub namespace in late 2025;
 the rationale is in [`Chart.yaml`](../../charts/spatiumddi/Chart.yaml).

--- a/k8s/ha/postgres-docker-compose.yaml
+++ b/k8s/ha/postgres-docker-compose.yaml
@@ -24,7 +24,7 @@ services:
   # on upstream — etcd already defaults to no auth) and the data-dir
   # mount path (``/bitnami/etcd`` → ``/var/lib/etcd``).
   etcd1:
-    image: quay.io/coreos/etcd:v3.5.30
+    image: quay.io/coreos/etcd:v3.5.33
     command: ["etcd"]
     networks: [spatiumddi]
     environment:
@@ -40,7 +40,7 @@ services:
     volumes: [etcd1_data:/var/lib/etcd]
 
   etcd2:
-    image: quay.io/coreos/etcd:v3.5.30
+    image: quay.io/coreos/etcd:v3.5.33
     command: ["etcd"]
     networks: [spatiumddi]
     environment:
@@ -56,7 +56,7 @@ services:
     volumes: [etcd2_data:/var/lib/etcd]
 
   etcd3:
-    image: quay.io/coreos/etcd:v3.5.30
+    image: quay.io/coreos/etcd:v3.5.33
     command: ["etcd"]
     networks: [spatiumddi]
     environment:
@@ -131,7 +131,7 @@ services:
 
   # ── HAProxy (transparent primary routing) ───────────────────────────────────
   haproxy:
-    image: haproxy:2.9-alpine
+    image: haproxy:3.4-alpine
     networks: [spatiumddi]
     ports:
       - "5000:5000"   # read/write → primary only

--- a/k8s/ha/redis-sentinel.yaml
+++ b/k8s/ha/redis-sentinel.yaml
@@ -95,7 +95,7 @@ spec:
       initContainers:
         # Set replica-of on non-primary pods
         - name: init-redis
-          image: redis:8.8-alpine
+          image: redis:8.10.1-alpine
           command:
             - sh
             - -c
@@ -130,7 +130,7 @@ spec:
               mountPath: /data
       containers:
         - name: redis
-          image: redis:8.8-alpine
+          image: redis:8.10.1-alpine
           command: ["redis-server", "/data/redis.conf"]
           ports:
             - containerPort: 6379
@@ -151,7 +151,7 @@ spec:
               memory: 512Mi
 
         - name: sentinel
-          image: redis:8.8-alpine
+          image: redis:8.10.1-alpine
           command: ["redis-sentinel", "/data/sentinel.conf"]
           ports:
             - containerPort: 26379

--- a/scripts/lint_versions.py
+++ b/scripts/lint_versions.py
@@ -202,14 +202,35 @@ def check(manifest: dict[str, Any], root: pathlib.Path) -> tuple[list[str], int]
 # ── the upstream check (advisory, network) ───────────────────────────────────
 
 
+#: Hosts this script is allowed to talk to. Every URL it builds is composed
+#: from a literal here plus a repo name out of the manifest, so the set is
+#: closed; asserting it anyway keeps a malformed ``upstream.repo`` from
+#: steering a request somewhere else.
+_ALLOWED_HOSTS = frozenset(
+    {"api.github.com", "hub.docker.com", "quay.io", "rubygems.org"}
+)
+
+#: The one host that gets the token.
+_GITHUB_API_HOST = "api.github.com"
+
+
 def _http_json(url: str, token: str | None = None) -> Any:
-    import urllib.error
+    import urllib.parse
     import urllib.request
 
+    parts = urllib.parse.urlsplit(url)
+    # Compare the parsed HOSTNAME, never a substring of the URL. ``"api.
+    # github.com" in url`` is also true for ``https://evil.example/api.
+    # github.com/x`` — which would send the token to whoever owns that host.
+    # (CodeQL: incomplete URL substring sanitization.)
+    host = (parts.hostname or "").lower()
+    if parts.scheme != "https" or host not in _ALLOWED_HOSTS:
+        raise LookupError(f"refusing to fetch {url!r}: not an allowed https endpoint")
+
     req = urllib.request.Request(url, headers={"User-Agent": "spatiumddi-lint-versions"})
-    if token and "api.github.com" in url:
+    if token and host == _GITHUB_API_HOST:
         req.add_header("Authorization", f"Bearer {token}")
-    with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310 (fixed hosts)
+    with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310 — https + allowlist above
         return json.loads(resp.read().decode("utf-8"))
 
 

--- a/scripts/lint_versions.py
+++ b/scripts/lint_versions.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Guard the version pins Dependabot cannot see (#975).
+
+``versions.json`` at the repo root is the source of truth for every pin that
+is not owned by a lockfile or by Dependabot. This script is what makes it a
+source of truth rather than a second copy: it asserts that every ``match``
+template in the manifest still appears in its file, the expected number of
+times, at the version the manifest declares.
+
+Two modes:
+
+``--check`` (the default)
+    Offline, stdlib-only, no network. Runs in CI's unconditional Backend Lint
+    job. Exit 0 when every pin agrees with the manifest, 1 otherwise.
+
+``--check-upstream``
+    Resolves each component's declared upstream and prints a current-vs-latest
+    table. **Advisory** -- it exits 0 even when things are behind, because a
+    deliberate hold is not a failure and a network hiccup must not be one
+    either. The weekly job turns its output into a tracking issue.
+
+Failure semantics, because this repo has been bitten four separate times by a
+guard that reported success while evaluating nothing (#1028, #1029, #1030,
+and the ``previous.json`` rotation in #882):
+
+* A manifest that is missing, unparseable, or has no components is a hard
+  error -- never "nothing to check, all good".
+* A ``pinned_in`` path that does not exist is an ERROR, not a skip. A pin
+  whose file was renamed is precisely the drift this exists to catch, and
+  skipping it would report the rename as a pass.
+* ``--check`` refuses to report success unless it actually compared at least
+  one assertion, and prints the number it made so "0 checked" cannot read the
+  same as "all passed".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "versions.json"
+
+
+class ManifestError(Exception):
+    """The manifest itself is unusable -- distinct from a pin being wrong."""
+
+
+#: Exhaustive key sets. Anything outside them is a typo, and a typo in this
+#: file is a guard that silently stops guarding -- see load_manifest.
+_MANIFEST_KEYS = {"$comment", "components", "holds"}
+_COMPONENT_KEYS = {"version", "digest", "pinned_in", "upstream", "hold", "note"}
+_SITE_KEYS = {"path", "match", "count"}
+
+
+# ── manifest loading ─────────────────────────────────────────────────────────
+
+
+def load_manifest(path: pathlib.Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise ManifestError(f"{path} does not exist")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"{path} is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ManifestError(f"{path} must contain a JSON object")
+
+    components = data.get("components")
+    if not isinstance(components, dict) or not components:
+        raise ManifestError(f"{path} declares no components — nothing would be checked")
+
+    unknown_top = set(data) - _MANIFEST_KEYS
+    if unknown_top:
+        raise ManifestError(f"unknown top-level key(s): {sorted(unknown_top)}")
+
+    for name, entry in components.items():
+        if not isinstance(entry, dict):
+            raise ManifestError(f"component {name!r} is not an object")
+        # Unknown keys are REFUSED, not ignored. A typo is otherwise silent
+        # and strictly weakening: ``"counts": 3`` leaves ``count`` unset, so
+        # the exact-occurrence assertion quietly downgrades to "at least one"
+        # and a 2-of-3 partial bump passes. Same failure shape the manifest
+        # exists to prevent, one level up.
+        unknown = set(entry) - _COMPONENT_KEYS
+        if unknown:
+            raise ManifestError(
+                f"component {name!r} has unknown key(s): {sorted(unknown)} "
+                f"(allowed: {sorted(_COMPONENT_KEYS)})"
+            )
+        version = entry.get("version")
+        if not isinstance(version, str) or not version.strip():
+            raise ManifestError(f"component {name!r} has no version")
+        pinned_in = entry.get("pinned_in")
+        if not isinstance(pinned_in, list) or not pinned_in:
+            # A component with nowhere to check is a documentation entry
+            # wearing a component's clothes. Those belong under "holds", which
+            # is honest about asserting nothing.
+            raise ManifestError(
+                f"component {name!r} has an empty pinned_in — "
+                f"move it to the top-level 'holds' list if it asserts nothing"
+            )
+        for site in pinned_in:
+            if not isinstance(site, dict) or not isinstance(site.get("path"), str):
+                raise ManifestError(f"component {name!r} has a pinned_in entry with no path")
+            unknown = set(site) - _SITE_KEYS
+            if unknown:
+                raise ManifestError(
+                    f"component {name!r} site {site['path']!r} has unknown key(s): "
+                    f"{sorted(unknown)} (allowed: {sorted(_SITE_KEYS)})"
+                )
+            count = site.get("count")
+            if count is not None and (not isinstance(count, int) or count < 1):
+                raise ManifestError(
+                    f"component {name!r} site {site['path']!r}: "
+                    f"count must be a positive integer, got {count!r}"
+                )
+    return data
+
+
+def render_match(template: str, version: str) -> str:
+    """Substitute the version placeholders in a match template.
+
+    ``{version}`` is the canonical string; ``{version_no_v}`` is the same with
+    a leading ``v`` stripped, which is what image tags and chart dependency
+    versions use where the release tag carries one (``v3.21.4`` -> ``3.21.4``).
+    """
+    return template.format(version=version, version_no_v=version.lstrip("v"))
+
+
+# ── the offline check ────────────────────────────────────────────────────────
+
+
+def check(manifest: dict[str, Any], root: pathlib.Path) -> tuple[list[str], int]:
+    """Return (problems, number of assertions actually made)."""
+    problems: list[str] = []
+    checked = 0
+
+    for name, entry in manifest["components"].items():
+        version = entry["version"]
+        # A digest pin is asserted as a literal in every file that carries the
+        # tag. It cannot be a template -- a digest does not derive from a
+        # version -- so ``--check-upstream`` is what proves the PAIR still
+        # agrees; this only stops the literal being edited to something the
+        # files do not contain.
+        digest = entry.get("digest")
+        if digest is not None:
+            checked += 1
+            first = manifest["components"][name]["pinned_in"][0]["path"]
+            path = root / first
+            if not path.is_file():
+                problems.append(f"{name}: {first} does not exist (pinned_in is stale)")
+            elif digest not in path.read_text(encoding="utf-8", errors="replace"):
+                problems.append(
+                    f"{name}: {first} does not contain digest {digest!r} "
+                    f"(manifest pins {name} {version} at that digest)"
+                )
+        for site in entry["pinned_in"]:
+            rel = site["path"]
+            template = site.get("match", "{version}")
+            expected = site.get("count")
+            path = root / rel
+
+            try:
+                needle = render_match(template, version)
+            except (KeyError, IndexError, ValueError) as exc:
+                problems.append(
+                    f"{name}: match template {template!r} is not a valid "
+                    f"version template ({exc})"
+                )
+                continue
+
+            checked += 1
+
+            if not path.is_file():
+                # Deliberately an error, not a skip: a pin whose file moved is
+                # the drift this guard exists for.
+                problems.append(f"{name}: {rel} does not exist (pinned_in is stale)")
+                continue
+
+            found = path.read_text(encoding="utf-8", errors="replace").count(needle)
+            if expected is None:
+                if found < 1:
+                    problems.append(
+                        f"{name}: {rel} does not contain {needle!r} "
+                        f"(manifest says {name} is {version})"
+                    )
+            elif found != expected:
+                problems.append(
+                    f"{name}: {rel} contains {needle!r} {found}×, expected {expected}× "
+                    f"(manifest says {name} is {version})"
+                )
+
+    return problems, checked
+
+
+# ── the upstream check (advisory, network) ───────────────────────────────────
+
+
+def _http_json(url: str, token: str | None = None) -> Any:
+    import urllib.error
+    import urllib.request
+
+    req = urllib.request.Request(url, headers={"User-Agent": "spatiumddi-lint-versions"})
+    if token and "api.github.com" in url:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310 (fixed hosts)
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _latest_github(repo: str, track: str | None, token: str | None) -> str:
+    if not track:
+        return str(_http_json(f"https://api.github.com/repos/{repo}/releases/latest", token)["tag_name"])
+    pattern = re.compile(track)
+    rel = _http_json(f"https://api.github.com/repos/{repo}/releases?per_page=100", token)
+    for entry in rel:
+        tag = str(entry.get("tag_name", ""))
+        if pattern.search(tag) and not entry.get("prerelease"):
+            return tag
+    raise LookupError(f"no release on {repo} matching {track!r}")
+
+
+def _latest_tag(tags: list[str], track: str | None) -> str:
+    """Newest tag by natural version order, optionally filtered by a regex."""
+    pattern = re.compile(track) if track else None
+    candidates = [t for t in tags if pattern is None or pattern.search(t)]
+    if not candidates:
+        raise LookupError(f"no tag matching {track!r}")
+
+    def key(tag: str) -> list[int]:
+        return [int(part) for part in re.findall(r"\d+", tag)]
+
+    return max(candidates, key=key)
+
+
+def _latest_dockerhub(repo: str, track: str | None) -> str:
+    tags: list[str] = []
+    url = f"https://hub.docker.com/v2/repositories/{repo}/tags?page_size=100"
+    for _ in range(5):  # bounded: five pages is 500 tags
+        page = _http_json(url)
+        tags.extend(str(t["name"]) for t in page.get("results", []))
+        url = page.get("next")
+        if not url:
+            break
+    return _latest_tag(tags, track)
+
+
+def _latest_quay(repo: str, track: str | None) -> str:
+    page = _http_json(
+        f"https://quay.io/api/v1/repository/{repo}/tag/?limit=100&onlyActiveTags=true"
+    )
+    return _latest_tag([str(t["name"]) for t in page.get("tags", [])], track)
+
+
+def resolve_upstream(entry: dict[str, Any], token: str | None) -> str | None:
+    """Latest upstream version, or None when the entry declares no upstream."""
+    upstream = entry.get("upstream") or {}
+    kind = upstream.get("kind", "none")
+    track = upstream.get("track")
+    if kind == "none":
+        return None
+    if kind == "github-release":
+        return _latest_github(upstream["repo"], track, token)
+    if kind == "dockerhub":
+        return _latest_dockerhub(upstream["repo"], track)
+    if kind == "quay":
+        return _latest_quay(upstream["repo"], track)
+    if kind == "rubygems":
+        return str(_http_json(f"https://rubygems.org/api/v1/versions/{upstream['repo']}/latest.json")["version"])
+    raise LookupError(f"unknown upstream kind {kind!r}")
+
+
+def _comparable(value: str) -> str:
+    """Reduce a version string to the part worth comparing.
+
+    Upstream and the pin rarely spell a version the same way: a chart release
+    is tagged ``metallb-chart-0.16.1`` against a pin of ``v0.15.3``, k3s tags
+    ``v1.36.4+k3s1``, and an image tag carries a base-OS suffix
+    (``8.10.1-alpine``). So take the LAST dotted number run, which is the
+    version in every one of those shapes.
+
+    "Last" and "dotted" are both load-bearing: ``frr-k8s-chart-0.0.26``
+    contains a bare ``8`` inside "k8s", and a first-match or any-digits rule
+    would compare that against the real version and report a wrong verdict.
+    Tags with no dotted run (``16-alpine``) fall back to their digits, and
+    ones with no digits at all (``latest``) compare as themselves.
+    """
+    dotted = re.findall(r"\d+(?:\.\d+)+", value)
+    if dotted:
+        return dotted[-1]
+    digits = re.findall(r"\d+", value)
+    return digits[-1] if digits else value
+
+
+def _dockerhub_tag_digest(repo: str, tag: str) -> str:
+    return str(_http_json(f"https://hub.docker.com/v2/repositories/{repo}/tags/{tag}")["digest"])
+
+
+def check_upstream(manifest: dict[str, Any], token: str | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for name, entry in manifest["components"].items():
+        row: dict[str, Any] = {
+            "name": name,
+            "current": entry["version"],
+            "hold": entry.get("hold"),
+            "latest": None,
+            "error": None,
+            "behind": False,
+            "digest_mismatch": False,
+        }
+        try:
+            latest = resolve_upstream(entry, token)
+        except Exception as exc:  # noqa: BLE001 — advisory; one failure must not stop the sweep
+            row["error"] = f"{type(exc).__name__}: {exc}"
+        else:
+            row["latest"] = latest
+            if latest is not None:
+                row["behind"] = _comparable(latest) != _comparable(entry["version"])
+
+        # A digest-pinned component has TWO ways to be wrong, and the offline
+        # lint can only see one: bumping `version` while leaving `digest`
+        # alone passes every literal assertion and still builds the OLD image.
+        # This is where that is caught.
+        digest = entry.get("digest")
+        upstream = entry.get("upstream") or {}
+        if digest and upstream.get("kind") == "dockerhub" and not row["error"]:
+            try:
+                actual = _dockerhub_tag_digest(upstream["repo"], entry["version"])
+            except Exception as exc:  # noqa: BLE001 — advisory, like the lookup above
+                row["error"] = f"digest check failed: {type(exc).__name__}: {exc}"
+            else:
+                if actual != digest:
+                    row["digest_mismatch"] = True
+                    row["error"] = (
+                        f"digest pin does not match tag {entry['version']} upstream "
+                        f"(pinned {digest[:19]}…, upstream {actual[:19]}…) — "
+                        f"bump `digest` alongside `version`"
+                    )
+        rows.append(row)
+    return rows
+
+
+def format_upstream_table(rows: list[dict[str, Any]]) -> str:
+    out = ["| Component | Pinned | Latest upstream | Status |", "|---|---|---|---|"]
+    for row in rows:
+        if row["error"]:
+            status = f"⚠️ check failed — {row['error']}"
+            latest = "—"
+        elif row["latest"] is None:
+            status = "— no upstream declared"
+            latest = "—"
+        elif row["behind"] and row["hold"]:
+            status = "🔒 behind, held on purpose"
+            latest = row["latest"]
+        elif row["behind"]:
+            status = "⬆️ behind"
+            latest = row["latest"]
+        else:
+            status = "✅ current"
+            latest = row["latest"]
+        out.append(f"| `{row['name']}` | `{row['current']}` | `{latest}` | {status} |")
+    return "\n".join(out)
+
+
+# ── entry point ──────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        # Without this, argparse resolves any unambiguous PREFIX of a long
+        # option -- so ``--check``, the mode this script's own docstring
+        # documents, silently became ``--check-upstream``: the advisory
+        # network mode that always exits 0. Following the documentation
+        # turned the guard off. ``--check`` is now a real flag, and any
+        # other undefined option is an error instead of a near-miss.
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="assert every pin matches the manifest (the default; offline, no network)",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=pathlib.Path,
+        default=MANIFEST_PATH,
+        help="path to versions.json (default: the repo root's)",
+    )
+    parser.add_argument(
+        "--root",
+        type=pathlib.Path,
+        default=None,
+        help="repo root the pinned_in paths are relative to (default: the manifest's directory)",
+    )
+    parser.add_argument(
+        "--check-upstream",
+        action="store_true",
+        help="resolve each upstream and print a current-vs-latest table (advisory, needs network)",
+    )
+    parser.add_argument(
+        "--github-token",
+        default=None,
+        help="token for api.github.com (raises the rate limit); also read from GITHUB_TOKEN",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = load_manifest(args.manifest)
+    except ManifestError as exc:
+        print(f"versions.json is unusable: {exc}", file=sys.stderr)
+        return 1
+
+    if args.check_upstream and args.check:
+        print("--check and --check-upstream are different modes; pass one", file=sys.stderr)
+        return 1
+
+    if args.check_upstream:
+        token = args.github_token or os.environ.get("GITHUB_TOKEN")
+        rows = check_upstream(manifest, token)
+        print(format_upstream_table(rows))
+        behind = [r for r in rows if r["behind"] and not r["hold"]]
+        held = [r for r in rows if r["behind"] and r["hold"]]
+        failed = [r for r in rows if r["error"]]
+        print()
+        print(
+            f"{len(behind)} behind upstream, {len(held)} behind but held on purpose, "
+            f"{len(failed)} could not be checked, {len(rows)} components total."
+        )
+        # Machine-readable, because the prose line above is not. A consumer
+        # scraping the first number off it reads "0 behind" when every lookup
+        # failed and reports the fleet current -- the reason this line exists.
+        # ``failed`` is what makes "we could not tell" distinguishable from
+        # "nothing is behind"; they must never collapse into one verdict.
+        print(
+            f"RESULT behind={len(behind)} held={len(held)} "
+            f"failed={len(failed)} total={len(rows)}"
+        )
+        # Advisory by design: a hold is not a failure, and neither is a
+        # transient network error on a weekly informational job.
+        return 0
+
+    root = args.root or args.manifest.resolve().parent
+    problems, checked = check(manifest, root)
+
+    if checked == 0:
+        # Unreachable given load_manifest's guarantees, and asserted anyway:
+        # "0 assertions" must never be able to print the same line as "all
+        # passed" (#1030).
+        print("versions.json produced no assertions — refusing to report a pass", file=sys.stderr)
+        return 1
+
+    if problems:
+        print(f"{len(problems)} version pin(s) disagree with versions.json:\n", file=sys.stderr)
+        for problem in problems:
+            print(f"  ✗ {problem}", file=sys.stderr)
+        print(
+            "\nversions.json is the source of truth. Either the file is stale "
+            "(bump it) or the pin was edited without it (put it back).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"OK — {checked} pin assertion(s) across "
+        f"{len(manifest['components'])} component(s) agree with versions.json."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/versions.json
+++ b/versions.json
@@ -285,7 +285,7 @@
         { "path": "docs/THIRD_PARTY.md", "match": "| {version} |", "count": 1 }
       ],
       "upstream": { "kind": "dockerhub", "repo": "library/redis", "track": "^8\\.[0-9]+\\.[0-9]+-alpine$" },
-      "note": "Fifteen copies across compose, CI service containers, two charts, a k8s overlay, the appliance bake array and four docs pages. The prose occurrences are asserted too, not just the image refs: a comment naming the old version is this repo's most-reported review finding, and here it would tell the next reader the chart and compose disagree when they do not. Redis 8+ is RSALv2 / SSPLv1 / AGPLv3 -- a MAJOR bump is a licence decision, not a version bump."
+      "note": "The most-copied component here: both compose files, the CI test-shard service container, two charts (values, template comment and Chart.yaml), the Sentinel overlay's three containers, the appliance bake array and four docs pages. Deliberately not stated as a number -- a count in prose goes stale the next time a copy is added, and the pinned_in list below is the count. The prose occurrences are asserted too, not just the image refs: a comment naming the old version is this repo's most-reported review finding, and here it would tell the next reader the chart and compose disagree when they do not. Redis 8+ is RSALv2 / SSPLv1 / AGPLv3 -- a MAJOR bump is a licence decision, not a version bump."
     },
 
     "postgres": {
@@ -306,7 +306,7 @@
         { "path": "docs/THIRD_PARTY.md", "match": "| {version} |", "count": 1 }
       ],
       "upstream": { "kind": "dockerhub", "repo": "library/postgres", "track": "^1[0-9]-alpine$" },
-      "hold": "Thirteen copies, so the #208 migration has to move all of them. PostgreSQL 16 is supported until Nov 2028. Moving to 18 is a data migration, not a tag bump, and has its own issue (#208). Dependabot defers the major; this records why."
+      "hold": "Copied about as widely as redis, so the #208 migration has to move every entry in pinned_in below -- that list is the worklist, and is why it is enumerated rather than summarised. PostgreSQL 16 is supported until Nov 2028. Moving to 18 is a data migration, not a tag bump, and has its own issue (#208). Dependabot defers the major; this records why."
     },
 
     "kube-state-metrics": {

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,494 @@
+{
+  "$comment": [
+    "Every version pin in this repository that neither Dependabot nor a lockfile owns.",
+    "",
+    "WHY THIS FILE EXISTS (#975). Dependabot covers four ecosystems here:",
+    "github-actions, docker `FROM` lines in the directories listed in",
+    ".github/dependabot.yml, pip and npm. Everything else is invisible to it --",
+    "it has no Helm ecosystem, does not read `ARG` values, chart values.yaml,",
+    "action `with:` inputs, CI shell scripts or the appliance bake arrays. Those",
+    "pins were scattered across nine file types, several behind upstream, two",
+    "past end-of-life, and one component sat on two different versions because",
+    "only one of its copies was Dependabot-visible.",
+    "",
+    "HOW IT IS ENFORCED. scripts/lint_versions.py runs in CI's unconditional",
+    "Backend Lint job and asserts that every `match` below still appears in its",
+    "file the expected number of times. Bumping a component is ONE edit -- the",
+    "`version` field -- because every `match` is a template over it.",
+    "",
+    "WHY LITERALS STAY IN THE FILES rather than being read from here at build",
+    "time. A build-time read that silently yields an empty string is the exact",
+    "failure class this repo has been bitten by repeatedly (#1028, #1029, #1030):",
+    "a guard that evaluates nothing looks identical to one that passed. An",
+    "action input resolving to '' falls back to the action's own default (for",
+    "azure/setup-helm, `latest`) with no error anywhere. The lint gives the same",
+    "single-source guarantee with no new build-time failure mode, so the literal",
+    "stays and the lint keeps it honest.",
+    "",
+    "WHAT IS DELIBERATELY NOT HERE. Anything a lockfile or Dependabot already",
+    "owns -- pyproject / package-lock dependencies, `uses:` action refs, and",
+    "`FROM` lines Dependabot actually bumps. Listing those twice would create",
+    "the drift this file exists to remove.",
+    "",
+    "THE ONE EXCEPTION, and it is deliberate: where a Dependabot-visible `FROM`",
+    "shares a component with a copy Dependabot cannot see, the `FROM` IS listed",
+    "(see `nginx`). That is what turns a Dependabot bump into a failing lint",
+    "that forces the other copies to move with it, instead of letting them",
+    "silently fall a minor behind -- which is exactly what happened to the",
+    "appliance chart's nginx while the frontend image moved on without it.",
+    "",
+    "SCHEMA. Each entry under `components`:",
+    "  version     canonical version string; the single thing you edit to bump.",
+    "  digest      optional, for a component pinned by tag AND digest. A digest",
+    "              does not derive from a version, so it is asserted as a",
+    "              literal offline and --check-upstream resolves the tag to",
+    "              prove the PAIR still agrees. Without that second half,",
+    "              bumping `version` alone passes every assertion and still",
+    "              builds the old image.",
+    "  pinned_in   [{path, match, count?}]. `match` is a template over",
+    "              {version} and {version_no_v} (the same string with a leading",
+    "              'v' stripped). `count` is the EXACT number of occurrences",
+    "              required; omit it to require at least one. Use an exact count",
+    "              where the copies must be exhaustive (three etcd services, three",
+    "              redis containers) -- without it, bumping two of three passes.",
+    "  upstream    how --check-upstream resolves the current release. `kind`:",
+    "              github-release | dockerhub | quay | rubygems | none.",
+    "  hold        present when the pin is deliberately BEHIND upstream. The",
+    "              string is the reason; --check-upstream reports these",
+    "              separately so a known hold never reads as neglect.",
+    "  note        anything the next person needs before touching it.",
+    "",
+    "Unknown keys are REFUSED at every level, not ignored. A typo here is a",
+    "guard that silently stops guarding: `\"counts\": 3` leaves `count` unset,",
+    "downgrading an exact assertion to \"at least one\", and a bump that moved",
+    "two of three copies then passes.",
+    "",
+    "`holds` at the bottom records decisions that have no literal for a lint to",
+    "hold honest -- their pins live in Dependabot ignore rules or in a distro",
+    "codename that never changes. The reason is the deliverable there."
+  ],
+
+  "components": {
+    "k3s": {
+      "version": "v1.36.4+k3s1",
+      "pinned_in": [
+        { "path": "Makefile", "match": "K3S_VERSION ?= {version}", "count": 1 },
+        { "path": "appliance/scripts/fetch-k3s.sh", "match": "K3S_VERSION:-{version}", "count": 1 },
+        { "path": "docs/THIRD_PARTY.md", "match": "| {version} |", "count": 1 }
+      ],
+      "upstream": { "kind": "github-release", "repo": "k3s-io/k3s" },
+      "note": "Bump only alongside a slot-image cut. A Kubernetes minor is NOT slot-revertible: the k3s data dir lives on persistent /var, not in the A/B slot, so reverting the slot starts the old apiserver against a store the new one has written (#974). Moving this also moves kind-node and kubeconform-k8s-target below."
+    },
+
+    "kind-node": {
+      "version": "v1.36.4",
+      "pinned_in": [
+        {
+          "path": ".github/workflows/agent-e2e.yml",
+          "match": "kindest/node:{version}@sha256:",
+          "count": 1
+        }
+      ],
+      "upstream": { "kind": "none" },
+      "note": "Lock-stepped to k3s's Kubernetes minor, not chosen independently -- the e2e exists to prove the chart on the Kubernetes the appliance actually runs. Digest-pinned because kindest/node tags are re-pushed. Bump with k3s, and take the digest kind publishes for the tag."
+    },
+
+    "helm": {
+      "version": "v3.21.4",
+      "pinned_in": [
+        { "path": "Makefile", "match": "alpine/helm:{version_no_v}", "count": 1 },
+        { "path": ".github/workflows/ci.yml", "match": "version: {version}", "count": 1 },
+        { "path": ".github/workflows/release.yml", "match": "version: {version}", "count": 1 },
+        { "path": ".github/workflows/build-appliance.yml", "match": "version: {version}", "count": 1 },
+        { "path": ".github/workflows/agent-e2e.yml", "match": "version: {version}", "count": 1 }
+      ],
+      "upstream": { "kind": "github-release", "repo": "helm/helm", "track": "^v3\\." },
+      "note": "Build-time tool only -- nothing ships it. Stay on the 3.x track deliberately: the appliance renders charts through k3s's BUNDLED helm-controller, which is independent of this binary, so a Helm 4 move here buys nothing and risks the chart-rendering CLI diverging from what the appliance uses. Five copies, none of them Dependabot-visible; this component is the reason the manifest exists."
+    },
+
+    "kubeconform": {
+      "version": "v0.8.0",
+      "pinned_in": [
+        {
+          "path": ".github/scripts/install-kubeconform.sh",
+          "match": "KUBECONFORM_VERSION:-{version}",
+          "count": 1
+        },
+        { "path": ".github/workflows/ci.yml", "match": "kubeconform-schemas-{version}-", "count": 1 }
+      ],
+      "upstream": { "kind": "github-release", "repo": "yannh/kubeconform" },
+      "note": "The ci.yml occurrence is the schema cache key, which embeds both this version and kubeconform-k8s-target. Bumping either without the key is a stale-cache bug, so both are asserted against it."
+    },
+
+    "kubeconform-k8s-target": {
+      "version": "1.36.0",
+      "pinned_in": [
+        {
+          "path": ".github/scripts/charts-render-check.sh",
+          "match": "K8S_VERSION:-{version}",
+          "count": 1
+        },
+        { "path": ".github/workflows/ci.yml", "match": "-k8s-{version}-", "count": 1 }
+      ],
+      "upstream": { "kind": "none" },
+      "note": "The Kubernetes API version `make charts-lint` validates against. Lock-stepped to k3s above -- validating against a Kubernetes the appliance does not run is how a chart that renders in CI fails on the box (#974)."
+    },
+
+    "metallb": {
+      "version": "v0.15.3",
+      "pinned_in": [
+        {
+          "path": "charts/spatiumddi-metallb/Chart.yaml",
+          "match": "version: {version_no_v}",
+          "count": 1
+        },
+        { "path": "charts/spatiumddi-metallb/values.yaml", "match": "tag: {version}", "count": 2 },
+        {
+          "path": "appliance/scripts/bake-images.sh",
+          "match": "quay.io/metallb/controller:{version}",
+          "count": 1
+        },
+        {
+          "path": "appliance/scripts/bake-images.sh",
+          "match": "quay.io/metallb/speaker:{version}",
+          "count": 1
+        },
+        { "path": "docs/THIRD_PARTY.md", "match": "chart + images {version_no_v}", "count": 1 }
+      ],
+      "upstream": { "kind": "github-release", "repo": "metallb/metallb" },
+      "hold": "v0.16.x regressed the speaker's ServiceL2Status reconciler into an apiserver-flooding create-fail/not-found loop -- metallb/metallb#3063, still OPEN as of 2026-09-08. An image-only pin on the 0.16 chart does not work either: its speaker probe hits /healthz:17472, which 0.15.3 does not serve, so the pod crashloops. The chart is therefore pinned end-to-end. Re-check #3063 before bumping.",
+      "note": "frr-k8s, frr and kube-rbac-proxy below are this chart's vendored sub-pins, not independent choices -- they move when this moves, and the baked image refs must equal what the pod spec pulls or an air-gapped appliance gets ImagePullBackOff."
+    },
+
+    "frr-k8s": {
+      "version": "v0.0.21",
+      "pinned_in": [
+        { "path": "charts/spatiumddi-metallb/values.yaml", "match": "tag: {version}", "count": 1 },
+        {
+          "path": "appliance/scripts/bake-images.sh",
+          "match": "quay.io/metallb/frr-k8s:{version}",
+          "count": 1
+        }
+      ],
+      "upstream": { "kind": "github-release", "repo": "metallb/frr-k8s" },
+      "hold": "MetalLB sub-pin -- the default inside the vendored metallb-0.15.3 chart. Moves with metallb, which is held."
+    },
+
+    "frr": {
+      "version": "10.4.1",
+      "pinned_in": [
+        { "path": "charts/spatiumddi-metallb/values.yaml", "match": "tag: {version}", "count": 1 },
+        {
+          "path": "appliance/scripts/bake-images.sh",
+          "match": "quay.io/frrouting/frr:{version}",
+          "count": 1
+        }
+      ],
+      "upstream": { "kind": "github-release", "repo": "FRRouting/frr" },
+      "hold": "MetalLB sub-pin -- the frr-k8s 0.0.21 default. Moves with metallb, which is held. GPL-2.0, and only pulled when BGP mode is enabled (default off); flagged distinctly in NOTICE."
+    },
+
+    "kube-rbac-proxy": {
+      "version": "v0.12.0",
+      "pinned_in": [
+        { "path": "charts/spatiumddi-metallb/values.yaml", "match": "tag: {version}", "count": 1 },
+        {
+          "path": "appliance/scripts/bake-images.sh",
+          "match": "quay.io/brancz/kube-rbac-proxy:{version}",
+          "count": 1
+        }
+      ],
+      "upstream": { "kind": "github-release", "repo": "brancz/kube-rbac-proxy" },
+      "hold": "MetalLB sub-pin -- the vendored frr-k8s chart's default, inherited rather than chosen. Moves with metallb, which is held. Only reachable on the default-off BGP path. #575 moved it off the sunset gcr.io/kubebuilder mirror; the chart override and the bake entry must stay byte-identical or the baked image is not the one the pod pulls."
+    },
+
+    "cloudnative-pg-chart": {
+      "version": "0.29.0",
+      "pinned_in": [
+        {
+          "path": "charts/spatiumddi-appliance/Chart.yaml",
+          "match": "version: {version}",
+          "count": 1
+        },
+        { "path": "docs/THIRD_PARTY.md", "match": "chart {version} (operator", "count": 1 }
+      ],
+      "upstream": { "kind": "github-release", "repo": "cloudnative-pg/charts", "track": "^cloudnative-pg-v" },
+      "note": "Carries the operator version below; the two must move together. Run `helm dependency update` on a bump."
+    },
+
+    "cloudnative-pg-operator": {
+      "version": "1.30.0",
+      "pinned_in": [
+        {
+          "path": "appliance/scripts/bake-images.sh",
+          "match": "cloudnative-pg:{version}",
+          "count": 1
+        },
+        { "path": "docs/THIRD_PARTY.md", "match": "(operator {version})", "count": 1 }
+      ],
+      "upstream": { "kind": "github-release", "repo": "cloudnative-pg/cloudnative-pg" },
+      "note": "Set by cloudnative-pg-chart above -- this entry pins the image the appliance bakes, which must equal the operator that chart deploys or an air-gapped install cannot start Postgres. Watch the CNPG support matrix: 1.29.x reached EOL 2026-09-29."
+    },
+
+    "cloudnative-pg-postgresql": {
+      "version": "16",
+      "pinned_in": [
+        {
+          "path": "appliance/scripts/bake-images.sh",
+          "match": "ghcr.io/cloudnative-pg/postgresql:{version}",
+          "count": 1
+        },
+        {
+          "path": "charts/spatiumddi/values.yaml",
+          "match": "ghcr.io/cloudnative-pg/postgresql:{version}",
+          "count": 1
+        }
+      ],
+      "upstream": { "kind": "none" },
+      "hold": "The PostgreSQL major CNPG runs, so it moves with `postgres` above and with #208, not on its own. Bumping it alone would put the appliance's CNPG cluster on a different major from every other deployment shape.",
+      "note": "The one bake-array/chart-values pair the first pass of this manifest missed, and the pair where a divergence is worst: the appliance imports baked images into containerd and never pulls, so a chart naming a tag the bake did not save is ImagePullBackOff on an AIR-GAPPED box -- no error until the cluster is already offline and no network to recover over. `cnpg.imageName` in the umbrella chart and the CNPG_IMAGES entry must stay byte-identical."
+    },
+
+    "nginx": {
+      "version": "1.31.5-alpine",
+      "pinned_in": [
+        { "path": "frontend/Dockerfile", "match": "FROM nginx:{version}", "count": 1 },
+        { "path": "charts/spatiumddi-appliance/values.yaml", "match": "tag: {version}", "count": 1 },
+        {
+          "path": "charts/spatiumddi-appliance/templates/agent-landing.yaml",
+          "match": "``nginx:{version}``",
+          "count": 1
+        },
+        { "path": "appliance/scripts/bake-images.sh", "match": "\"nginx:{version}\"", "count": 1 }
+      ],
+      "upstream": { "kind": "dockerhub", "repo": "library/nginx", "track": "^1\\.[0-9]+\\.[0-9]+-alpine$" },
+      "note": "The frontend `FROM` IS Dependabot-visible and is listed anyway -- that is the deliberate exception in the header. It is the reason this entry exists: Dependabot moved the frontend image to 1.31 on 2026-07-20 (#688) and the appliance chart's agent-landing copy sat on 1.30.3 for the seven weeks until #975, because nothing connected them. Listing both means the next Dependabot bump fails this lint until the chart and the bake array move too."
+    },
+
+    "redis": {
+      "version": "8.10.1-alpine",
+      "pinned_in": [
+        { "path": "docker-compose.yml", "match": "image: redis:{version}", "count": 1 },
+        { "path": "docker-compose.dev.yml", "match": "image: redis:{version}", "count": 1 },
+        { "path": ".github/workflows/ci.yml", "match": "image: redis:{version}", "count": 1 },
+        { "path": "charts/spatiumddi/templates/redis.yaml", "match": "redis:{version}", "count": 1 },
+        { "path": "appliance/README.md", "match": "redis:{version}", "count": 1 },
+        { "path": "docs/deployment/APPLIANCE.md", "match": "redis:{version}", "count": 1 },
+        { "path": "docs/deployment/KUBERNETES.md", "match": "redis:{version}", "count": 1 },
+        { "path": "docs/DEVELOPMENT.md", "match": "redis:{version}", "count": 1 },
+        { "path": "docs/THIRD_PARTY.md", "match": "redis:{version}", "count": 1 },
+        { "path": "charts/spatiumddi/values.yaml", "match": "tag: \"{version}\"", "count": 1 },
+        { "path": "charts/spatiumddi/values.yaml", "match": "redis:{version}", "count": 2 },
+        { "path": "charts/spatiumddi/Chart.yaml", "match": "``redis:{version}``", "count": 1 },
+        { "path": "k8s/ha/redis-sentinel.yaml", "match": "image: redis:{version}", "count": 3 },
+        { "path": "appliance/scripts/bake-images.sh", "match": "\"redis:{version}\"", "count": 1 },
+        { "path": "docs/THIRD_PARTY.md", "match": "| {version} |", "count": 1 }
+      ],
+      "upstream": { "kind": "dockerhub", "repo": "library/redis", "track": "^8\\.[0-9]+\\.[0-9]+-alpine$" },
+      "note": "Fifteen copies across compose, CI service containers, two charts, a k8s overlay, the appliance bake array and four docs pages. The prose occurrences are asserted too, not just the image refs: a comment naming the old version is this repo's most-reported review finding, and here it would tell the next reader the chart and compose disagree when they do not. Redis 8+ is RSALv2 / SSPLv1 / AGPLv3 -- a MAJOR bump is a licence decision, not a version bump."
+    },
+
+    "postgres": {
+      "version": "16-alpine",
+      "pinned_in": [
+        { "path": "docker-compose.yml", "match": "image: postgres:{version}", "count": 1 },
+        { "path": "docker-compose.dev.yml", "match": "image: postgres:{version}", "count": 1 },
+        { "path": ".github/workflows/ci.yml", "match": "image: postgres:{version}", "count": 1 },
+        { "path": "charts/spatiumddi/values.yaml", "match": "tag: \"{version}\"", "count": 1 },
+        { "path": "charts/spatiumddi/values.yaml", "match": "postgres:{version}", "count": 2 },
+        { "path": "charts/spatiumddi/templates/postgres.yaml", "match": "postgres:{version}", "count": 1 },
+        { "path": "charts/spatiumddi/Chart.yaml", "match": "postgres:{version}", "count": 1 },
+        { "path": "k8s/ha/postgres-docker-compose.yaml", "match": "FROM postgres:{version}", "count": 1 },
+        { "path": "k8s/README.md", "match": "postgres:{version}", "count": 1 },
+        { "path": "docs/deployment/APPLIANCE.md", "match": "postgres:{version}", "count": 1 },
+        { "path": "docs/deployment/KUBERNETES.md", "match": "postgres:{version}", "count": 1 },
+        { "path": "docs/DEVELOPMENT.md", "match": "postgres:{version}", "count": 1 },
+        { "path": "docs/THIRD_PARTY.md", "match": "| {version} |", "count": 1 }
+      ],
+      "upstream": { "kind": "dockerhub", "repo": "library/postgres", "track": "^1[0-9]-alpine$" },
+      "hold": "Thirteen copies, so the #208 migration has to move all of them. PostgreSQL 16 is supported until Nov 2028. Moving to 18 is a data migration, not a tag bump, and has its own issue (#208). Dependabot defers the major; this records why."
+    },
+
+    "kube-state-metrics": {
+      "version": "v2.20.0",
+      "pinned_in": [
+        { "path": "charts/spatiumddi-appliance/values.yaml", "match": "tag: {version}", "count": 1 },
+        {
+          "path": "appliance/scripts/bake-images.sh",
+          "match": "kube-state-metrics:{version}",
+          "count": 1
+        },
+        { "path": "docs/THIRD_PARTY.md", "match": "| {version}, **default off**", "count": 1 }
+      ],
+      "upstream": { "kind": "github-release", "repo": "kubernetes/kube-state-metrics" },
+      "note": "Default off. Baked regardless, so an operator can enable it on an air-gapped appliance without a pull."
+    },
+
+    "node-exporter": {
+      "version": "v1.12.1",
+      "pinned_in": [
+        { "path": "charts/spatiumddi-appliance/values.yaml", "match": "tag: {version}", "count": 1 },
+        {
+          "path": "appliance/scripts/bake-images.sh",
+          "match": "node-exporter:{version}",
+          "count": 1
+        },
+        { "path": "docs/THIRD_PARTY.md", "match": "| {version}, **default off**", "count": 1 }
+      ],
+      "upstream": { "kind": "github-release", "repo": "prometheus/node_exporter" },
+      "note": "Default off, like kube-state-metrics. The upstream repo is `node_exporter` with an underscore; the image is `node-exporter` with a hyphen."
+    },
+
+    "gobgp": {
+      "version": "4.9.0",
+      "pinned_in": [
+        {
+          "path": "agent/looking-glass/images/gobgp/Dockerfile",
+          "match": "ARG GOBGP_VERSION={version}",
+          "count": 1
+        },
+        { "path": "docs/THIRD_PARTY.md", "match": "| {version} (built from source)", "count": 1 }
+      ],
+      "upstream": { "kind": "github-release", "repo": "osrg/gobgp" },
+      "note": "Built from source in the image, so Dependabot's `FROM` coverage never sees it. Run `make trivy IMAGE=gobgp` on a bump -- the golang builder is a security pin (Go static-links its stdlib, so no apk upgrade can fix a stdlib CVE)."
+    },
+
+    "technitium": {
+      "version": "15.4.0",
+      "digest": "sha256:df7d90ef0f7b6fff6916d291a7022cd902290cc31c3141d4158b6c375a641b41",
+      "pinned_in": [
+        {
+          "path": "agent/dns/images/technitium/Dockerfile",
+          "match": "TECHNITIUM_VERSION={version}"
+        },
+        { "path": "docs/THIRD_PARTY.md", "match": "| {version} (digest-pinned)", "count": 1 }
+      ],
+      "upstream": { "kind": "dockerhub", "repo": "technitium/dns-server" },
+      "note": "The ONLY component here pinned by tag AND digest, and the two must move together: the Dockerfile pulls `technitium/dns-server:${TECHNITIUM_VERSION}@${TECHNITIUM_DIGEST}`, so bumping the tag alone builds the OLD image while every literal assertion still passes. The offline lint cannot catch that -- a digest does not derive from a version -- so `--check-upstream` resolves the tag on Docker Hub and reports a mismatch. Currently latest; listed so the next sweep is a lookup rather than a hunt."
+    },
+
+    "haproxy": {
+      "version": "3.4-alpine",
+      "pinned_in": [
+        {
+          "path": "k8s/ha/postgres-docker-compose.yaml",
+          "match": "image: haproxy:{version}",
+          "count": 1
+        },
+        { "path": "docs/THIRD_PARTY.md", "match": "| {version} |", "count": 1 }
+      ],
+      "upstream": { "kind": "dockerhub", "repo": "library/haproxy", "track": "^3\\.[0-9]+-alpine$" },
+      "note": "Stay on an LTS branch: this proxies every Patroni connection and nothing else in the repo watches it. 3.4 IS the current LTS -- `haproxy:lts-alpine` and `haproxy:3.4-alpine` resolve to the same digest, verified 2026-09-08. The previous pin (2.9) was a short-lived NON-LTS branch whose last release was March 2025, so it had gone 18 months with no security fixes at all."
+    },
+
+    "etcd-patroni": {
+      "version": "v3.5.33",
+      "pinned_in": [
+        {
+          "path": "k8s/ha/postgres-docker-compose.yaml",
+          "match": "image: quay.io/coreos/etcd:{version}",
+          "count": 3
+        }
+      ],
+      "upstream": { "kind": "quay", "repo": "coreos/etcd", "track": "^v3\\.5\\.[0-9]+$" },
+      "note": "The Patroni DCS in the bare-metal HA overlay -- NOT the etcd embedded in k3s, which the k3s bundle owns. Three services share it, hence the exact count: bumping two of three leaves a mixed-version DCS. Stay on 3.5 until 3.6 is verified with this Patroni version."
+    },
+
+    "patroni-image": {
+      "version": "latest",
+      "pinned_in": [
+        {
+          "path": "k8s/ha/postgres-docker-compose.yaml",
+          "match": "image: patroni-spatiumddi:{version}",
+          "count": 3
+        }
+      ],
+      "upstream": { "kind": "none" },
+      "note": "NOT a pin, and recorded here so it stops looking like one. The overlay BUILDS this image itself -- the sibling `build.dockerfile_inline` layers Patroni onto postgres:16-alpine via pip -- so `latest` names a purely local artifact that exists in no registry. Giving it a version number here would imply SpatiumDDI publishes one. The real unpinned thing in that block is `pip install patroni[etcd3]`, which resolves at build time, so two hosts built on different days get different Patroni versions; documented in docs/deployment/BAREMETAL.md rather than pinned, because the overlay is a reference template an operator is expected to adapt."
+    },
+
+    "ruby-docs-preview": {
+      "version": "3.4-slim",
+      "pinned_in": [{ "path": "docs/Dockerfile", "match": "FROM ruby:{version}", "count": 1 }],
+      "upstream": { "kind": "dockerhub", "repo": "library/ruby", "track": "^3\\.[0-9]+-slim$" },
+      "note": "Local docs-preview container only -- nothing ships it, and the published site is built by GitHub Pages, not by this image. Bumped off 3.2, which reached EOL 2026-03-31. Keep it on a supported branch anyway: it is the one place in the repo that runs a web server, and an EOL interpreter there is a CVE nobody is watching for."
+    },
+
+    "jekyll": {
+      "version": "4.4.1",
+      "pinned_in": [{ "path": "docs/Dockerfile", "match": "jekyll:{version}", "count": 1 }],
+      "upstream": { "kind": "rubygems", "repo": "jekyll" },
+      "note": "The local preview deliberately runs Jekyll 4.x while GitHub Pages runs 3.10.0 (pinned by the github-pages gem). The two agree on the plugin set and on the rendering this repo relies on; they are NOT the same Jekyll, so a page that renders only under 4.x is still a bug the preview will not catch. `make docs-verify` and the render sweep are the backstop."
+    },
+
+    "webrick": {
+      "version": "1.9.2",
+      "pinned_in": [{ "path": "docs/Dockerfile", "match": "webrick:{version}", "count": 1 }],
+      "upstream": { "kind": "rubygems", "repo": "webrick" },
+      "note": "`jekyll serve` needs it explicitly -- webrick stopped being a default gem in Ruby 3.x. Bumped off 1.8.1, which predates the request-smuggling fix in 1.8.2 (CVE-2024-47220). Local-only, but it was the only known-vulnerable web server in the tree and no lockfile or bot could see it."
+    },
+
+    "jekyll-optional-front-matter": {
+      "version": "0.3.2",
+      "pinned_in": [
+        { "path": "docs/Dockerfile", "match": "jekyll-optional-front-matter:{version}", "count": 1 }
+      ],
+      "upstream": { "kind": "rubygems", "repo": "jekyll-optional-front-matter" },
+      "hold": "Pinned to EXACTLY what the `github-pages` gem pins (verified against its published dependencies: `= 0.3.2`). 0.3.3 exists upstream and taking it would make the local preview render with a plugin the published site does not have -- which defeats the only reason this image exists. Bump when github-pages does, not when rubygems does."
+    },
+
+    "jekyll-relative-links": {
+      "version": "0.6.1",
+      "pinned_in": [
+        { "path": "docs/Dockerfile", "match": "jekyll-relative-links:{version}", "count": 1 }
+      ],
+      "upstream": { "kind": "rubygems", "repo": "jekyll-relative-links" },
+      "hold": "Same as jekyll-optional-front-matter: `github-pages` pins `= 0.6.1`. This plugin rewrites the .md links between docs pages, so a version skew here changes URLs in the preview that the published site would not produce -- the exact class of divergence the preview is supposed to rule out. 0.8.0 upstream."
+    },
+
+    "alpine": {
+      "version": "3.23",
+      "pinned_in": [
+        { "path": "agent/dhcp/images/kea/Dockerfile", "match": "FROM alpine:{version}", "count": 2 },
+        { "path": "agent/dns/images/bind9/Dockerfile", "match": "FROM alpine:{version}", "count": 2 },
+        { "path": "agent/dns/images/powerdns/Dockerfile", "match": "FROM alpine:{version}", "count": 2 },
+        { "path": "agent/dns/images/dnsdist/Dockerfile", "match": "FROM alpine:{version}", "count": 1 },
+        {
+          "path": "agent/looking-glass/images/gobgp/Dockerfile",
+          "match": "FROM alpine:{version}",
+          "count": 2
+        },
+        {
+          "path": "agent/supervisor/images/supervisor/Dockerfile",
+          "match": "FROM alpine:{version}",
+          "count": 2
+        },
+        { "path": "docs/THIRD_PARTY.md", "match": "| {version} |", "count": 1 }
+      ],
+      "upstream": { "kind": "dockerhub", "repo": "library/alpine", "track": "^3\\.[0-9]+$" },
+      "hold": "Alpine 3.24 moves the bundled interpreter to Python 3.14.7 (NOT 3.13, as the dependabot.yml comment said until #975). The agent images install spatium_*_agent for 3.12, so on 3.24 the module lands off sys.path -> ModuleNotFoundError -> CrashLoopBackOff. The blocker is therefore a 3.12 -> 3.14 jump needing every agent's dependencies verified on 3.14, not the one-minor step the comment implied. Dependabot's ignore rule lets 3.23.x patches flow; this is the minor hold.",
+      "note": "3.24 also carries pdns 5.0.7, dnsdist 2.0.8 and bind 9.20.27 (Kea stays 3.0.3), so the bump moves four shipped daemons at once and wants its own change."
+    }
+  },
+
+  "holds": [
+    {
+      "name": "Python (backend runtime + CI)",
+      "version": "3.12",
+      "reason": "3.14.7 is current. A deliberate, coordinated interpreter upgrade -- backend/Dockerfile, every setup-python step and the agents move together or not at all.",
+      "why_not_enforced": "The literal is `python-version: \"3.12\"` repeated across CI jobs, and an exact count there would fail every time a job is added -- a guard that fires for unrelated reasons is one people learn to weaken."
+    },
+    {
+      "name": "Node (frontend builder)",
+      "version": "22",
+      "reason": "24 is the active LTS; 22 is in maintenance until April 2027. Low priority, no known blocker.",
+      "why_not_enforced": "Dependabot owns the `FROM` and defers the major by an explicit ignore rule; there is no second copy for the two to drift apart."
+    },
+    {
+      "name": "Debian (appliance base)",
+      "version": "trixie",
+      "reason": "Pinned by codename, so point releases (13.6 today) flow at build time. Nothing to bump.",
+      "why_not_enforced": "A codename never changes; there is no version string for a lint to compare."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #975

Dependabot covers four ecosystems here: `github-actions`, `docker` `FROM` lines in the directories declared in `.github/dependabot.yml`, `pip` and `npm`. Everything else was invisible to it — it has no Helm ecosystem, and it does not read Dockerfile `ARG` values, chart `values.yaml`, action `with:` inputs, CI shell-script defaults or the appliance bake arrays. Those pins were spread across nine file types, several behind upstream, two past end-of-life, and one component sat on two different versions at once because only one of its copies was Dependabot-visible.

## Part 1 — one manifest, enforced

Root **`versions.json`** declares **28 components**; **`scripts/lint_versions.py`** asserts each still appears in every file that carries it — **89 assertions** — from CI's unconditional Backend Lint job and from `make ci`. Every site's expected string is a *template* over the component's `version`, so **a bump is one edit** plus whatever the lint then reports.

A weekly **`pin-drift`** job in `trivy-scheduled.yml` resolves each declared upstream and files the delta, separating pins that are behind **on purpose** from real drift. `make versions-upstream` runs it locally.

Two deliberate departures from the issue text:

- **Literals stay in the files; nothing reads the manifest at build time.** An action input resolving to `""` falls back to the action's own default — for `azure/setup-helm`, `latest` — silently. That is the "guard that evaluates nothing" class from #1028/#1029/#1030. The lint gives the same single-source guarantee with no new build-time failure mode.
- **One Dependabot-owned `FROM` *is* listed** (nginx), against the issue's exclusion rule. Pairing it with the copies Dependabot cannot see is what turns the next bot bump into a failing lint rather than another silent minor of drift — which is exactly what produced this entry: the bot moved `frontend/Dockerfile` to 1.31 on 2026-07-20 and the appliance chart's copy sat on 1.30.3 for seven weeks.

`count` (exact occurrence count) is an addition the issue did not specify, and it is load-bearing: the HA overlay runs three etcd services and three Redis containers, and a substring check with no count passes a bump that moved two of three.

## Part 2 — the sweep

`make versions-upstream` now reports **0 behind upstream, 8 behind on purpose**.

**Out of support:** Ruby 3.2 (EOL 2026-03-31) → 3.4; webrick 1.8.1 → 1.9.2 — 1.8.1 predates the request-smuggling fix in 1.8.2 (CVE-2024-47220) and was the only known-vulnerable web server in the tree, seen by no lockfile and no bot; Jekyll → 4.4.1; HAProxy 2.9 → 3.4.

**Behind upstream:** Helm v3.20.2 → v3.21.4 (×5), Redis 8.8 → 8.10.1 (×15), appliance-chart nginx 1.30.3 → 1.31.5, kube-state-metrics → v2.20.0, node-exporter → v1.12.1, GoBGP 4.7.0 → 4.9.0, Patroni-overlay etcd v3.5.30 → v3.5.33 (×3).

**MetalLB stays on 0.15.3**, re-verified rather than assumed: metallb/metallb#3063 is still open, so the hold and its three vendored sub-pins stand, now recorded with reasons.

### Three claims in the issue that did not survive checking

- `haproxy:lts-alpine` and `haproxy:3.4-alpine` resolve to the same digest, so **3.4 is the LTS branch**, not 3.2.
- Alpine 3.24 ships Python **3.14.7**, not the 3.13 the `dependabot.yml` comment had claimed for as long as the hold existed. That makes the agent-image blocker a 3.12 → 3.14 jump needing every dependency re-verified, not the one-minor step the wrong number implied.
- `patroni-spatiumddi:latest` is **not** an unpinned pull — the HA overlay *builds* it inline from `postgres:16-alpine`. What is genuinely unpinned there is the `pip install patroni[etcd3]` beside it, now documented in `BAREMETAL.md`.

## Bugs found on the way

**The backend test shards' own Redis in `ci.yml` was still on 8.8** — a real pin, in the file the sweep was being written in, that the issue's hand-written table missed.

**The weekly Trivy scan could report "clean" and could never report a CVE.** Actions runs a `run:` block under `bash -e`, which the step's `set -uo pipefail` does *not* clear — so `docker run … trivy --exit-code 1` followed by `rc=$?` killed the step at the first image with findings. `has_findings` was never written, and the reporting step's fail-safe then correctly refused to touch the tracking issue. A clean week and a week full of criticals produced the same visible outcome. Pre-existing and separate from #975; fixed here because the new job was one line from shipping the same bug beside it.

## Review findings (all fixed)

`/code-review` found seven, six of them the guard itself failing open:

1. **`--check` was not a flag.** argparse resolves an unambiguous prefix, so the mode the docstring documents ran `--check-upstream` — the advisory network mode that always exits 0. Following the documentation turned the check off. Now a real flag, with `allow_abbrev=False` to stop the next one.
2. **Unknown manifest keys were ignored**, so `"counts": 3` left `count` unset and downgraded an exact assertion to "at least one". Refused at every level now.
3. **The drift job scraped the first number off a prose line** that opens `0 behind upstream` *when every lookup failed* — a rate-limited run would have reported the fleet current and closed the drift issue. The script now emits a machine-readable `RESULT` line carrying `failed`, and any component that could not be checked makes the verdict indeterminate.
4. **Technitium is pinned by tag *and* digest** and only the tag was asserted, so bumping `version` alone passed while the build stayed on the old image. `digest` is a manifest field now — asserted offline, resolved against Docker Hub weekly.
5. **`ghcr.io/cloudnative-pg/postgresql`** was the one bake-array/chart-values pair still unguarded, and the worst to lose: the appliance never pulls, so a divergence is ImagePullBackOff on an air-gapped box.
6. **`docs/DEVELOPMENT.md` referred twice to a section that did not exist** — now written as §9.
7. **HAProxy 2.9 → 3.4 had no upgrade note** for an overlay whose `haproxy.cfg` is operator-supplied. The canonical Patroni config was validated unchanged on both versions, so a config of that shape needs no edit; `BAREMETAL.md` says so and gives the `haproxy -c` command for one that is not.

## Verification

- `python3 scripts/lint_versions.py` — 89 assertions across 28 components, green
- 31 new linter tests + 52 existing gate tests pass; **every guard was run against a sabotaged linter and fails there** (missing-file-as-skip, ignored count, empty manifest accepted, first-match version extraction, `--check` abbreviation, ignored unknown keys, dropped digest assertion)
- Both fixed workflow steps verified by **executing the shipped `run:` bodies under `bash -e`** against stubs where `docker build` succeeds and the scan exits 1 — patched reaches its handler, unpatched exits 1 having written nothing. The drift parse was checked across all four outcomes (all-failed / current / behind / unparseable)
- `make charts-lint` green; ruff + black clean; compose files valid
- GoBGP 4.9.0 image builds and is **Trivy-clean**; its `go get` overrides re-checked against upstream's go.mod and all three are still upgrades, never downgrades
- Docs image builds and `jekyll build` renders the site in 1.4 s on Ruby 3.4.10 / Jekyll 4.4.1, with the plugins still at the versions the `github-pages` gem pins
- Appliance suite: 88 failed / 590 passed — **byte-identical failure set on pristine `main`** (pre-existing macOS environment failures)

One caveat: the Helm 3.20 → 3.21 bump is exercised locally by `make charts-lint`, but the four workflow copies only run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)