### PR TITLE
ci+images: guard `$?` under set -e, move the agents to Alpine 3.24 / Python 3.14, reschedule the nightly (#1036 #1037)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,19 +82,28 @@ updates:
       - dependency-name: "python"
         update-types:
           ["version-update:semver-minor", "version-update:semver-major"]
-      # Alpine 3.24 bumps the bundled Python 3.12→3.14.7, which breaks the agent
-      # images: they install spatium_*_agent for 3.12, so on 3.24 the module
-      # lands on the wrong Python path -> "ModuleNotFoundError: No module named
-      # 'spatium_dns_agent'" -> CrashLoopBackOff (caught by agent-e2e on #672).
-      # Pin the agents to alpine 3.23.x until their Dockerfiles are updated;
-      # patch bumps (3.23.x) still flow. The 3.24 move is a deliberate task.
+      # An Alpine MINOR carries the bundled Python with it, and the agent
+      # images are installed into /usr/local/lib/python<X.Y>/site-packages and
+      # found only via PYTHONPATH. A base bump alone therefore produces an
+      # image that builds clean and then CrashLoopBackOffs with
+      # "ModuleNotFoundError: No module named 'spatium_dns_agent'" — #672,
+      # caught by agent-e2e. It also drags pdns / dnsdist / bind along in the
+      # same step. So a minor stays a deliberate, verified change; patch bumps
+      # (3.24.x) still flow.
       #
-      # #975 — this comment said "3.12→3.13" until the sweep checked the Alpine
-      # package index: v3.24/main ships python3-3.14.7. That makes the blocker a
-      # 3.12 → 3.14 jump needing every agent's dependencies verified on 3.14,
-      # not the one-minor step the wrong number implied — a materially bigger
-      # task that had been under-scoped for as long as the comment stood.
-      # The full reason lives in versions.json under `alpine`.
+      # #1037 did that move: 3.23 → 3.24, Python 3.12 → 3.14.7. Two things
+      # changed so the next one is bounded rather than archaeological —
+      # PYTHONPATH now interpolates the PYTHON_VERSION arg instead of
+      # hardcoding a version (that arg was referenced by NOTHING in four of
+      # the five images before #1037), and every agent image asserts
+      # `import <agent>` at build time, so a mismatched pair fails the build
+      # instead of the pod. The full reason lives in versions.json under
+      # `alpine` and `agent-python`.
+      #
+      # Historical note worth keeping: this comment claimed "3.12→3.13" for a
+      # year. The #975 sweep checked the package index — v3.24/main ships
+      # python3-3.14.7 — which made the task materially bigger than the wrong
+      # number implied, and is why it had sat untouched.
       - dependency-name: "alpine"
         update-types:
           ["version-update:semver-minor", "version-update:semver-major"]

--- a/.github/scripts/ci-backend-must-run.txt
+++ b/.github/scripts/ci-backend-must-run.txt
@@ -54,6 +54,12 @@ scripts/merge_test_durations.py
 # future widening of the deny-list must not silently drop this one.
 scripts/lint_versions.py
 
+# test_lint_workflow_shell.py (#1036) loads the workflow shell-status guard
+# and pins it against the real pre-fix trivy-scheduled.yml body, plus the
+# false-positive case that made the first draft unusable (a `set -e` inside a
+# function is not evidence that -e is on at an arbitrary later line).
+scripts/lint_workflow_shell.py
+
 # test_zone_name_scope.py (#986) loads the release-prep TLD regenerator and
 # pins that it uses the PRODUCT's payload guard rather than a second copy —
 # so a PR that gives the script its own parser has to run the test that says

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,17 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: python3 scripts/lint_versions.py
 
+      # #1036 — a `run:` step that captures $? after a bare command is dead
+      # code: Actions supplies `bash -e`, and the `set -uo pipefail` several
+      # steps open with does NOT clear it, so the capture is never reached on
+      # the failure it exists to handle. That silently disarmed the weekly
+      # CVE scan for as long as it had findings to report. Neither actionlint
+      # nor shellcheck -S style flags the shape (both checked), hence a
+      # linter of our own. stdlib-only; runs from repo root.
+      - name: Workflow shell-status linter
+        working-directory: ${{ github.workspace }}
+        run: python3 scripts/lint_workflow_shell.py
+
       # Guards the appliance host-side runner scripts (issues #550/#553):
       # every systemd ExecStart runner must be executable in the built
       # image (git +x OR chmod'd in mkosi.postinst) and bash -n clean.
@@ -615,7 +626,11 @@ jobs:
 
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          # #1037 — the agent IMAGES ship Python 3.14 (alpine 3.24). Testing
+          # on 3.12 while shipping 3.14 is the skew that lets a 3.14-only
+          # regression reach a pod with every check green. All three suites
+          # were run on 3.14 before this moved.
+          python-version: "3.14"
           cache: pip
           cache-dependency-path: agent/${{ matrix.agent }}/pyproject.toml
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,20 +51,31 @@ name: Nightly
 
 on:
   schedule:
-    # Target: 02:23 America/New_York — Eric + Matt work Eastern evenings,
+    # Target: 03:23 America/New_York — Eric + Matt work Eastern evenings,
     # so the nightly must run AFTER their late pushes, DST included. Cron
-    # is UTC-only, so schedule both candidate UTC hours (06:23 = 02:23
-    # EDT, 07:23 = 02:23 EST) and let the gate job keep exactly the one
-    # whose SCHEDULED slot reads 02 on the Eastern clock — the other fires
+    # is UTC-only, so schedule both candidate UTC hours (07:23 = 03:23
+    # EDT, 08:23 = 03:23 EST) and let the gate job keep exactly the one
+    # whose SCHEDULED slot reads 03 on the Eastern clock — the other fires
     # and immediately skips. The gate decides from the cron string GitHub
     # hands it (github.event.schedule), never from the clock at run time:
     # GitHub starts these runs 40 min to 13 h late (measured, every
     # night), so the run-time wall clock says nothing about which slot a
-    # run belongs to. Off-the-hour minute for the same reason
-    # prune-release-assets.yml uses one: the top-of-hour cron stampede
-    # delays runner scheduling on GitHub's shared infrastructure.
-    - cron: "23 6 * * *"
+    # run belongs to.
+    #
+    # The :23 is not decoration and must not be rounded to :00 — same
+    # reason prune-release-assets.yml is off the hour: the top-of-hour
+    # cron stampede delays runner scheduling on GitHub's shared
+    # infrastructure, and these runs are already started up to 13 h late.
+    #
+    # 03:xx rather than the original 02:xx is also a CORRECTNESS fix, not
+    # just a later slot. On the spring-forward night the Eastern clock
+    # jumps 01:59 → 03:00, so no 02:xx exists and BOTH twins skipped: the
+    # nightly silently built nothing once a year. 03:xx exists on every
+    # night of the year, including both transitions. Verified against
+    # tzdata for normal EDT, normal EST, and both DST nights in 2026-2028:
+    # exactly one twin builds in every case.
     - cron: "23 7 * * *"
+    - cron: "23 8 * * *"
   workflow_dispatch:
     inputs:
       force:
@@ -118,14 +129,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORCE: ${{ github.event.inputs.force || 'false' }}
           EVENT_NAME: ${{ github.event_name }}
-          # The cron string that fired ("23 6 * * *"); empty on dispatch.
+          # The cron string that fired ("23 7 * * *"); empty on dispatch.
           SCHEDULE: ${{ github.event.schedule }}
         run: |
           set -euo pipefail
 
           # ── Which twin fired? ────────────────────────────────────────
-          # Two UTC crons cover 02:23 America/New_York across DST (see the
-          # trigger comment). Keep the twin whose SCHEDULED slot reads 02
+          # Two UTC crons cover 03:23 America/New_York across DST (see the
+          # trigger comment). Keep the twin whose SCHEDULED slot reads 03
           # on the Eastern clock; the other is a no-op. Manual dispatch
           # always proceeds.
           #
@@ -138,12 +149,15 @@ jobs:
           # 2026-08-09 and this change (the only nightly in that window
           # was a manual dispatch). The cron string is immune to the delay.
           #
-          # DST nights: on the fall-back night the 06:23 twin reads 01:23
-          # EST and the 07:23 twin 02:23 EST — one build. On the
-          # spring-forward night no Eastern 02:xx exists (01:59 → 03:00),
-          # so neither twin builds; the next night covers it.
+          # DST nights: on the fall-back night the 07:23 twin reads 02:23
+          # EST and the 08:23 twin 03:23 EST — one build. On the
+          # spring-forward night the 07:23 twin reads 03:23 EDT and builds
+          # while the 08:23 twin reads 04:23 and skips — also one build.
+          # That second case is why the target moved off 02:xx: 01:59 jumps
+          # straight to 03:00, so an 02:xx target matched NEITHER twin and
+          # the nightly silently skipped a night every spring.
           if [ "$EVENT_NAME" = "schedule" ]; then
-            # "23 6 * * *" → "6:23", that cron's UTC instant read on the
+            # "23 7 * * *" → "7:23", that cron's UTC instant read on the
             # Eastern clock. A missing or odd cron string is a hard failure,
             # never a skip — a failed gate is what finalize turns into the
             # tracking issue, whereas a quiet skip is exactly how the
@@ -159,9 +173,9 @@ jobs:
             # TOMORROW's slot. On a same-offset day both readings agree, so
             # this is invisible 363 nights a year — but on a DST-change day
             # they differ by an hour and that is the whole decision. Worked
-            # example: the 02:23 EDT twin of Sat 10-31, started 00:30 UTC on
-            # Sun 11-01, reads 11-01 06:23 UTC = 01:23 EST and skips, while
-            # the 03:23 EDT twin that must skip reads 02:23 EST and builds.
+            # example: the 03:23 EDT twin of Sat 10-31, started 00:30 UTC on
+            # Sun 11-01, reads 11-01 07:23 UTC = 02:23 EST and skips, while
+            # the 04:23 EDT twin that must skip reads 03:23 EST and builds.
             # With the on-time twin also skipping, that night builds nothing
             # — the same silent miss this gate was rewritten to end, just
             # twice a year instead of nightly.
@@ -170,9 +184,9 @@ jobs:
               SLOT_UTC=$((SLOT_UTC - 86400))
             fi
             SLOT_ET=$(TZ=America/New_York date -d "@$SLOT_UTC" '+%H:%M %Z')
-            if [ "${SLOT_ET%%:*}" != "02" ]; then
+            if [ "${SLOT_ET%%:*}" != "03" ]; then
               echo "should_build=false" >> "$GITHUB_OUTPUT"
-              echo "→ cron '${SCHEDULE}' is the ${SLOT_ET} slot, not 02:xx Eastern; skipping (DST twin cron)"
+              echo "→ cron '${SCHEDULE}' is the ${SLOT_ET} slot, not 03:xx Eastern; skipping (DST twin cron)"
               exit 0
             fi
             echo "→ cron '${SCHEDULE}' is the ${SLOT_ET} slot; run started $(TZ=America/New_York date '+%H:%M %Z')"
@@ -199,7 +213,7 @@ jobs:
           echo "images=$(jq -c . /tmp/images.json)" >> "$GITHUB_OUTPUT"
 
           # Both stamps use the EASTERN calendar date — the run targets
-          # 02:23 America/New_York, so "tonight's build" carries the date
+          # 03:23 America/New_York, so "tonight's build" carries the date
           # the team just worked through, not whatever UTC rolled over to.
           DATE_TAG="nightly-$(TZ=America/New_York date +%Y%m%d)"
           echo "date_tag=${DATE_TAG}" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -515,6 +515,15 @@ the formatter handles the rest.
   snapshot — the 4.9 → 5.0 crossing already happened on 3.22 →
   3.23), dnsdist → 2.0.8, bind → 9.20.27, Kea unchanged at 3.0.3.
   All eight images `make trivy` covers build clean and scan clean.
+  **CI surfaced one CVE the local scan had not**, which is the
+  path-filter effect this repo has hit before (#639): touching a
+  Dockerfile is what makes CI scan that image, so the PR inherits
+  everything published since the last time anything touched it.
+  `google.golang.org/grpc` was pinned at 1.83.1 for CVE-2026-84304
+  and 1.83.1 now carries CVE-2026-84445 (HIGH, xDS server DoS).
+  Clearing it took three rounds, because those `go get` pins are a
+  coupled set that `go get` refuses rather than resolves: grpc 1.83.2
+  wanted x/net 0.58.0, and both then wanted x/text 0.41.0.
   **`Agent — Tests` moves to 3.14 with them.** It ran on 3.12 while
   the images shipped 3.14, which is the skew that lets a
   3.14-only regression reach a pod with every check green. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -477,6 +477,63 @@ the formatter handles the rest.
   the prose in four docs pages that named a version as fact.
 
 
+- **The agent images move to Alpine 3.24 / Python 3.14.7, and the
+  arg that was supposed to control that becomes real (#1037).**
+  The base had been pinned to 3.23 for a year behind a
+  `dependabot.yml` comment that said 3.24 moves Python "3.12→3.13";
+  the #975 sweep checked the package index and found **3.14.7**, so
+  the task was a two-minor interpreter jump, not a one-minor step —
+  which is most of why nobody had done it. All three agent suites
+  were run on 3.14 first (dhcp 188, dns 276, supervisor 374; the
+  supervisor's 11 apparent failures were a test container with no
+  `bash`, identical on 3.12). The looking-glass agent has no suite
+  at all, so it and the others were additionally checked by
+  importing **every** submodule inside the shipped image — 96
+  across the five agents, none failing.
+  **The real pin was never `PYTHON_VERSION`.** Four of the five
+  images declared `ARG PYTHON_VERSION=3.12` and referenced it
+  **nowhere** — bumping it changed the image not at all — while
+  `PYTHONPATH=/usr/local/lib/python3.12/site-packages`, hardcoded,
+  was what actually located the agent. That is the exact shape #672
+  hit: base moves, PYTHONPATH does not, the image builds perfectly
+  and the pod CrashLoopBackOffs on `ModuleNotFoundError`. So
+  `PYTHONPATH` now interpolates the arg, and every agent image
+  asserts `import <agent>` as a build step — verified by building
+  with a deliberately stale `--build-arg PYTHON_VERSION=3.12`,
+  which now fails the BUILD instead of shipping.
+  **The technitium image needed a different assertion**, which
+  review caught it not having at all: it is the one agent that is
+  not Alpine-based, and its arg drives BOTH the builder and
+  `PYTHONPATH`, so those move together and an import alone still
+  passes when the arg is wrong (they resolve, because `cryptography`
+  and `pydantic-core` ship abi3 wheels that load across 3.x). What
+  can drift there is the interpreter inside the upstream
+  `technitium/dns-server` base, so that image compares
+  `sys.version_info` to the arg directly. Verified both ways.
+  Carried along by the same index: pdns 5.0.5 → 5.0.7 (a patch
+  within pdns 5, so the #638 LMDB schema guard correctly takes no
+  snapshot — the 4.9 → 5.0 crossing already happened on 3.22 →
+  3.23), dnsdist → 2.0.8, bind → 9.20.27, Kea unchanged at 3.0.3.
+  All eight images `make trivy` covers build clean and scan clean.
+  **`Agent — Tests` moves to 3.14 with them.** It ran on 3.12 while
+  the images shipped 3.14, which is the skew that lets a
+  3.14-only regression reach a pod with every check green. The
+  backend stays on 3.12 — a separate, deliberate hold.
+
+- **The nightly build moves from 02:23 to 03:23 America/New_York,
+  which also closes a hole it had every spring.** Cron is UTC-only,
+  so the schedule is two twin crons plus a gate that keeps the one
+  whose slot reads the target hour on the Eastern clock. On the
+  spring-forward night the Eastern clock jumps 01:59 → 03:00, so
+  **no 02:xx exists and BOTH twins skipped** — the nightly silently
+  built nothing once a year. 03:xx exists on every night there is.
+  Verified against tzdata for normal EDT, normal EST and both DST
+  nights across 2026-2028: exactly one twin builds in every case.
+  The `:23` is kept deliberately and must not be rounded to `:00` —
+  the top-of-hour cron stampede delays runner scheduling, and these
+  runs already start up to 13 h late.
+
+
 ### Security
 
 - **The two source restrictions composed into a console-only
@@ -655,6 +712,54 @@ the formatter handles the rest.
   having written nothing. The first attempt at that harness
   proved nothing, because a stub that failed `docker build` too
   took the build-failure path and never reached the scan.
+
+
+- **A `run:` step that captures `$?` after a bare command is dead
+  code, and nothing anywhere said so (#1036).** GitHub Actions runs
+  every `run:` block under `bash -e`, and the `set -uo pipefail`
+  several steps open with does **not** clear it — so
+  `cmd; rc=$?` is never reached on the failure it was written to
+  handle. #975 fixed the two live sites; this adds the guard, which
+  that issue deliberately left out of scope.
+  The instance that matters: `trivy-scheduled.yml` captured Trivy's
+  status this way, and Trivy exits 1 **on findings**. The step died
+  at the first image with a CVE, `has_findings` was never written,
+  and the reporting step's fail-safe correctly declined to act on an
+  indeterminate result. **A clean week and a week full of criticals
+  produced the same visible outcome: no issue.**
+  `scripts/lint_workflow_shell.py` refuses the shape in CI's
+  unconditional Backend Lint job and in `make ci`. It is a linter of
+  our own because **neither `actionlint` nor `shellcheck -S style`
+  reports it** (both run against the exact snippet): SC2181 fires on
+  a direct `if [ $? -ne 0 ]` and not on `rc=$?` followed by a test
+  of `$rc`. It is pinned against the REAL pre-fix
+  `trivy-scheduled.yml` body, which it reports at the right line.
+  **The false positive it had to stop making is the interesting
+  half.** Turning the check on for a standalone script requires an
+  UNINDENTED `set -e`, because file order is not execution order and
+  this reads the file: `spatium-install` is `set -uo pipefail` at the
+  top and enables `-e` deep inside `do_install()`, which runs *after*
+  the wizard loop and preseed parser that appear below it. Counting
+  that produced four confident findings about code where `-e` is off
+  — and a linter that cries wolf on the installer is one that gets
+  deleted. Suppressing accepts weaker evidence than asserting, on
+  purpose.
+  **The sweep found a second live instance, in the DHCP agent's own
+  entrypoint** — and only after review caught that the guard was not
+  scanning the files its rationale was built on: it globbed `*.sh`,
+  and all 45 appliance host runners (`spatium-install` among them)
+  are extension-less. It now matches on a shell shebang too, and
+  refuses to print a pass when the script half scanned nothing.
+  What that turned up: `agent/dhcp/images/kea/entrypoint.sh` runs
+  under `set -eu` and ends with
+  `wait -n … || wait …` / `EXIT_CODE=$?` / `_term`. Reproduced
+  against busybox ash — when a supervised child exits non-zero the
+  list returns non-zero, `-e` kills the script on that line, and
+  `EXIT_CODE`, `_term` and `exit` are ALL skipped. So a kea or agent
+  **crash** — the case the supervision block exists for — tore the
+  container down without terminating its siblings, while a clean
+  SIGTERM (which returns 0) ran the cleanup perfectly. The failure
+  path was the only one that skipped it.
 
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2558,13 +2558,19 @@ make migrate                           # apply
 # Lint, typecheck, test
 make lint                              # ruff + black + mypy, eslint + prettier
 make ci                                # the lint/build/chart/perf jobs CI runs (backend-lint + frontend-lint + frontend-build
-                                       #   + charts-lint + perf-test + versions-check). Run before pushing.
+                                       #   + charts-lint + perf-test + versions-check + workflow-shell-check).
+                                       #   Run before pushing.
 make versions-check                    # Version-pin manifest (#975) — asserts every pin declared in the root versions.json
                                        #   still appears, at that version, in each file carrying a copy of it. Bumping a
                                        #   component is ONE edit (its `version` field) plus whatever this then reports.
                                        #   Covers what Dependabot cannot see: Helm's five copies, chart values.yaml,
                                        #   Dockerfile ARGs, action `with:` inputs, CI script defaults, the appliance bake
                                        #   arrays, and the version column of docs/THIRD_PARTY.md. Part of `make ci`.
+make workflow-shell-check              # Workflow shell-status guard (#1036) — refuses `$?` captured after a bare command
+                                       #   in a `run:` block. Actions supplies `bash -e` and `set -uo pipefail` does NOT
+                                       #   clear it, so `cmd; rc=$?` is dead code on exactly the failure it handles; that
+                                       #   silently disarmed the weekly CVE scan. Neither actionlint nor shellcheck flags
+                                       #   the shape. Part of `make ci`.
 make versions-upstream                 #   ...the other half: resolve each declared upstream and print a current-vs-latest
                                        #   table. Advisory + network-bound, so NOT part of `make ci`; the weekly
                                        #   trivy-scheduled workflow runs it and files the delta. `hold` entries in the

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: charts-lint perf-test versions-check versions-upstream help up down dev build build-supervisor migrate lint test lint-backend lint-frontend test-backend test-cov test-durations \
+.PHONY: charts-lint perf-test versions-check versions-upstream workflow-shell-check help up down dev build build-supervisor migrate lint test lint-backend lint-frontend test-backend test-cov test-durations \
         openapi \
         lint-untyped-routes \
         lint-untyped-routes-baseline \
@@ -83,6 +83,7 @@ help:
 	@echo "  make docs-verify Check every docs SVG diagram for overflow / clipping"
 	@echo "  make versions-check     Assert every pin matches versions.json (part of make ci)"
 	@echo "  make versions-upstream  Current-vs-latest table for every pinned component"
+	@echo "  make workflow-shell-check  Refuse \$$? captured after a bare command under set -e"
 	@echo "  make appliance      Build the OS-appliance qcow2 (Phase 1 — Debian 13 amd64)"
 	@echo "  make appliance-iso  Wrap the Phase 1 raw image as a hybrid USB/CD ISO (Phase 2)"
 	@echo ""
@@ -412,7 +413,7 @@ lint-untyped-routes-baseline: $(UNTYPED_LIST)
 
 FORCE:
 
-ci: ci-backend-lint ci-frontend-lint ci-frontend-build charts-lint perf-test versions-check
+ci: ci-backend-lint ci-frontend-lint ci-frontend-build charts-lint perf-test versions-check workflow-shell-check
 	@echo ""
 	@echo "✓ All CI checks passed — safe to push."
 
@@ -463,6 +464,14 @@ versions-check:
 
 versions-upstream:
 	@python3 scripts/lint_versions.py --check-upstream
+
+# Workflow shell-status guard (#1036). GitHub Actions runs every `run:` block
+# under `bash -e`, which `set -uo pipefail` does NOT clear — so `cmd; rc=$$?`
+# is dead code on exactly the failure it was written to handle. Neither
+# actionlint nor shellcheck reports it. Same check CI's Backend Lint job runs.
+workflow-shell-check:
+	@echo "→ Workflow shell-status linter (matches .github/workflows/ci.yml)"
+	@python3 scripts/lint_workflow_shell.py
 
 # Perf — Tests (#968): hermetic, stdlib-only tests under perf/.
 perf-test:

--- a/agent/dhcp/images/kea/Dockerfile
+++ b/agent/dhcp/images/kea/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1.7
 # SpatiumDDI Kea DHCP container — kea-dhcp4 + kea-dhcp6 + kea-ctrl-agent + spatium-dhcp-agent
 # Multi-arch: linux/amd64, linux/arm64 (non-negotiable #11)
-ARG PYTHON_VERSION=3.12
+ARG PYTHON_VERSION=3.14
 
-FROM alpine:3.23 AS agent-build
+FROM alpine:3.24 AS agent-build
 RUN apk add --no-cache python3 py3-pip py3-wheel
 WORKDIR /src
 COPY agent/dhcp/pyproject.toml /src/pyproject.toml
@@ -11,7 +11,7 @@ COPY agent/dhcp/spatium_dhcp_agent /src/spatium_dhcp_agent
 COPY agent/dhcp/README.md /src/README.md
 RUN python3 -m pip install --prefix=/install --no-cache-dir --break-system-packages .
 
-FROM alpine:3.23 AS runtime
+FROM alpine:3.24 AS runtime
 # libpcap is pulled in for scapy's BPF socket support, used by the
 # optional Phase 2 device-fingerprinting sniffer (DHCP_FINGERPRINT_ENABLED=1).
 # scapy itself is pure-python so the install works on amd64 + arm64
@@ -38,7 +38,7 @@ FROM alpine:3.23 AS runtime
 # raises NET_RAW into the *ambient* set via setpriv (survives the
 # setuid + execve into ``spatium``). See entrypoint.sh (#383).
 #
-# ``kea>=3.0.3-r0`` (issue #637) — alpine 3.23 ships Kea 3.0.3, ISC's first
+# ``kea>=3.0.3-r0`` (issue #637) — alpine 3.24 ships Kea 3.0.3, ISC's first
 # LTS. The explicit ``>=`` lower-bound is what makes the major EXPLICIT: the
 # old ``>=2.6.5-r0`` bound was *satisfied* by 3.0.3-r0, so flipping the base
 # tag alone would have silently pulled a major version bump. 3.0.3 (not
@@ -78,12 +78,12 @@ FROM alpine:3.23 AS runtime
 # database is fresh and any previously-baked layer carrying an older
 # libpq version (CVE-2026-6638 fixed in 17.10-r0 — pulled in
 # transitively by kea-admin's optional psql backend wiring) gets
-# re-resolved against the current alpine 3.23 index. GitHub Actions
+# re-resolved against the current alpine 3.24 index. GitHub Actions
 # Docker layer cache (``cache-from: type=gha``) is otherwise happy
 # to serve a 30-day-old ``apk add`` layer that Trivy will then flag.
 #
 # The old explicit ``libcrypto3>=3.5.7-r0`` / ``libssl3>=3.5.7-r0`` bounds
-# (CVE-2026-45447) are gone: the alpine 3.23 base already ships openssl
+# (CVE-2026-45447) are gone: the alpine 3.24 base already ships openssl
 # 3.5.7-r0, so they were redundant. ``apk upgrade`` above keeps them current.
 # ``APK_SNAPSHOT`` is what makes that upgrade actually run in CI. BuildKit
 # keys a layer on its RUN text, so a ``type=gha`` cache serves this whole
@@ -131,18 +131,30 @@ RUN chmod +x /usr/local/bin/spatium-dhcp-entrypoint \
  && chown spatium:spatium \
       /etc/kea/kea-dhcp4.conf /etc/kea/kea-dhcp6.conf
 
+ARG PYTHON_VERSION
 ENV CACHE_DIR=/var/lib/spatium-dhcp-agent \
     KEA_CONFIG_PATH=/etc/kea/kea-dhcp4.conf \
     KEA_CONTROL_SOCKET=/run/kea/kea4-ctrl-socket \
     KEA_LEASE_FILE=/var/lib/kea/kea-leases4.csv \
     KEA_CONFIG_PATH_V6=/etc/kea/kea-dhcp6.conf \
     KEA_CONTROL_SOCKET_V6=/run/kea/kea6-ctrl-socket \
-    PYTHONPATH=/usr/local/lib/python3.12/site-packages \
+    PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages \
     LOG_LEVEL=INFO \
     RADVD_MANAGED=0 \
     RADVD_CONFIG_PATH=/etc/radvd/radvd.conf \
     RADVD_PIDFILE=/run/radvd/radvd.pid \
     RADVD_DEFAULT_IFACE=eth0
+
+# #1037 — prove PYTHONPATH matches THIS image's interpreter, at build time.
+# The agent is installed into /usr/local/lib/python<X.Y>/site-packages by the
+# build stage and is found only because PYTHONPATH names that exact directory.
+# When the Alpine base moves the bundled Python (3.23 shipped 3.12, 3.24 ships
+# 3.14) a stale PYTHONPATH yields an image that builds clean and then
+# CrashLoopBackOffs with ModuleNotFoundError — what #672 hit, and the reason
+# the base stayed pinned for a year. One import turns that into a build
+# failure, here, instead of a pod failure in the field.
+RUN python3 -c "import spatium_dhcp_agent"
+
 
 VOLUME ["/var/lib/spatium-dhcp-agent", "/var/lib/kea"]
 # DHCPv4 server

--- a/agent/dhcp/images/kea/entrypoint.sh
+++ b/agent/dhcp/images/kea/entrypoint.sh
@@ -192,6 +192,17 @@ setpriv --reuid spatium --regid spatium --init-groups \
         spatium-dhcp-agent &
 AGENT_PID=$!
 
+# `set +e` from here to the end (#1036). This script runs under `set -eu`,
+# and everything below exists to CAPTURE a non-zero status and then clean up —
+# which is exactly what `-e` prevents. Reproduced against busybox ash: with a
+# supervised child exiting 3, the `||` list returns 3, `-e` killed the script
+# on that line, and `EXIT_CODE=$?`, `_term` and `exit` were ALL skipped. So a
+# kea or agent CRASH — the case this supervision block exists for — tore the
+# container down without terminating its siblings, while a clean SIGTERM
+# (which returns 0 here) ran the cleanup perfectly. The failure path was the
+# only one that skipped it.
+set +e
+
 # wait -n is a bash-ism; busybox ash accepts it too as of 1.30+
 # (Alpine 3.11+). Fall back to plain wait on older variants.
 wait -n "$KEA_PID" "$KEA6_PID" "$AGENT_PID" 2>/dev/null \

--- a/agent/dns/images/bind9/Dockerfile
+++ b/agent/dns/images/bind9/Dockerfile
@@ -1,16 +1,16 @@
 # syntax=docker/dockerfile:1.7
 # SpatiumDDI BIND9 DNS container — BIND9 + spatium-dns-agent
 # Multi-arch: linux/amd64, linux/arm64 (non-negotiable #11)
-ARG PYTHON_VERSION=3.12
+ARG PYTHON_VERSION=3.14
 
-FROM alpine:3.23 AS agent-build
+FROM alpine:3.24 AS agent-build
 RUN apk add --no-cache python3 py3-pip py3-wheel
 WORKDIR /src
 COPY agent/dns/pyproject.toml /src/pyproject.toml
 COPY agent/dns/spatium_dns_agent /src/spatium_dns_agent
 RUN python3 -m pip install --prefix=/install --no-cache-dir --break-system-packages .
 
-FROM alpine:3.23 AS runtime
+FROM alpine:3.24 AS runtime
 # ``libcap`` brings in ``setcap`` so we can grant ``named`` the
 # CAP_NET_BIND_SERVICE file capability — without it, the unprivileged
 # ``spatium`` user the entrypoint drops to can't bind port 53 (named
@@ -21,7 +21,7 @@ FROM alpine:3.23 AS runtime
 # ``apk upgrade --no-cache`` runs BEFORE ``apk add`` so the package
 # database is fresh and any previously-baked layer carrying an older
 # bind / bind-libs version gets re-resolved against the current alpine
-# 3.23 index. GitHub Actions Docker layer cache (the ``cache-from:
+# 3.24 index. GitHub Actions Docker layer cache (the ``cache-from:
 # type=gha`` on the build workflow) is otherwise perfectly happy to
 # serve a 30-day-old ``apk add`` layer that Trivy will then flag.
 #
@@ -38,8 +38,8 @@ FROM alpine:3.23 AS runtime
 #   BIND was touching a sibling file under ``agent/dns/``: the image had
 #   been building from a cached layer carrying 9.20.23-r0.
 # * ``libcrypto3`` / ``libssl3`` ``>=3.5.7-r0`` — CVE-2026-45447 (HIGH,
-#   OpenSSL). The 3.23 base already satisfies this one; the bound is
-#   kept because it still busts a pre-3.23 cache layer.
+#   OpenSSL). The 3.24 base already satisfies this one; the bound is
+#   kept because it still busts a pre-3.24 cache layer.
 # ``APK_SNAPSHOT`` is what makes that upgrade actually run in CI. BuildKit
 # keys a layer on its RUN text, so a ``type=gha`` cache serves this whole
 # layer — package set included — from whenever it was first built, until
@@ -73,10 +73,22 @@ COPY --from=agent-build /install /usr/local
 COPY agent/dns/images/bind9/entrypoint.sh /usr/local/bin/spatium-dns-entrypoint
 RUN chmod +x /usr/local/bin/spatium-dns-entrypoint
 
+ARG PYTHON_VERSION
 ENV AGENT_DRIVER=bind9 \
     AGENT_STATE_DIR=/var/lib/spatium-dns-agent \
-    PYTHONPATH=/usr/local/lib/python3.12/site-packages \
+    PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages \
     LOG_LEVEL=INFO
+
+# #1037 — prove PYTHONPATH matches THIS image's interpreter, at build time.
+# The agent is installed into /usr/local/lib/python<X.Y>/site-packages by the
+# build stage and is found only because PYTHONPATH names that exact directory.
+# When the Alpine base moves the bundled Python (3.23 shipped 3.12, 3.24 ships
+# 3.14) a stale PYTHONPATH yields an image that builds clean and then
+# CrashLoopBackOffs with ModuleNotFoundError — what #672 hit, and the reason
+# the base stayed pinned for a year. One import turns that into a build
+# failure, here, instead of a pod failure in the field.
+RUN python3 -c "import spatium_dns_agent"
+
 
 VOLUME ["/var/lib/spatium-dns-agent", "/var/cache/bind"]
 EXPOSE 53/udp 53/tcp

--- a/agent/dns/images/dnsdist/Dockerfile
+++ b/agent/dns/images/dnsdist/Dockerfile
@@ -7,7 +7,7 @@
 # operator's rate-limit rules, which the PowerDNS agent renders into a shared
 # read-only volume; it rebuilds + restarts dnsdist whenever the rules change.
 # Multi-arch: linux/amd64, linux/arm64 (non-negotiable #11).
-FROM alpine:3.23 AS runtime
+FROM alpine:3.24 AS runtime
 
 # apk upgrade before add so the layer cache can't serve a stale index that
 # Trivy would then flag (mirrors the powerdns image rationale).

--- a/agent/dns/images/powerdns/Dockerfile
+++ b/agent/dns/images/powerdns/Dockerfile
@@ -3,8 +3,8 @@
 # Issue #127, Phase 1 — LMDB backend, no external DB dependency.
 # Multi-arch: linux/amd64, linux/arm64 (non-negotiable #11)
 #
-# ⚠️ alpine:3.23 ships pdns 5.0.5 (3.22 shipped 4.9.5) — READ THIS BEFORE
-# TOUCHING THE BASE OR THE ENTRYPOINT (issue #638).
+# ⚠️ alpine:3.24 ships pdns 5.0.7 (3.23 shipped 5.0.5; 3.22 shipped 4.9.5) —
+# READ THIS BEFORE TOUCHING THE BASE OR THE ENTRYPOINT (issue #638).
 #
 # PowerDNS 5.0 performs an AUTOMATIC, SILENT, IRREVERSIBLE LMDB schema
 # upgrade (v5 → v6) on the first open of the database. A read is enough to
@@ -20,22 +20,29 @@
 # partition. So an upgrade-then-rollback would leave pdns 4.9 crash-looping on
 # a schema-6 database: DNS down, with the rollback unable to recover it.
 #
-# This image is only safe on 3.23 because of the LMDB guard installed below:
-# the entrypoint snapshots the database whenever the pdns MAJOR version
-# changed since the last start, BEFORE the agent spawns pdns_server, and fails
-# closed if it cannot. Rolling back means redeploying the older image AND
+# This image is only safe on a pdns-5 base because of the LMDB guard
+# installed below: the entrypoint snapshots the database whenever the pdns
+# MAJOR version changed since the last start, BEFORE the agent spawns
+# pdns_server, and fails closed if it cannot.
+#
+# The 3.23 → 3.24 move (#1037) is 5.0.5 → 5.0.7 — a PATCH within pdns 5, so
+# the schema is already v6, no upgrade is triggered and the guard correctly
+# takes no snapshot. The 4.9 → 5.0 crossing is the one that matters, and it
+# already happened on the 3.22 → 3.23 move.
+#
+# Rolling back means redeploying the older image AND
 # running ``spatium-pdns-lmdb-guard restore latest`` — see lmdb-guard.sh and
 # docs/deployment/DNS_AGENT.md. Do not bypass the guard call in entrypoint.sh.
-ARG PYTHON_VERSION=3.12
+ARG PYTHON_VERSION=3.14
 
-FROM alpine:3.23 AS agent-build
+FROM alpine:3.24 AS agent-build
 RUN apk add --no-cache python3 py3-pip py3-wheel
 WORKDIR /src
 COPY agent/dns/pyproject.toml /src/pyproject.toml
 COPY agent/dns/spatium_dns_agent /src/spatium_dns_agent
 RUN python3 -m pip install --prefix=/install --no-cache-dir --break-system-packages .
 
-FROM alpine:3.23 AS runtime
+FROM alpine:3.24 AS runtime
 # pdns + the LMDB backend; bind-tools only for `dig` so the smoke test
 # in agent-e2e.yml works against the PowerDNS pod the same way it
 # does against the BIND pod. ``libcap`` brings in ``setcap`` so we
@@ -45,7 +52,7 @@ FROM alpine:3.23 AS runtime
 #
 # ``apk upgrade --no-cache`` runs BEFORE ``apk add`` so the package
 # database is fresh and any previously-baked layer gets re-resolved
-# against the current alpine 3.23 index. GitHub Actions Docker layer
+# against the current alpine 3.24 index. GitHub Actions Docker layer
 # cache (the ``cache-from: type=gha`` on the build workflow) is
 # otherwise happy to serve a 30-day-old ``apk add`` layer that Trivy
 # will then flag.
@@ -61,8 +68,8 @@ FROM alpine:3.23 AS runtime
 #   wanted here, but pdns also drags ``bind-libs`` transitively for the
 #   DNS-name parser, and both come from the same source package.
 # * ``libcrypto3`` / ``libssl3`` ``>=3.5.7-r0`` — CVE-2026-45447 (HIGH,
-#   OpenSSL). The 3.23 base already satisfies it; the bound is kept
-#   because it still busts a pre-3.23 cache layer.
+#   OpenSSL). The 3.24 base already satisfies it; the bound is kept
+#   because it still busts a pre-3.24 cache layer.
 # ``APK_SNAPSHOT`` is what makes that upgrade actually run in CI. BuildKit
 # keys a layer on its RUN text, so a ``type=gha`` cache serves this whole
 # layer — package set included — from whenever it was first built, until
@@ -109,10 +116,22 @@ COPY agent/dns/images/powerdns/entrypoint.sh /usr/local/bin/spatium-dns-entrypoi
 COPY agent/dns/images/powerdns/lmdb-guard.sh /usr/local/bin/spatium-pdns-lmdb-guard
 RUN chmod +x /usr/local/bin/spatium-dns-entrypoint /usr/local/bin/spatium-pdns-lmdb-guard
 
+ARG PYTHON_VERSION
 ENV AGENT_DRIVER=powerdns \
     AGENT_STATE_DIR=/var/lib/spatium-dns-agent \
-    PYTHONPATH=/usr/local/lib/python3.12/site-packages \
+    PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages \
     LOG_LEVEL=INFO
+
+# #1037 — prove PYTHONPATH matches THIS image's interpreter, at build time.
+# The agent is installed into /usr/local/lib/python<X.Y>/site-packages by the
+# build stage and is found only because PYTHONPATH names that exact directory.
+# When the Alpine base moves the bundled Python (3.23 shipped 3.12, 3.24 ships
+# 3.14) a stale PYTHONPATH yields an image that builds clean and then
+# CrashLoopBackOffs with ModuleNotFoundError — what #672 hit, and the reason
+# the base stayed pinned for a year. One import turns that into a build
+# failure, here, instead of a pod failure in the field.
+RUN python3 -c "import spatium_dns_agent"
+
 
 VOLUME ["/var/lib/spatium-dns-agent", "/var/lib/powerdns"]
 EXPOSE 53/udp 53/tcp

--- a/agent/dns/images/technitium/Dockerfile
+++ b/agent/dns/images/technitium/Dockerfile
@@ -104,10 +104,37 @@ RUN chmod +x /usr/local/bin/spatium-dns-entrypoint
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/spatium-dns-entrypoint"]
 CMD []
 
+ARG PYTHON_VERSION
 ENV AGENT_DRIVER=technitium \
     AGENT_STATE_DIR=/var/lib/spatium-dns-agent \
-    PYTHONPATH=/usr/local/lib/python3.12/site-packages \
+    PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages \
     LOG_LEVEL=INFO
+
+# #1037 — prove PYTHONPATH matches THIS image's interpreter, at build time.
+# Unlike the Alpine agents, PYTHON_VERSION here has to match TWO things: the
+# `python:${PYTHON_VERSION}-slim-bookworm` builder above (which resolves the
+# compiled `cryptography` wheel) and the python3 inside the upstream
+# `technitium/dns-server` image, which is whatever Ubuntu release it is built
+# on. Today both are 3.12 — by coincidence, not by construction. The next
+# TECHNITIUM_DIGEST bump onto a newer Ubuntu silently breaks the pair: the
+# wheels stay cp312, the interpreter does not, and the agent dies at runtime
+# with no build-time signal (#672's shape on the one image #1037 first missed).
+#
+# The version EQUALITY check is the load-bearing half, and an import alone is
+# not enough here — verified: building with `--build-arg PYTHON_VERSION=3.13`
+# moves the builder AND PYTHONPATH together, so the import still succeeds even
+# though the runtime interpreter is 3.12. (It succeeds because `cryptography`
+# and `pydantic-core` ship abi3 wheels, which load across 3.x — so the import
+# cannot see the skew that a pure-cp3XX dependency would trip over.) Compare
+# the interpreter to the arg directly instead.
+RUN set -eu; \
+    have="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"; \
+    if [ "$have" != "${PYTHON_VERSION}" ]; then \
+        echo "PYTHON_VERSION=${PYTHON_VERSION} but this image ships python $have." >&2; \
+        echo "The technitium base moved Python: bump PYTHON_VERSION (and versions.json)." >&2; \
+        exit 1; \
+    fi; \
+    python3 -c "import spatium_dns_agent, cryptography"
 
 VOLUME ["/var/lib/spatium-dns-agent", "/etc/dns", "/var/log/technitium"]
 EXPOSE 53/udp 53/tcp

--- a/agent/looking-glass/images/gobgp/Dockerfile
+++ b/agent/looking-glass/images/gobgp/Dockerfile
@@ -8,9 +8,10 @@
 # global default-export-policy is always "reject-route" and no
 # export-policy-list is ever populated, so the daemon can receive routes
 # from every configured peer but can never advertise one back.
+ARG PYTHON_VERSION=3.14
 ARG GOBGP_VERSION=4.9.0
 
-FROM alpine:3.23 AS agent-build
+FROM alpine:3.24 AS agent-build
 RUN apk add --no-cache python3 py3-pip py3-wheel
 WORKDIR /src
 COPY agent/looking-glass/pyproject.toml /src/pyproject.toml
@@ -86,7 +87,7 @@ RUN GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
  && GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
       go build -trimpath -ldflags="-s -w" -o /out/gobgp ./cmd/gobgp
 
-FROM alpine:3.23 AS runtime
+FROM alpine:3.24 AS runtime
 # ``libcap`` brings in ``setcap`` so gobgpd can bind BGP's privileged
 # TCP/179 as the unprivileged ``spatium`` user (same pattern as
 # kea-dhcp4/6 + named/pdns_server in the DHCP/DNS images — a
@@ -132,14 +133,26 @@ RUN chmod +x /usr/local/bin/spatium-lg-entrypoint \
       echo "gobgp=${GOBGP_VERSION}"; \
     } > /etc/spatiumddi-versions
 
+ARG PYTHON_VERSION
 ENV AGENT_STATE_DIR=/var/lib/spatium-lg-agent \
     GOBGPD_CONFIG_PATH=/etc/gobgp/gobgpd.json \
     GOBGPD_BIN=/usr/local/bin/gobgpd \
     GOBGP_BIN=/usr/local/bin/gobgp \
     GOBGP_GRPC_HOST=127.0.0.1 \
     GOBGP_GRPC_PORT=50051 \
-    PYTHONPATH=/usr/local/lib/python3.12/site-packages \
+    PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages \
     LOG_LEVEL=INFO
+
+# #1037 — prove PYTHONPATH matches THIS image's interpreter, at build time.
+# The agent is installed into /usr/local/lib/python<X.Y>/site-packages by the
+# build stage and is found only because PYTHONPATH names that exact directory.
+# When the Alpine base moves the bundled Python (3.23 shipped 3.12, 3.24 ships
+# 3.14) a stale PYTHONPATH yields an image that builds clean and then
+# CrashLoopBackOffs with ModuleNotFoundError — what #672 hit, and the reason
+# the base stayed pinned for a year. One import turns that into a build
+# failure, here, instead of a pod failure in the field.
+RUN python3 -c "import spatium_lg_agent"
+
 
 VOLUME ["/var/lib/spatium-lg-agent"]
 # BGP (receive-only — see spatium_lg_agent/gobgp.py's module docstring)

--- a/agent/looking-glass/images/gobgp/Dockerfile
+++ b/agent/looking-glass/images/gobgp/Dockerfile
@@ -60,7 +60,21 @@ RUN git clone --depth 1 --branch "v${GOBGP_VERSION}" https://github.com/osrg/gob
 # 0.55 carries several HIGH (html XSS, IDNA punycode privilege escalation,
 # HTTP/2 DoS); x/text below 0.39 carries CVE-2026-56852 (norm.Iter infinite
 # loop); grpc-go below 1.82.1 carries GHSA-hrxh-6v49-42gf (xDS RBAC +
-# HTTP/2) and 1.83.0 carries CVE-2026-84304 (HIGH, fixed in 1.83.1).
+# HTTP/2), 1.83.0 carries CVE-2026-84304 (HIGH, fixed in 1.83.1) and
+# 1.83.1 carries CVE-2026-84445 (HIGH, xDS server DoS, fixed in 1.83.2).
+#
+# That last one was caught by CI on #1037, not locally: touching a
+# Dockerfile is what makes CI scan the image, so the PR inherits every
+# CVE published since the last time anything touched it. A local
+# `make trivy` against a stale DB reported clean an hour earlier.
+#
+# These three are NOT independent, and `go get` REFUSES a mismatched set
+# rather than resolving it — so raising one drags the others and the build
+# says exactly which. Bumping grpc alone to clear CVE-2026-84445 took two
+# more rounds: grpc 1.83.2 wanted x/net 0.58.0, then both wanted x/text
+# 0.41.0. That is a feature — the failure is loud and at build time — but
+# budget for it, and re-run `make trivy IMAGE=looking-glass` after, since
+# the versions you end up on are not the ones you set out to pin.
 #
 # EVERY ONE OF THESE MUST BE AN UPGRADE, NEVER A DOWNGRADE. ``go get pkg@vX``
 # sets exactly that version, so once GoBGP's own go.mod moves past one of
@@ -78,9 +92,9 @@ RUN git clone --depth 1 --branch "v${GOBGP_VERSION}" https://github.com/osrg/gob
 # not a tracked manifest, which is why they live in versions.json's orbit and
 # why `make trivy IMAGE=looking-glass` is what surfaces the next one.
 RUN go get \
-      golang.org/x/net@v0.57.0 \
-      golang.org/x/text@v0.40.0 \
-      google.golang.org/grpc@v1.83.1
+      golang.org/x/net@v0.58.0 \
+      golang.org/x/text@v0.41.0 \
+      google.golang.org/grpc@v1.83.2
 ENV CGO_ENABLED=0
 RUN GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
       go build -trimpath -ldflags="-s -w" -o /out/gobgpd ./cmd/gobgpd \

--- a/agent/supervisor/images/supervisor/Dockerfile
+++ b/agent/supervisor/images/supervisor/Dockerfile
@@ -5,9 +5,9 @@
 # Phase A1 ships a near-empty supervisor — the box exists, builds
 # clean, and logs an idle heartbeat. Real work lands in Waves A2 → D.
 # See agent/supervisor/README.md.
-ARG PYTHON_VERSION=3.12
+ARG PYTHON_VERSION=3.14
 
-FROM alpine:3.23 AS build
+FROM alpine:3.24 AS build
 RUN apk add --no-cache python3 py3-pip py3-wheel
 WORKDIR /src
 COPY agent/supervisor/pyproject.toml /src/pyproject.toml
@@ -15,7 +15,7 @@ COPY agent/supervisor/spatium_supervisor /src/spatium_supervisor
 COPY agent/supervisor/README.md /src/README.md
 RUN python3 -m pip install --prefix=/install --no-cache-dir --break-system-packages .
 
-FROM alpine:3.23 AS runtime
+FROM alpine:3.24 AS runtime
 # Issue #183 Phase 7 — k3s-only appliance. ``docker-cli`` +
 # ``docker-cli-compose`` are gone; the supervisor's k3s lifecycle
 # module talks to the local kubeapi via stdlib http.client (no
@@ -91,9 +91,21 @@ COPY --from=build /install /usr/local
 COPY agent/supervisor/images/supervisor/entrypoint.sh /usr/local/bin/spatium-supervisor-entrypoint
 RUN chmod +x /usr/local/bin/spatium-supervisor-entrypoint
 
+ARG PYTHON_VERSION
 ENV STATE_DIR=/var/lib/spatium-supervisor \
-    PYTHONPATH=/usr/local/lib/python3.12/site-packages \
+    PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages \
     LOG_LEVEL=INFO
+
+# #1037 — prove PYTHONPATH matches THIS image's interpreter, at build time.
+# The agent is installed into /usr/local/lib/python<X.Y>/site-packages by the
+# build stage and is found only because PYTHONPATH names that exact directory.
+# When the Alpine base moves the bundled Python (3.23 shipped 3.12, 3.24 ships
+# 3.14) a stale PYTHONPATH yields an image that builds clean and then
+# CrashLoopBackOffs with ModuleNotFoundError — what #672 hit, and the reason
+# the base stayed pinned for a year. One import turns that into a build
+# failure, here, instead of a pod failure in the field.
+RUN python3 -c "import spatium_supervisor"
+
 
 VOLUME ["/var/lib/spatium-supervisor"]
 

--- a/backend/tests/test_ci_backend_relevant.py
+++ b/backend/tests/test_ci_backend_relevant.py
@@ -53,6 +53,7 @@ _KNOWN_REPO_ROOT_READS: dict[str, str] = {
     "test_outbound_hosts_documented.py": "docs/PRIVACY.md",
     "test_zone_name_scope.py": "scripts/refresh_iana_tlds.py",
     "test_lint_versions.py": "scripts/lint_versions.py",
+    "test_lint_workflow_shell.py": "scripts/lint_workflow_shell.py",
     "test_dhcp_packet_loss.py": "agent/dhcp/spatium_dhcp_agent/metrics.py",
     "test_ntp_initial_seed.py": ("appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot"),
 }

--- a/backend/tests/test_lint_workflow_shell.py
+++ b/backend/tests/test_lint_workflow_shell.py
@@ -1,0 +1,288 @@
+"""The workflow shell-status guard (#1036).
+
+``scripts/lint_workflow_shell.py`` refuses ``$?`` captured from a bare command
+in a context where ``-e`` is active — which is every GitHub Actions ``run:``
+block, because Actions supplies ``bash -e`` and the ``set -uo pipefail`` those
+blocks open with does not clear it.
+
+The two cases that matter most, and that the first draft got wrong in opposite
+directions, are both pinned below: the real pre-fix ``trivy-scheduled.yml``
+body must be REPORTED, and a ``set -e`` sitting inside a function must not be
+read as evidence that ``-e`` is on at some arbitrary later line.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import textwrap
+import types
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "lint_workflow_shell.py"
+
+pytestmark = pytest.mark.skipif(
+    not _SCRIPT.exists(),
+    reason="workflow shell linter not present in this checkout",
+)
+
+
+@pytest.fixture(scope="module")
+def lint() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("lint_workflow_shell", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _workflow(tmp_path: pathlib.Path, body: str, shell: str | None = None) -> pathlib.Path:
+    """Write a one-step workflow whose `run:` block is `body`."""
+    shell_line = f"        shell: {shell}\n" if shell else ""
+    indented = textwrap.indent(textwrap.dedent(body).strip("\n"), " " * 10)
+    wf = tmp_path / "workflows"
+    wf.mkdir(exist_ok=True)
+    (wf / "w.yml").write_text(
+        "name: t\non: {push: {}}\njobs:\n  j:\n    runs-on: ubuntu-latest\n"
+        "    steps:\n      - name: s\n" + shell_line + "        run: |\n" + indented + "\n"
+    )
+    return wf
+
+
+def _findings(lint: types.ModuleType, wf: pathlib.Path) -> list:
+    return lint.scan_workflows(wf)
+
+
+# ── the bug this exists for ──────────────────────────────────────────────────
+
+
+def test_the_real_pre_fix_trivy_body_is_reported(lint: types.ModuleType) -> None:
+    """The actual shape that disarmed the weekly CVE scan.
+
+    Trivy exits 1 **on findings**, so `-e` killed the step at the first image
+    with a CVE, `has_findings` was never written, and the reporting step's
+    fail-safe left the tracking issue alone. A clean week and a week full of
+    criticals looked identical from outside.
+    """
+    findings = lint.scan_block(
+        textwrap.dedent("""
+            set -uo pipefail
+            for spec in "${specs[@]}"; do
+              docker run --rm aquasec/trivy:latest image --exit-code 1 "$img" > out.txt
+              rc=$?
+              if [ "$rc" -eq 0 ]; then echo clean; else any=1; fi
+            done
+            echo "has_findings=$any" >> "$GITHUB_OUTPUT"
+            """),
+        "trivy-scheduled.yml",
+        1,
+        e_by_default=True,
+    )
+    assert len(findings) == 1
+    assert findings[0].line == "rc=$?"
+
+
+def test_direct_test_of_dollar_question_is_reported(lint: types.ModuleType) -> None:
+    findings = lint.scan_block(
+        "set -uo pipefail\nmycmd > out\nif [ $? -ne 0 ]; then echo bad; fi\n",
+        "w.yml",
+        1,
+        e_by_default=True,
+    )
+    assert len(findings) == 1
+
+
+# ── the three correct forms must all pass ────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("body", "why"),
+    [
+        ("set -uo pipefail\nif mycmd > out; then rc=0; else rc=$?; fi\n", "the if form"),
+        ("set -uo pipefail\nmycmd > out || true\nrc=$?\n", "|| true"),
+        ("set -uo pipefail\nset +e\nmycmd > out\nrc=$?\nset -e\n", "explicit set +e"),
+        ("set -uo pipefail\nmycmd > out  # lint-workflow-shell: allow\nrc=$?\n", "opt-out marker"),
+        ("set -uo pipefail\n# lint-workflow-shell: allow\nrc=$?\n", "marker on the line above"),
+    ],
+)
+def test_safe_forms_pass(lint: types.ModuleType, body: str, why: str) -> None:
+    assert lint.scan_block(body, "w.yml", 1, e_by_default=True) == [], why
+
+
+# ── the false positive that made the first draft unusable ────────────────────
+
+
+def test_set_e_inside_a_function_does_not_arm_the_check(lint: types.ModuleType) -> None:
+    """File order is not execution order, and this reads the file.
+
+    ``spatium-install`` is ``set -uo pipefail`` at the top and turns ``-e`` on
+    deep inside ``do_install()`` — which runs AFTER the wizard loop and the
+    preseed parser that appear further down the file. Counting an indented
+    ``set -e`` produced four confident findings about code where ``-e`` is
+    off, and a linter that cries wolf on the installer is one that gets
+    deleted. Turning the check ON therefore needs a TOP-LEVEL ``set -e``.
+    """
+    body = textwrap.dedent("""
+        set -uo pipefail
+
+        do_install() {
+            set -e
+            mkfs.ext4 "$dev"
+        }
+
+        run_step() {
+            "$step"
+            rc=$?
+        }
+        """)
+    assert lint.scan_block(body, "spatium-install", 1, e_by_default=False) == []
+
+
+def test_top_level_set_e_in_a_script_does_arm_the_check(lint: types.ModuleType) -> None:
+    """The other half: an unindented `set -e` really has run by then."""
+    body = "#!/usr/bin/env bash\nset -euo pipefail\nmycmd > out\nrc=$?\n"
+    assert len(lint.scan_block(body, "s.sh", 1, e_by_default=False)) == 1
+
+
+def test_a_plain_script_without_set_e_is_not_flagged(lint: types.ModuleType) -> None:
+    body = "#!/bin/sh\nmycmd > out\nrc=$?\n"
+    assert lint.scan_block(body, "s.sh", 1, e_by_default=False) == []
+
+
+# ── workflow parsing ─────────────────────────────────────────────────────────
+
+
+def test_run_block_is_found_and_line_numbers_are_real(
+    lint: types.ModuleType, tmp_path: pathlib.Path
+) -> None:
+    """A finding a human cannot locate is a finding nobody fixes."""
+    wf = _workflow(tmp_path, "set -uo pipefail\nmycmd\nrc=$?\n")
+    findings = _findings(lint, wf)
+    assert len(findings) == 1
+    reported = (wf / "w.yml").read_text().split("\n")[findings[0].line_no - 1]
+    assert reported.strip() == "rc=$?", "the reported line number must point at the capture"
+
+
+def test_a_non_bash_shell_is_not_scanned(lint: types.ModuleType, tmp_path: pathlib.Path) -> None:
+    """`shell: python` has no `-e` and no `$?`."""
+    wf = _workflow(tmp_path, "import os\nrc = 0\n", shell="python")
+    assert _findings(lint, wf) == []
+
+
+def test_a_custom_shell_without_e_is_not_flagged(
+    lint: types.ModuleType, tmp_path: pathlib.Path
+) -> None:
+    wf = _workflow(tmp_path, "mycmd\nrc=$?\n", shell="bash --noprofile {0}")
+    assert _findings(lint, wf) == []
+
+
+def test_a_custom_shell_with_e_is_flagged(lint: types.ModuleType, tmp_path: pathlib.Path) -> None:
+    wf = _workflow(tmp_path, "mycmd\nrc=$?\n", shell="bash -eo pipefail {0}")
+    assert len(_findings(lint, wf)) == 1
+
+
+def test_empty_workflow_dir_is_refused_not_passed(
+    lint: types.ModuleType, tmp_path: pathlib.Path
+) -> None:
+    """ "0 workflows scanned" must never print the same line as "all clean".
+
+    The failure this whole guard is about is a check that evaluates nothing
+    and looks like one that passed (#1028/#1029/#1030); it would be absurd for
+    the guard itself to have it.
+    """
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert lint.main(["--workflow-dir", str(empty), "--script-dir", str(tmp_path / "nope")]) == 1
+
+
+# ── the /code-review findings, each pinned ───────────────────────────────────
+
+
+def test_or_true_at_the_end_of_a_continued_command_is_seen(lint) -> None:
+    r"""The safe suffix and the safe structure live at OPPOSITE ends.
+
+    `else`/`fi` are at the start of the preceding command; `|| true` is at its
+    end. Testing only the first physical line of a `\`-continued command
+    reported a very common CI shape as a violation — and printed the wrong
+    line as the context.
+    """
+    body = "set -uo pipefail\nmycmd \\\n  --flag \\\n  || true\nrc=$?\n"
+    assert lint.scan_block(body, "w.yml", 1, e_by_default=True) == []
+
+
+def test_a_continuation_without_or_true_is_still_caught(lint) -> None:
+    body = "set -uo pipefail\nmycmd \\\n  --flag\nrc=$?\n"
+    assert len(lint.scan_block(body, "w.yml", 1, e_by_default=True)) == 1
+
+
+@pytest.mark.parametrize(
+    ("body", "want", "why"),
+    [
+        ("set +o errexit\ncmd\nrc=$?\n", 0, "`set +o errexit` disarms it"),
+        ("set -o errexit\ncmd\nrc=$?\n", 1, "`set -o errexit` arms it"),
+    ],
+)
+def test_long_form_errexit_is_understood(lint, body: str, want: int, why: str) -> None:
+    """`-o`/`+o` carry no `e`, and `errexit` carries no sign.
+
+    The first cut matched neither, so `set +o errexit` left the check armed
+    over a block that had deliberately turned it off.
+    """
+    assert len(lint.scan_block(body, "s.sh", 1, e_by_default=False)) == want, why
+
+
+def test_set_e_can_rearm_inside_a_workflow_block(lint, tmp_path) -> None:
+    """Run-block bodies must be DEDENTED before the top-level rule sees them.
+
+    Every line of a YAML block scalar carries the block's indent, so nothing
+    in a `run:` block was ever "top level" and `set -e` could never re-arm
+    after a `set +e` — a false negative in the one place the check is meant
+    to be unconditional.
+    """
+    wf = _workflow(tmp_path, "set +e\ncmd\nset -e\ncmd2\nrc=$?\n")
+    assert len(_findings(lint, wf)) == 1
+
+
+def test_a_previous_steps_shell_does_not_leak(lint, tmp_path) -> None:
+    """`shell:` binds to its own step, not to whatever the window caught."""
+    wf = tmp_path / "workflows"
+    wf.mkdir(exist_ok=True)
+    (wf / "w.yml").write_text(
+        "name: t\non: {push: {}}\njobs:\n  j:\n    steps:\n"
+        "      - name: a\n        shell: python\n        run: |\n          x = 1\n"
+        "      - name: b\n        run: |\n          cmd\n          rc=$?\n"
+    )
+    assert len(lint.scan_workflows(wf)) == 1, "the bash step must still be checked"
+
+
+def test_extensionless_shell_files_are_scanned(lint, tmp_path) -> None:
+    """The appliance host runners have no extension — a `*.sh` glob saw none.
+
+    All 45 of them, including `spatium-install`, which is the file the
+    top-level asymmetry and DEVELOPMENT.md §10 are justified by. The guard
+    was reasoning about a file it never opened.
+    """
+    d = tmp_path / "bin"
+    d.mkdir()
+    runner = d / "spatiumddi-thing"
+    runner.write_text("#!/usr/bin/env bash\nset -euo pipefail\nmycmd\nrc=$?\n")
+    findings, seen = lint.scan_scripts([d])
+    assert seen == 1, "a shebang must be enough to identify a shell file"
+    assert len(findings) == 1
+
+
+def test_binary_and_non_shell_files_are_skipped(lint, tmp_path) -> None:
+    d = tmp_path / "bin"
+    d.mkdir()
+    (d / "blob").write_bytes(b"\x7fELF\x02\x01\x01\x00rc=$?\n")
+    (d / "notes.txt").write_text("rc=$?\n")
+    findings, seen = lint.scan_scripts([d])
+    assert (findings, seen) == ([], 0)
+
+
+def test_a_missing_requested_script_dir_is_an_error(lint, tmp_path) -> None:
+    """A typo'd --script-dir silently scanned nothing and still passed."""
+    wf = _workflow(tmp_path, "echo hi\n")
+    assert lint.main(["--workflow-dir", str(wf), "--script-dir", str(tmp_path / "nope")]) == 1

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -191,7 +191,7 @@ the canonical wording lives in `CLAUDE.md`.
 10. **Driver abstraction** — DHCP/DNS backend logic never leaks into the
     service layer (`backend/app/drivers/{dns,dhcp}/`).
 11. **Multi-arch builds** — all Docker images support `linux/amd64` and
-    `linux/arm64` (see §10).
+    `linux/arm64` (see §11).
 12. **K8s manifests stay current** — when you add or change a service,
     update `k8s/base/` and `k8s/README.md`.
 13. **MCP coverage for new features** — a new REST resource also gets
@@ -358,7 +358,7 @@ every push and pull request. Run it locally before pushing.
 make ci
 ```
 
-It chains six targets:
+It chains seven targets:
 
 | `make` target | What it runs |
 |---|---|
@@ -368,6 +368,7 @@ It chains six targets:
 | `charts-lint` | The `Charts — Lint & Template` gate, in a helm container (see the job table below) |
 | `perf-test` | `python -m pytest perf` in a python container |
 | `versions-check` | `python3 scripts/lint_versions.py` — asserts every pin in `versions.json` still matches the files that carry it (see §9). Stdlib-only, no container, no network |
+| `workflow-shell-check` | `python3 scripts/lint_workflow_shell.py` — refuses `$?` captured after a bare command in a workflow `run:` block, where GitHub's `bash -e` makes it dead code (see §10) |
 
 `make ci` requires the dev stack to be running (the backend checks
 execute inside the api container) and Node 20+ on the host. It does **not**
@@ -380,7 +381,7 @@ triggered on push to `main` and on every pull request:
 
 | Job | What it does |
 |---|---|
-| **Backend — Lint & Type Check** (`backend-lint`) | `pip install -e ".[dev]"` on Python 3.12, then `ruff check`, `black --check`, `mypy app`, **plus the migration-shape linter** (`python3 scripts/lint_migrations.py` — see §8) and the **version-pin manifest linter** (`python3 scripts/lint_versions.py` — see §9). |
+| **Backend — Lint & Type Check** (`backend-lint`) | `pip install -e ".[dev]"` on Python 3.12, then `ruff check`, `black --check`, `mypy app`, **plus the migration-shape linter** (`python3 scripts/lint_migrations.py` — see §8), the **version-pin manifest linter** (`python3 scripts/lint_versions.py` — see §9) and the **workflow shell-status linter** (`python3 scripts/lint_workflow_shell.py` — see §10). |
 | **Backend — Tests** (`backend-test`) | A required-check aggregator over **twelve** parallel `backend-test-shard` jobs. Each shard spins up `postgres:16-alpine` + `redis:8.10.1-alpine` services, runs `alembic upgrade head`, then `pytest -n auto --splits 12 --group N --store-durations --clean-durations` (pytest-split selects the shard's slice, **balanced by duration** from the committed `backend/.test_durations` — see §Shard balancing; `-n auto` parallelizes it across the runner's vCPUs, each xdist worker on its own `spatiumddi_test_gw<N>` DB). On a PR the `changes` job may first narrow the run to the test files the diff can affect (#1020 — see §Test-impact selection). The aggregator passes only if all twelve shards pass; on a full run it also merges the shards' measured durations into a `test-durations` artifact, and on a push to `main` it builds the `test-impact-map` artifact from the shards' coverage contexts. Coverage is otherwise **not** collected here (#1019). |
 | **Frontend — Lint & Type Check** (`frontend-lint`) | Node 22, `npm install`, then `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test`. |
 | **Frontend — Build** (`frontend-build`) | Node 22, `npm install`, `npm run build`. |
@@ -477,7 +478,7 @@ than it saves.
 ### Nightly builds
 
 [`.github/workflows/nightly.yml`](../.github/workflows/nightly.yml) builds
-and publishes every image from `main` at **02:23 America/New_York** (the
+and publishes every image from `main` at **03:23 America/New_York** (the
 team works Eastern evenings, so the nightly runs after the late pushes —
 two UTC crons plus a wall-clock gate keep that true across DST). It exists
 because
@@ -673,7 +674,63 @@ the other copies move with it.
 
 ---
 
-## 10. Multi-Arch Image Builds
+## 10. Workflow Shell — `$?` under `set -e`
+
+GitHub Actions runs every `run:` block under **`bash -e`**. Writing
+`set -uo pipefail` at the top — which several steps here do — does **not**
+clear that flag:
+
+```console
+$ bash -ec 'set -uo pipefail; case "$-" in *e*) echo "-e STILL ON";; esac'
+-e STILL ON
+```
+
+So this shape is dead code on exactly the failure it was written to handle:
+
+```bash
+some_command > out      # -e kills the step here when it fails
+rc=$?                   # never reached
+if [ "$rc" -eq 0 ]; ...
+```
+
+**It is invisible by construction.** The step is green on the happy path, and
+the branch that would report a problem is the one that never runs. It cost
+this repo a working weekly CVE scan: `trivy-scheduled.yml` captured Trivy's
+status this way, and Trivy exits 1 *on findings* — so the step died at the
+first image with a CVE, `has_findings` was never written, and a clean week
+looked identical to a week full of criticals
+([#1036](https://github.com/spatiumddi/spatiumddi/issues/1036)).
+
+`scripts/lint_workflow_shell.py` refuses the shape, in CI's Backend Lint job
+and in `make ci`. Neither `actionlint` nor `shellcheck -S style` reports it
+(both checked) — shellcheck's SC2181 fires on a direct `if [ $? -ne 0 ]` but
+not on `rc=$?` followed by a test of `$rc`.
+
+### The three accepted forms
+
+```bash
+if cmd; then rc=0; else rc=$?; fi   # preferred — keeps the status AND the guard
+cmd || true                          # when the status is not needed
+set +e; cmd; rc=$?; set -e           # for a long run of commands
+```
+
+A genuine exception carries `# lint-workflow-shell: allow`.
+
+### Standalone `.sh` files
+
+The linter also scans `.github/scripts/*.sh`, where `-e` comes from the script
+rather than the interpreter. Turning the check **on** there requires an
+*unindented* `set -e`; turning it **off** accepts a `set +e` at any indent.
+That asymmetry is deliberate — file order is not execution order.
+`spatium-install` is `set -uo pipefail` at the top and enables `-e` deep inside
+`do_install()`, which runs *after* the wizard loop and preseed parser that
+appear below it in the file. Counting an indented `set -e` produced four
+confident findings about code where `-e` is off, and a linter that cries wolf
+on the installer is one that gets deleted.
+
+---
+
+## 11. Multi-Arch Image Builds
 
 Every Docker image must support **`linux/amd64` and `linux/arm64`**
 (non-negotiable #11). The release pipeline
@@ -685,7 +742,7 @@ multi-arch fan-out happens in CI on a tagged release.
 
 ---
 
-## 11. Branch & PR Conventions
+## 12. Branch & PR Conventions
 
 - **Branch from `main`.** The project uses one branch per issue, named
   `issue-NNN` (keep every phase of a multi-phase change on the same
@@ -716,7 +773,7 @@ multi-arch fan-out happens in CI on a tagged release.
 
 ---
 
-## 12. Security Disclosure
+## 13. Security Disclosure
 
 Do **not** file security vulnerabilities as public issues. Use
 [GitHub Security Advisories](https://github.com/spatiumddi/spatiumddi/security/advisories/new)

--- a/docs/THIRD_PARTY.md
+++ b/docs/THIRD_PARTY.md
@@ -315,7 +315,7 @@ Apache license covers it.
 
 | Component | Version | License | Where |
 |---|---|---|---|
-| [Alpine Linux](https://alpinelinux.org/) | 3.23 | MIT (+ GPL v2 kernel) | All agent images, supervisor |
+| [Alpine Linux](https://alpinelinux.org/) | 3.24 | MIT (+ GPL v2 kernel) | All agent images, supervisor |
 | [Debian slim](https://www.debian.org/) | trixie / bookworm | DFSG (mixed) | Appliance builder, Technitium agent build stage |
 | [python:3.12-slim](https://www.python.org/) | 3.12 | PSF + Debian | API image |
 | [node](https://nodejs.org/) | 22-alpine | MIT | Frontend build stage |

--- a/docs/THIRD_PARTY.md
+++ b/docs/THIRD_PARTY.md
@@ -315,11 +315,12 @@ Apache license covers it.
 
 | Component | Version | License | Where |
 |---|---|---|---|
-| [Alpine Linux](https://alpinelinux.org/) | 3.24 | MIT (+ GPL v2 kernel) | All agent images, supervisor |
+| [Alpine Linux](https://alpinelinux.org/) | 3.24 | MIT (+ GPL v2 kernel) | BIND9 / PowerDNS / dnsdist / Kea / Looking Glass agent images, supervisor — **not** Technitium (see below) |
 | [Debian slim](https://www.debian.org/) | trixie / bookworm | DFSG (mixed) | Appliance builder, Technitium agent build stage |
+| [technitium/dns-server](https://hub.docker.com/r/technitium/dns-server) | 15.4.0 (digest-pinned; Ubuntu-based) | GPL v3 | Technitium agent image **runtime** — the one agent image that is not Alpine |
 | [python:3.12-slim](https://www.python.org/) | 3.12 | PSF + Debian | API image |
 | [node](https://nodejs.org/) | 22-alpine | MIT | Frontend build stage |
-| [nginx](https://nginx.org/) | 1.31.3-alpine | BSD 2-Clause | Frontend runtime |
+| [nginx](https://nginx.org/) | 1.31.5-alpine | BSD 2-Clause | Frontend runtime |
 | [ASP.NET Core runtime](https://dotnet.microsoft.com/) | 10.0 | MIT | Technitium agent image |
 | [tini](https://github.com/krallin/tini) | Alpine/Debian pkg | MIT | PID 1 in every agent image |
 | [su-exec](https://github.com/ncopa/su-exec) / [gosu](https://github.com/tianon/gosu) | Alpine / Debian pkg | MIT / Apache 2.0 | Privilege drop at entrypoint |

--- a/scripts/lint_workflow_shell.py
+++ b/scripts/lint_workflow_shell.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Guard against `$?` captured from a bare command under `set -e` (#1036).
+
+GitHub Actions runs a ``run:`` block with ``bash -e`` (the default shell is
+``bash -e {0}``; an explicit ``shell: bash`` is ``bash --noprofile --norc -eo
+pipefail {0}``). Writing ``set -uo pipefail`` at the top of the script — which
+several steps in this repo do — does **not** clear ``-e``::
+
+    $ bash -ec 'set -uo pipefail; case "$-" in *e*) echo "-e STILL ON";; esac'
+    -e STILL ON
+
+So this shape is dead code exactly when it matters::
+
+    some_command > out          # <- -e kills the step here when it fails
+    rc=$?                       # <- never reached
+    if [ "$rc" -eq 0 ]; then ...
+
+**Why this is worth a linter of its own.** The step goes green on the happy
+path, and the branch that would have reported a problem is the one that never
+runs — so the failure is invisible by construction. It cost this repo a
+working weekly CVE scan: ``trivy-scheduled.yml`` captured Trivy's status this
+way, and Trivy exits 1 *on findings*, which is the only case the job exists
+for. The step died at the first image with a CVE, ``has_findings`` was never
+written, and the reporting step's fail-safe correctly declined to touch the
+tracking issue. A clean week and a week full of criticals looked identical.
+
+Neither ``actionlint`` nor ``shellcheck -S style`` reports this shape
+(verified against both, 2026-09-09) — shellcheck's SC2181 fires on a direct
+``if [ $? -ne 0 ]`` but not on ``rc=$?`` followed by a test of ``$rc``. Hence
+this script rather than adopting a tool.
+
+**The fix is always one of three**, and each is recognised as safe here:
+
+* the ``if`` form — ``if cmd; then rc=0; else rc=$?; fi`` — whose condition is
+  exempt from ``-e``. Preferred: it keeps the status AND the guard.
+* ``cmd || true`` on the preceding line, when the status is not needed.
+* an explicit ``set +e`` earlier in the same block, when a long run of
+  commands must not abort.
+
+A genuine exception can carry ``# lint-workflow-shell: allow`` on the capture
+line or the line above, which is deliberately ugly and greppable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+import textwrap
+from typing import Iterable, NamedTuple
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+#: Every tree holding shell this repo ships or runs. The appliance host
+#: runners are the ones that matter most and were the ones missed: they are
+#: EXTENSION-LESS, so a ``*.sh`` glob saw none of the 45 — including
+#: ``spatium-install``, the file the top-level asymmetry above is justified by.
+SCRIPT_DIRS = (
+    REPO_ROOT / ".github" / "scripts",
+    REPO_ROOT / "appliance" / "scripts",
+    REPO_ROOT / "appliance" / "mkosi.extra" / "usr" / "local" / "bin",
+    REPO_ROOT / "agent",
+)
+
+#: A file is shell if it ends in .sh or opens with a sh/bash shebang.
+_SHEBANG_RE = re.compile(rb"^#!.*\b(?:ba|da|k|z)?sh\b")
+
+#: ``rc=$?`` / ``local rc=$?`` / ``declare rc=$?`` on a line of its own.
+_CAPTURE_RE = re.compile(r"^\s*(?:local\s+|declare\s+|export\s+)?[A-Za-z_][A-Za-z0-9_]*=\$\?\s*(?:#.*)?$")
+
+#: A direct test of ``$?``: ``if [ $? -ne 0 ]``.
+_DIRECT_TEST_RE = re.compile(r"^\s*(?:if|while|until)\s+.*\[\[?\s*\"?\$\?")
+
+#: ``set -e`` in any bundled spelling. ``set +e`` is matched separately.
+_SET_E_RE = re.compile(r"^\s*set\s+[-+][A-Za-z]*\b")
+
+_ALLOW_MARKER = "lint-workflow-shell: allow"
+
+#: Lines after which capturing ``$?`` is safe, because the preceding command
+#: either cannot abort the script or already ran inside an exempt context.
+_SAFE_PRECEDING = re.compile(
+    r"(?:^|\s)(?:else|fi|then|do|done|\{|\})\s*$"  # if/else/loop structure
+    r"|\|\|\s*(?:true|:)\s*$"  # explicitly tolerated failure
+    r"|\|\|\s*\\$"  # continued `|| \`
+)
+
+
+class Finding(NamedTuple):
+    path: str
+    line_no: int
+    line: str
+    context: str
+
+
+def _set_e_active(lines: list[str], upto: int, default: bool) -> bool:
+    """Is ``-e`` in effect at ``lines[upto]``?
+
+    ``default`` is True for a workflow ``run:`` block (Actions supplies
+    ``-e`` on the interpreter command line) and False for a standalone
+    ``.sh`` file, which only has it if it asks. ``set -uo pipefail`` does NOT
+    clear ``-e``, so only an explicit ``+e`` in the flag string turns it off —
+    which is the entire bug this guard exists for.
+
+    **The two directions are deliberately asymmetric**, because file order is
+    not execution order and this reads the file:
+
+    * turning ``-e`` ON requires an UNINDENTED ``set -e`` — i.e. one at the
+      script's top level, which really has run by the time a later line does.
+      An indented one is inside a function or a subshell and says nothing
+      about an arbitrary later line. ``spatium-install`` is the worked
+      example: it is ``set -uo pipefail`` at the top and enables ``-e`` deep
+      inside ``do_install()``, which runs *after* the wizard loop and the
+      preseed parser that appear below it in the file. Counting that would
+      report four confident findings about code where ``-e`` is off.
+    * turning it OFF accepts a ``set +e`` at any indent. Suppressing on weak
+      evidence costs a missed finding; asserting on weak evidence costs a
+      false one, and a linter that cries wolf is a linter somebody deletes.
+
+    Workflow blocks get ``default=True`` from the interpreter, and their
+    bodies are DEDENTED before they reach here — without that every line
+    carries the YAML block indent, nothing is ever top-level, and a ``set -e``
+    could never re-arm the check after a ``set +e`` in the same block.
+    """
+    active = default
+    for raw in lines[:upto]:
+        line = raw.strip()
+        if not _SET_E_RE.match(line):
+            continue
+        top_level = raw[:1] not in (" ", "\t")
+        words = line.split()[1:]
+        for i, word in enumerate(words):
+            if not word.startswith(("-", "+")):
+                continue
+            sign = word[0]
+            flags = word[1:]
+            if flags.startswith("o"):
+                # `set -o errexit` / `set +o errexit` — the option NAME is the
+                # next word, and the letters here carry no `e`. Missing this
+                # made `set +o errexit` invisible, so the check stayed armed
+                # over a block that had deliberately disarmed it.
+                if words[i + 1 : i + 2] == ["errexit"]:
+                    if sign == "+":
+                        active = False
+                    elif top_level:
+                        active = True
+                continue
+            if "e" not in flags:
+                continue
+            if sign == "+":
+                active = False
+            elif top_level:
+                active = True
+    return active
+
+
+def scan_block(
+    body: str, path: str, base_line: int, e_by_default: bool
+) -> list[Finding]:
+    """Report every unsafe ``$?`` capture in one shell block."""
+    findings: list[Finding] = []
+    lines = body.split("\n")
+
+    for idx, line in enumerate(lines):
+        is_capture = bool(_CAPTURE_RE.match(line))
+        is_direct = bool(_DIRECT_TEST_RE.match(line))
+        if not (is_capture or is_direct):
+            continue
+
+        prev_line = lines[idx - 1] if idx else ""
+        if _ALLOW_MARKER in line or _ALLOW_MARKER in prev_line:
+            continue
+        if not _set_e_active(lines, idx, e_by_default):
+            continue
+
+        # Walk back to the command that actually ran, skipping blanks and
+        # comments, then reassemble it if it was `\`-continued.
+        #
+        # Both ends matter and they are different lines: the STRUCTURE that
+        # makes a capture safe (`else`, `fi`) is at the start, while `|| true`
+        # is at the end. Testing only the first physical line reported
+        # `mycmd \ / --flag \ / || true` as a violation — a common CI shape —
+        # and printed the wrong line as the context.
+        end = idx - 1
+        while end >= 0 and (not lines[end].strip() or lines[end].strip().startswith("#")):
+            end -= 1
+        start = end
+        while start > 0 and lines[start - 1].rstrip().endswith("\\"):
+            start -= 1
+        logical = " ".join(ln.strip().rstrip("\\").strip() for ln in lines[start : end + 1])
+
+        if _SAFE_PRECEDING.search(logical.rstrip()):
+            continue
+        preceding = logical
+
+        findings.append(
+            Finding(path, base_line + idx, line.strip(), preceding.strip())
+        )
+    return findings
+
+
+def _iter_run_blocks(text: str) -> Iterable[tuple[str, int, bool]]:
+    """Yield (body, 1-based start line, `-e` default) for each ``run:`` block.
+
+    Parsed from the raw text rather than through a YAML loader on purpose:
+    the loader discards line numbers and the surrounding ``shell:`` key, and a
+    finding a human cannot locate is a finding nobody fixes.
+    """
+    lines = text.split("\n")
+    i = 0
+    while i < len(lines):
+        m = re.match(r"^(\s*)-?\s*run:\s*\|.*$", lines[i])
+        if not m:
+            i += 1
+            continue
+        indent = len(m.group(1))
+        body: list[str] = []
+        start = i + 2  # 1-based line number of the first body line
+        j = i + 1
+        while j < len(lines):
+            nxt = lines[j]
+            if nxt.strip() and (len(nxt) - len(nxt.lstrip())) <= indent:
+                break
+            body.append(nxt)
+            j += 1
+
+        # DEDENT. Every body line carries the block scalar's YAML indent, so
+        # without this nothing in a `run:` block is ever "unindented" and the
+        # top-level rule in _set_e_active can never re-arm -e: `set +e … set -e
+        # … cmd; rc=$?` passed silently, which is a false NEGATIVE in the one
+        # place the check is supposed to be unconditional.
+        body_text = textwrap.dedent("\n".join(body))
+
+        # A custom `shell:` can remove -e — but only the one on THIS step.
+        # Scanning a fixed window reached into the previous step, so a
+        # `shell: python` step disarmed the check for the bash step after it.
+        # Walk back to the nearest step boundary instead.
+        shell_spec = None
+        for k in range(i - 1, -1, -1):
+            stripped = lines[k].strip()
+            if re.match(r"^-\s*(name|uses|run|id|with|shell)\s*:", stripped) and k != i:
+                sm = re.match(r"^-\s*shell\s*:\s*(.+)$", stripped)
+                if sm:
+                    shell_spec = sm.group(1)
+                break  # start of this step — stop, never cross into the last
+            sm = re.match(r"^shell\s*:\s*(.+)$", stripped)
+            if sm:
+                shell_spec = sm.group(1)
+                break
+        e_default = True
+        if shell_spec:
+            spec = shell_spec.strip().strip("\"'")
+            if spec in ("bash", "sh"):
+                e_default = True  # Actions adds -e for these
+            elif "{0}" in spec:  # fully custom command line
+                # Short-option bundles only. A regex like `-\w*e` also
+                # matches `--noprofile`, which would arm the check on a
+                # shell that has no -e at all.
+                e_default = any(
+                    w.startswith("-") and not w.startswith("--") and "e" in w[1:]
+                    for w in spec.split()
+                )
+            else:  # python, pwsh, ...
+                e_default = False
+        yield body_text, start, e_default
+        i = j
+
+
+def _rel(path: pathlib.Path) -> str:
+    """Repo-relative where possible; absolute otherwise (tests scan tmp dirs)."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def scan_workflows(workflow_dir: pathlib.Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in sorted(workflow_dir.glob("*.yml")) + sorted(workflow_dir.glob("*.yaml")):
+        text = path.read_text(encoding="utf-8")
+        rel = _rel(path)
+        for body, start, e_default in _iter_run_blocks(text):
+            findings.extend(scan_block(body, rel, start, e_default))
+    return findings
+
+
+def _is_shell_file(path: pathlib.Path) -> bool:
+    if path.suffix == ".sh":
+        return True
+    try:
+        with path.open("rb") as fh:
+            return bool(_SHEBANG_RE.match(fh.readline()))
+    except OSError:
+        return False
+
+
+def scan_scripts(dirs: Iterable[pathlib.Path]) -> tuple[list[Finding], int]:
+    """Scan every shell file under ``dirs``. Returns (findings, files seen).
+
+    The count is returned rather than discarded so ``main`` can refuse to
+    print a pass over an empty scan — the failure mode this guard exists to
+    catch, applied to itself.
+    """
+    findings: list[Finding] = []
+    seen = 0
+    for directory in dirs:
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.rglob("*")):
+            if not path.is_file() or not _is_shell_file(path):
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            seen += 1
+            # A standalone script has -e only if it asks for it, so the
+            # default is False here and a TOP-LEVEL `set -e` turns it on.
+            findings.extend(scan_block(text, _rel(path), 1, False))
+    return findings, seen
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0], allow_abbrev=False
+    )
+    parser.add_argument(
+        "--workflow-dir", type=pathlib.Path, default=WORKFLOW_DIR,
+        help="directory of workflow YAML to scan",
+    )
+    parser.add_argument(
+        "--script-dir", type=pathlib.Path, action="append", default=None,
+        help="also scan .sh files here (repeatable)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.workflow_dir.is_dir():
+        print(f"{args.workflow_dir} is not a directory", file=sys.stderr)
+        return 1
+
+    workflows = sorted(args.workflow_dir.glob("*.yml")) + sorted(
+        args.workflow_dir.glob("*.yaml")
+    )
+    if not workflows:
+        # Refusing an empty scan is the point of the whole exercise: "0
+        # workflows checked" must never print the same line as "all clean".
+        print(f"no workflows found in {args.workflow_dir} — refusing to report a pass",
+              file=sys.stderr)
+        return 1
+
+    script_dirs = args.script_dir or list(SCRIPT_DIRS)
+    missing = [d for d in script_dirs if not pathlib.Path(d).is_dir()]
+    if missing and args.script_dir:
+        # Only for explicitly requested dirs: a typo'd --script-dir silently
+        # scanned nothing and still printed the pass line.
+        print(f"--script-dir does not exist: {', '.join(str(d) for d in missing)}",
+              file=sys.stderr)
+        return 1
+
+    findings = scan_workflows(args.workflow_dir)
+    script_findings, scripts_seen = scan_scripts(script_dirs)
+    findings += script_findings
+
+    if not args.script_dir and scripts_seen == 0:
+        print("no shell scripts found in the default script dirs — "
+              "refusing to report a pass", file=sys.stderr)
+        return 1
+
+    if findings:
+        print(
+            f"{len(findings)} shell status capture(s) that are dead code under "
+            f"`set -e`:\n", file=sys.stderr,
+        )
+        for f in findings:
+            print(f"  ✗ {f.path}:{f.line_no}", file=sys.stderr)
+            print(f"      after: {f.context}", file=sys.stderr)
+            print(f"      then:  {f.line}", file=sys.stderr)
+        print(
+            "\n`set -uo pipefail` does NOT clear the `-e` that GitHub Actions "
+            "supplies, so the\ncapture above is never reached when the command "
+            "fails — which is the case it\nexists for. Use the `if` form:\n"
+            "\n    if cmd; then rc=0; else rc=$?; fi\n"
+            "\nor `cmd || true` if the status is not needed, or `set +e` for a "
+            "long run of\ncommands. A real exception can carry "
+            f"`# {_ALLOW_MARKER}`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"OK — {len(workflows)} workflow(s) + {scripts_seen} shell script(s) "
+        f"scanned, no unguarded `$?` captures."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/versions.json
+++ b/versions.json
@@ -446,8 +446,34 @@
       "hold": "Same as jekyll-optional-front-matter: `github-pages` pins `= 0.6.1`. This plugin rewrites the .md links between docs pages, so a version skew here changes URLs in the preview that the published site would not produce -- the exact class of divergence the preview is supposed to rule out. 0.8.0 upstream."
     },
 
+    "agent-python": {
+      "version": "3.14",
+      "pinned_in": [
+        { "path": "agent/dns/images/bind9/Dockerfile", "match": "ARG PYTHON_VERSION={version}", "count": 1 },
+        { "path": "agent/dhcp/images/kea/Dockerfile", "match": "ARG PYTHON_VERSION={version}", "count": 1 },
+        { "path": "agent/dns/images/powerdns/Dockerfile", "match": "ARG PYTHON_VERSION={version}", "count": 1 },
+        { "path": "agent/looking-glass/images/gobgp/Dockerfile", "match": "ARG PYTHON_VERSION={version}", "count": 1 },
+        { "path": "agent/supervisor/images/supervisor/Dockerfile", "match": "ARG PYTHON_VERSION={version}", "count": 1 }
+      ],
+      "upstream": { "kind": "none" },
+      "note": "Not a choice -- it MUST equal the python3 that `alpine` above ships, because it is interpolated into PYTHONPATH and the agent lives at that exact path. Declared here so the pair is visibly coupled; the load-bearing check is the `RUN python3 -c \"import <agent>\"` in each image, which turns a mismatch into a build failure instead of the ModuleNotFoundError CrashLoopBackOff of #672. Until #1037 this arg was declared and referenced by NOTHING in four of the five images -- bumping it changed the image not at all, while the real pin sat hardcoded in PYTHONPATH."
+    },
+
+    "technitium-agent-python": {
+      "version": "3.12",
+      "pinned_in": [
+        {
+          "path": "agent/dns/images/technitium/Dockerfile",
+          "match": "ARG PYTHON_VERSION={version}",
+          "count": 1
+        }
+      ],
+      "upstream": { "kind": "none" },
+      "note": "Separate from `agent-python` above and NOT interchangeable with it: the technitium image is the one agent that is not Alpine-based. Its interpreter is whatever Ubuntu release the upstream technitium/dns-server image is built on, and this arg additionally selects the `python:<v>-slim-bookworm` builder that resolves the compiled cryptography wheel. Today both are 3.12 by coincidence; the coupling is enforced by the `RUN python3 -c \"import spatium_dns_agent, cryptography\"` in that Dockerfile, which fails the build if a TECHNITIUM_DIGEST bump moves the base onto a newer Ubuntu. Bump this only alongside that digest, never with `alpine`."
+    },
+
     "alpine": {
-      "version": "3.23",
+      "version": "3.24",
       "pinned_in": [
         { "path": "agent/dhcp/images/kea/Dockerfile", "match": "FROM alpine:{version}", "count": 2 },
         { "path": "agent/dns/images/bind9/Dockerfile", "match": "FROM alpine:{version}", "count": 2 },
@@ -466,8 +492,7 @@
         { "path": "docs/THIRD_PARTY.md", "match": "| {version} |", "count": 1 }
       ],
       "upstream": { "kind": "dockerhub", "repo": "library/alpine", "track": "^3\\.[0-9]+$" },
-      "hold": "Alpine 3.24 moves the bundled interpreter to Python 3.14.7 (NOT 3.13, as the dependabot.yml comment said until #975). The agent images install spatium_*_agent for 3.12, so on 3.24 the module lands off sys.path -> ModuleNotFoundError -> CrashLoopBackOff. The blocker is therefore a 3.12 -> 3.14 jump needing every agent's dependencies verified on 3.14, not the one-minor step the comment implied. Dependabot's ignore rule lets 3.23.x patches flow; this is the minor hold.",
-      "note": "3.24 also carries pdns 5.0.7, dnsdist 2.0.8 and bind 9.20.27 (Kea stays 3.0.3), so the bump moves four shipped daemons at once and wants its own change."
+      "note": "Bumped 3.23 -> 3.24 in #1037, which discharged the hold #975 corrected. It carried the agents Python 3.12 -> 3.14.7 (NOT 3.13, which the dependabot.yml comment claimed for a year) plus pdns 5.0.5 -> 5.0.7, dnsdist -> 2.0.8 and bind -> 9.20.27; Kea stays 3.0.3. The Python move is the sharp part: the agent is installed into /usr/local/lib/python<X.Y>/site-packages and found only via PYTHONPATH, so a base bump without a matching PYTHONPATH builds a clean image that CrashLoopBackOffs with ModuleNotFoundError (#672). PYTHONPATH now interpolates the PYTHON_VERSION arg -- which was declared and referenced by NOTHING in four of these images until #1037 -- and each image asserts `import <agent>` at build time, so a mismatch is a failed build rather than a failed pod. Dependabot still ignores Alpine minors: the next move is a deliberate task for the same reason, not a bot bump."
     }
   },
 

--- a/versions.json
+++ b/versions.json
@@ -259,7 +259,8 @@
           "match": "``nginx:{version}``",
           "count": 1
         },
-        { "path": "appliance/scripts/bake-images.sh", "match": "\"nginx:{version}\"", "count": 1 }
+        { "path": "appliance/scripts/bake-images.sh", "match": "\"nginx:{version}\"", "count": 1 },
+        { "path": "docs/THIRD_PARTY.md", "match": "| {version} |", "count": 1 }
       ],
       "upstream": { "kind": "dockerhub", "repo": "library/nginx", "track": "^1\\.[0-9]+\\.[0-9]+-alpine$" },
       "note": "The frontend `FROM` IS Dependabot-visible and is listed anyway -- that is the deliberate exception in the header. It is the reason this entry exists: Dependabot moved the frontend image to 1.31 on 2026-07-20 (#688) and the appliance chart's agent-landing copy sat on 1.30.3 for the seven weeks until #975, because nothing connected them. Listing both means the next Dependabot bump fails this lint until the chart and the bake array move too."


### PR DESCRIPTION
Closes #1036, Closes #1037

Plus the nightly reschedule requested alongside them.

## #1036 — a `run:` step that captures `$?` after a bare command is dead code

GitHub Actions runs every `run:` block under `bash -e`, and the `set -uo pipefail` several steps open with does **not** clear it:

```console
$ bash -ec 'set -uo pipefail; case "$-" in *e*) echo "-e STILL ON";; esac'
-e STILL ON
```

So `cmd; rc=$?` is never reached on the failure it exists to handle. #975 fixed the two live sites — after this silently disarmed the weekly CVE scan, where Trivy exits 1 *on findings*, so a clean week and a week full of criticals produced the same visible outcome — and left the guard out of scope. This is the guard.

`scripts/lint_workflow_shell.py` runs in CI's unconditional Backend Lint job and in `make ci`. It is a linter of our own because **neither `actionlint` nor `shellcheck -S style` reports the shape** (both run against the exact snippet): SC2181 fires on a direct `if [ $? -ne 0 ]`, not on `rc=$?` followed by a test of `$rc`. It is pinned against the **real pre-fix `trivy-scheduled.yml` body**, which it reports at the right line.

**The sweep found a second live instance** — but only after review caught the guard wasn't scanning the files its own rationale is built on. It globbed `*.sh`; all 45 appliance host runners are extension-less, `spatium-install` among them. `agent/dhcp/images/kea/entrypoint.sh` runs under `set -eu` and ends:

```sh
wait -n "$KEA_PID" "$KEA6_PID" "$AGENT_PID" 2>/dev/null || wait ...
EXIT_CODE=$?
_term
```

Reproduced against busybox ash: a supervised child exiting non-zero makes the list return non-zero, `-e` kills the script there, and `EXIT_CODE`, `_term` and `exit` are **all** skipped. A kea or agent **crash** — the case the supervision block exists for — tore the container down without terminating its siblings, while a clean SIGTERM (returning 0) cleaned up perfectly. The failure path was the only one that skipped cleanup.

## #1037 — Alpine 3.24 / Python 3.14.7

The base sat on 3.23 for a year behind a `dependabot.yml` comment saying 3.24 moves Python "3.12→3.13". #975 checked the index: **3.14.7**. A two-minor jump, which is most of why nobody had done it.

**The real pin was never `PYTHON_VERSION`.** Four of the five Alpine images declared `ARG PYTHON_VERSION=3.12` and referenced it **nowhere** — bumping it changed the image not at all — while a hardcoded `PYTHONPATH=.../python3.12/site-packages` actually located the agent. That is #672's exact shape: base moves, PYTHONPATH doesn't, image builds perfectly, pod CrashLoopBackOffs. Now `PYTHONPATH` interpolates the arg, and every image asserts its import as a build step.

**technitium needed a different assertion**, which review caught it not having at all. It is the one non-Alpine agent, and its arg drives *both* the builder and `PYTHONPATH` — so they move together and an import alone still passes when the arg is wrong (they resolve, because `cryptography` and `pydantic-core` ship abi3 wheels that load across 3.x). What can drift is the interpreter in the upstream base, so it compares `sys.version_info` to the arg directly. Both forms verified by building with a deliberately wrong `--build-arg`.

Carried along by the same index: pdns 5.0.5 → 5.0.7 (a patch *within* pdns 5, so the #638 LMDB schema guard correctly takes no snapshot — the 4.9 → 5.0 crossing already happened on 3.22 → 3.23), dnsdist → 2.0.8, bind → 9.20.27, Kea unchanged at 3.0.3.

**`Agent — Tests` moves to 3.14 with the images.** It ran on 3.12 while they shipped 3.14 — the skew that lets a 3.14-only regression reach a pod with every check green. The backend stays on 3.12, a separate hold.

## Nightly: 02:23 → 03:23 America/New_York

Requested alongside, and it closes a hole. Cron is UTC-only, so the schedule is two twin crons plus a gate keeping the one whose slot reads the target hour Eastern. **On the spring-forward night the Eastern clock jumps 01:59 → 03:00, so no 02:xx exists and BOTH twins skipped** — the nightly silently built nothing once a year. 03:xx exists every night there is.

Simulated against tzdata for normal EDT, normal EST and both DST nights across 2026–2028: exactly one twin builds in every case. The `:23` is kept deliberately — the top-of-hour stampede delays runner scheduling, and these runs already start up to 13 h late.

## Review findings (7, all fixed)

`/code-review` found seven, six in the new guard and all of them it failing open or crying wolf:

1. **`|| true` on a `\`-continued command was invisible** — the walk-back tested the first physical line, but the safe *suffix* is at the end while the safe *structure* (`else`/`fi`) is at the start. False positive on a very common CI shape, with the wrong line printed as context.
2. **`set -o errexit` / `set +o errexit` unrecognised** — `-o`/`+o` carry no `e`, `errexit` carries no sign. `set +o errexit` left the check armed over a block that had deliberately disarmed it.
3. **`set -e` could never re-arm inside a `run:` block** — every body line carries the YAML block indent, so nothing was ever "top level". Bodies are dedented now; the docstring claiming workflows were unaffected was wrong.
4. **The `shell:` lookback reached into the previous step** — a `shell: python` step disarmed the check for the next bash step. Bound to its own step now.
5. **The live `kea/entrypoint.sh` instance** (above), which the CHANGELOG had claimed did not exist.
6. **The script half could scan zero files and still print a pass** — `*.sh` saw none of the 45 extension-less host runners, and a typo'd `--script-dir` was silently skipped. Shebang detection now, plus a refusal on an empty scan and on a missing requested dir.
7. **technitium was uncovered** (above) while the CHANGELOG, `versions.json` and `dependabot.yml` all claimed "every agent image".

Non-blocking notes also addressed: "all eight images" clarified against the nine-entry nightly matrix, and the looking-glass agent — which has no test suite — is covered by importing every submodule in its shipped image.

## Verification

- Both linters green; **115 backend guard tests** pass, and **every fix was run against a sabotaged linter first** (8 separate reverts, each failing the test that pins it)
- The guard reports the real pre-#975 `trivy-scheduled.yml` at the right line, and finds the `kea/entrypoint.sh` instance on its own — which is what proved it was finally scanning the right files
- All 8 `make trivy` images build on 3.24 and scan **clean**; a deliberately stale `--build-arg PYTHON_VERSION` now **fails the build** on both the Alpine and technitium forms
- Agent suites on **Python 3.14**: dhcp 188, dns 276, supervisor 374 — plus 96 submodules imported inside the shipped images, none failing. (The supervisor's 11 apparent failures were a test container with no `bash`; identical on 3.12.)
- kea entrypoint fix reproduced against real busybox ash: cleanup runs *and* the exit code survives
- Nightly gate simulated across 2026–2028 with a self-checking harness
- `ruff`/`black` clean; every workflow parses; `versions.json` at 95 assertions across 30 components
- Appliance suite 88 failed / 590 passed — the known macOS environmental set, byte-identical on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)