### PR TITLE
ci(nightly): build at 20:05 Eastern via a trigger that fires early and waits; name every nightly for its evening

### DIFF
--- a/.github/workflows/nightly-trigger.yml
+++ b/.github/workflows/nightly-trigger.yml
@@ -1,0 +1,145 @@
+name: Nightly trigger
+
+# WHY THIS EXISTS. The nightly is wanted DONE by ~21:00 America/New_York
+# every night — the QA lane walks it before the team goes to bed — and
+# a build takes 45–55 min, so it has to START at ~20:05. GitHub's
+# scheduler cannot deliver that on its own: `schedule` runs in this
+# repository start 40 min to 7½ h after their cron — measured on every
+# scheduled workflow here (nightly, trivy-scheduled, prune-release-
+# assets) through August and September 2026 — and the delay changes
+# night to night. A cron alone lands the build somewhere in a seven-
+# hour window.
+#
+# So this workflow fires EARLY, waits for the target instant on the
+# Eastern clock, and only then dispatches nightly.yml. A workflow_dispatch
+# starts in seconds, not hours, and the dispatched run reads `main` at
+# dispatch time — so the build carries the day's work up to 20:05.
+# (Waiting inside nightly.yml instead would freeze its GITHUB_SHA at
+# whatever `main` was when the cron finally fired.)
+#
+# Cost: one hosted runner sleeps for at most MAX_HOP per run; free on a
+# public repository. A run that would need longer sleeps MAX_HOP and
+# then hands over to a fresh run of itself, so no job goes near the
+# 6 h limit however early GitHub happens to start it.
+#
+# Two crons, hours apart, because GitHub also DROPS scheduled runs
+# outright some nights: whichever run exists first does the waiting;
+# any other exits at once. nightly.yml's own 03:23 schedule is the
+# fallback of last resort — it builds only when the evening produced
+# no nightly (see the gate there).
+
+on:
+  schedule:
+    # 12:05 and 15:05 EDT (11:05 / 14:05 EST). Early on purpose, see
+    # above; :05 to stay off the top-of-hour cron stampede, like every
+    # other cron in this repository.
+    - cron: "5 16 * * *"
+    - cron: "5 19 * * *"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Eastern wall-clock time (HH:MM) to start the nightly at. Default 20:05."
+        type: string
+        required: false
+        default: ""
+      hop:
+        description: "Internal — set when a run hands over to a fresh copy of itself."
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  # Dispatch nightly.yml, and this workflow when handing over.
+  actions: write
+  contents: read
+
+jobs:
+  wait-then-dispatch:
+    name: Wait for the Eastern target, then start the nightly
+    # Forks inherit this workflow (#830); never dispatch the publisher
+    # outside the canonical repo.
+    if: github.repository_owner == 'spatiumddi'
+    runs-on: ubuntu-latest
+    # MAX_HOP plus a generous margin; never the 6 h ceiling.
+    timeout-minutes: 340
+    steps:
+      - name: Wait, then dispatch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}  # no checkout in this job
+          TARGET_ET: ${{ github.event.inputs.target || '20:05' }}
+          HOP: ${{ github.event.inputs.hop || 'false' }}
+          RUN_ID: ${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          MAX_HOP=$((5 * 3600))
+          now=$(date -u +%s)
+          echo "→ run ${RUN_ID} (${EVENT_NAME}, hop=${HOP}) started $(TZ=America/New_York date -d "@$now" '+%F %H:%M %Z')"
+
+          # ── Which evening does this run belong to? ───────────────────
+          # The occurrence of TARGET_ET nearest to now: today's, unless
+          # today's is more than 12 h ahead — then GitHub started a run
+          # that was meant for last evening after midnight, and it is
+          # late for THAT evening, not early for tonight's. A run that
+          # is late dispatches at once; the nightly names its build by
+          # the evening it belongs to either way (see nightly.yml).
+          if ! [[ "$TARGET_ET" =~ ^([01][0-9]|2[0-3]):[0-5][0-9]$ ]]; then
+            echo "::error::target '${TARGET_ET}' is not HH:MM"
+            exit 1
+          fi
+          today_et=$(TZ=America/New_York date -d "@$now" +%F)
+          target=$(TZ=America/New_York date -d "${today_et} ${TARGET_ET}" +%s)
+          if [ $((target - now)) -gt $((12 * 3600)) ]; then
+            target=$(TZ=America/New_York date -d "${today_et} -1 day ${TARGET_ET}" +%s)
+          fi
+          echo "→ target: $(TZ=America/New_York date -d "@$target" '+%F %H:%M %Z') ($(date -u -d "@$target" '+%H:%M UTC'))"
+
+          # ── Is another trigger already up for this evening? ──────────
+          # Two crons (and a hand-over) can each produce a run. The
+          # oldest one does the waiting. A hop trusts the run that
+          # created it — that parent is still finishing when the hop
+          # starts, and must not count as competition.
+          if [ "$HOP" != "true" ]; then
+            older=$(gh run list --workflow nightly-trigger.yml --status in_progress \
+                      --json databaseId \
+                      --jq "[.[] | select(.databaseId < ${RUN_ID}) | .databaseId | tostring] | join(\" \")")
+            if [ -n "$older" ]; then
+              echo "→ trigger run(s) ${older} already up and older than this one; nothing to do"
+              exit 0
+            fi
+          fi
+
+          # ── Has tonight's nightly already been dispatched? ───────────
+          # By this workflow or by hand — anything created in the hour
+          # before the target or later counts. (An afternoon dispatch by
+          # a human belongs to the previous evening; nightly.yml treats
+          # it that way too.)
+          since=$(date -u -d "@$((target - 3600))" +%FT%TZ)
+          already=$(gh run list --workflow nightly.yml --event workflow_dispatch --limit 20 \
+                      --json databaseId,createdAt \
+                      --jq "[.[] | select(.createdAt >= \"${since}\") | \"\\(.databaseId) (\\(.createdAt))\"] | join(\", \")")
+          if [ -n "$already" ]; then
+            echo "→ tonight's nightly was already dispatched: ${already}; nothing to do"
+            exit 0
+          fi
+
+          # ── Wait ─────────────────────────────────────────────────────
+          wait=$((target - now))
+          if [ "$wait" -gt "$MAX_HOP" ]; then
+            echo "→ ${wait}s to go; sleeping ${MAX_HOP}s, then handing over to a fresh run"
+            sleep "$MAX_HOP"
+            gh workflow run nightly-trigger.yml -f "target=${TARGET_ET}" -f hop=true
+            echo "→ handed over"
+            exit 0
+          fi
+          if [ "$wait" -gt 0 ]; then
+            echo "→ sleeping ${wait}s until the target"
+            sleep "$wait"
+          else
+            echo "→ $(( -wait / 60 )) min past the target already (GitHub started this run late); dispatching now"
+          fi
+
+          # ── Dispatch ─────────────────────────────────────────────────
+          gh workflow run nightly.yml
+          echo "→ nightly.yml dispatched at $(TZ=America/New_York date '+%F %H:%M:%S %Z')"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,16 +51,22 @@ name: Nightly
 
 on:
   schedule:
-    # Target: 03:23 America/New_York — Eric + Matt work Eastern evenings,
-    # so the nightly must run AFTER their late pushes, DST included. Cron
-    # is UTC-only, so schedule both candidate UTC hours (07:23 = 03:23
-    # EDT, 08:23 = 03:23 EST) and let the gate job keep exactly the one
-    # whose SCHEDULED slot reads 03 on the Eastern clock — the other fires
-    # and immediately skips. The gate decides from the cron string GitHub
-    # hands it (github.event.schedule), never from the clock at run time:
-    # GitHub starts these runs 40 min to 13 h late (measured, every
-    # night), so the run-time wall clock says nothing about which slot a
-    # run belongs to.
+    # FALLBACK ONLY. The nightly is normally started at 20:05
+    # America/New_York by nightly-trigger.yml, so the pre-release is done
+    # by ~21:00 for the evening QA walk. GitHub starts crons in this repo
+    # 40 min to 7½ h late, so that workflow fires early, waits for the
+    # instant, and dispatches this one. These crons cover the night the
+    # trigger never fires (GitHub also drops scheduled runs outright):
+    # the gate builds only when the evening produced no nightly, and
+    # names the build after that evening (see "Which evening" below).
+    #
+    # Slot: 03:23 America/New_York. Cron is UTC-only, so schedule both
+    # candidate UTC hours (07:23 = 03:23 EDT, 08:23 = 03:23 EST) and let
+    # the gate job keep exactly the one whose SCHEDULED slot reads 03 on
+    # the Eastern clock — the other fires and immediately skips. The gate
+    # decides from the cron string GitHub hands it (github.event.schedule),
+    # never from the clock at run time — see above for how late these
+    # runs start.
     #
     # The :23 is not decoration and must not be rounded to :00 — same
     # reason prune-release-assets.yml is off the hour: the top-of-hour
@@ -212,16 +218,40 @@ jobs:
           IMAGES_EOF
           echo "images=$(jq -c . /tmp/images.json)" >> "$GITHUB_OUTPUT"
 
-          # Both stamps use the EASTERN calendar date — the run targets
-          # 03:23 America/New_York, so "tonight's build" carries the date
-          # the team just worked through, not whatever UTC rolled over to.
-          DATE_TAG="nightly-$(TZ=America/New_York date +%Y%m%d)"
+          # ── Which evening is this build for? ─────────────────────────
+          # The nightly is built at 20:05 America/New_York (by
+          # nightly-trigger.yml), and every build from 19:00 one day to
+          # 19:00 the next belongs to the evening in between — the stamps
+          # use THAT date, not the calendar date the run happens to start
+          # on:
+          #   - the 03:23 fallback stands in for the evening before it and
+          #     is named after it, so the next evening's build never
+          #     collides with a fallback's tag;
+          #   - a run GitHub started after midnight is late for last
+          #     evening, not early for tonight;
+          #   - a re-run in the afternoon (dispatch --force) refreshes
+          #     last night's release rather than pre-empting tonight's.
+          # 19:00 rather than the trigger's own 20:05 so the two never
+          # have to agree to the minute: anything the trigger starts is
+          # comfortably inside its evening. Eastern throughout, so DST
+          # changes the instant and never the date.
+          NIGHT_BOUNDARY="19:00"
+          NOW=$(date -u +%s)
+          TODAY_ET=$(TZ=America/New_York date -d "@$NOW" +%F)
+          if [ "$NOW" -lt "$(TZ=America/New_York date -d "${TODAY_ET} ${NIGHT_BOUNDARY}" +%s)" ]; then
+            NIGHT_DATE=$(TZ=America/New_York date -d "${TODAY_ET} -1 day" +%Y%m%d)
+          else
+            NIGHT_DATE=$(TZ=America/New_York date -d "${TODAY_ET}" +%Y%m%d)
+          fi
+          DATE_TAG="nightly-${NIGHT_DATE}"
           echo "date_tag=${DATE_TAG}" >> "$GITHUB_OUTPUT"
           # Per-night pre-release tag: CalVer date so nightlies sort and
           # read like the releases they sit next to, PREFIXED so it can
           # never match release.yml's bare-CalVer tag trigger (a tag like
           # 2026.08.08-nightly would fire a full release build).
-          echo "release_tag=nightly-$(TZ=America/New_York date +%Y.%m.%d)" >> "$GITHUB_OUTPUT"
+          RELEASE_TAG="nightly-${NIGHT_DATE:0:4}.${NIGHT_DATE:4:2}.${NIGHT_DATE:6:2}"
+          echo "release_tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "→ this is the build for the evening of ${NIGHT_DATE} (${DATE_TAG}, ${RELEASE_TAG}); now $(TZ=America/New_York date -d "@$NOW" '+%F %H:%M %Z')"
           # Informational version string baked into the frontend build and
           # the appliance release stamp. Deliberately NOT CalVer-shaped, so
           # it can never be mistaken for a release by a human or a sort.
@@ -244,6 +274,21 @@ jobs:
           echo "last_sha=${LAST_SHA}" >> "$GITHUB_OUTPUT"
           echo "last nightly commit: ${LAST_SHA:-<none>}"
           echo "current main commit: ${GITHUB_SHA}"
+
+          # Skip when this evening already has its nightly. The 03:23
+          # fallback, and a second dispatch racing the first, must not
+          # rebuild an evening that published: the QA lane has walked
+          # those bytes, and a same-tag rebuild replaces them under it.
+          # "Published" means finalize stamped `built-from:` — a release
+          # that exists without it is an evening build that died part-way,
+          # and rebuilding that IS the fallback's job. `force` is the
+          # explicit way to rebuild a finished evening.
+          THIS_EVENING_SHA=$(gh release view "$RELEASE_TAG" --json body --jq '.body' 2>/dev/null                              | sed -n 's/^built-from: \([0-9a-f]\{40\}\).*/\1/p' | head -1 || true)
+          if [ "$FORCE" != "true" ] && [ -n "$THIS_EVENING_SHA" ]; then
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "→ ${RELEASE_TAG} is already published (built-from ${THIS_EVENING_SHA::7}); this evening is done. Skipping — dispatch with force=true to rebuild it"
+            exit 0
+          fi
 
           # Skip when main has not moved. Republishing byte-identical images
           # over a quiet weekend burns runner time and, worse, makes the

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -478,10 +478,17 @@ than it saves.
 ### Nightly builds
 
 [`.github/workflows/nightly.yml`](../.github/workflows/nightly.yml) builds
-and publishes every image from `main` at **03:23 America/New_York** (the
-team works Eastern evenings, so the nightly runs after the late pushes —
-two UTC crons plus a wall-clock gate keep that true across DST). It exists
-because
+and publishes every image from `main` at **20:05 America/New_York**, so
+the pre-release is done by about 21:00 for the evening QA walk. GitHub
+starts scheduled runs in this repository hours late, so a small companion,
+[`nightly-trigger.yml`](../.github/workflows/nightly-trigger.yml), fires
+early, waits for the instant on the Eastern clock, and dispatches the
+build; `nightly.yml`'s own 03:23 crons are only a fallback for a night
+the trigger never fired. Every nightly is named for the **evening it
+belongs to** — a build between one 20:05 and the next is
+`nightly-<that evening's date>`, whether it ran at 20:05, after midnight,
+or as the 03:23 fallback — and an evening that already published is never
+rebuilt without `force`. It exists because
 nothing else builds the *release* image except a release — which is how
 [#732](https://github.com/spatiumddi/spatiumddi/issues/732) shipped an api
 image carrying pytest as root, undetected until the next release cut it.


### PR DESCRIPTION
## Summary

**Ask:** have the nightly *finished* by about 21:00 America/New_York every night, so the evening QA walk (`ddi-pg`'s fix-check) can start on it before bed. A build takes 45–55 min, so it must **start at ~20:05**.

**Why a cron alone cannot do that.** GitHub's scheduler starts every scheduled workflow in this repository hours after its cron, and the delay changes night to night:

| workflow | cron (UTC) | run created (UTC), most recent first | late by |
|---|---|---|---|
| nightly, `23 6` twin (#970 era) | 06:23 | 09-09 11:32 · 09-08 11:27 · 09-07 12:45 · 09-06 11:05 · 09-05 10:43 | 4.3 – 6.4 h |
| nightly, `23 7` twin | 07:23 | 09-09 12:23 · 09-08 12:11 · 09-07 13:34 · 09-06 11:41 | 4.3 – 6.2 h |
| trivy-scheduled | Mon 06:17 | 09-07 12:28 · 08-31 13:45 · 08-24 07:18 · 08-17 07:14 · 08-10 08:02 · 08-03 10:04 | 1.0 – 7.5 h |
| prune-release-assets | Mon 04:17 | 09-07 09:18 · 08-31 10:49 · 08-24 04:59 · 08-17 04:56 · 08-10 05:42 | 0.7 – 6.5 h |

(`gh run list --event schedule` on each.) #970 measured "40 min to 13 h" in August. Placing a cron early enough to absorb a 7 h delay means it also fires 7 h early on a good night — the build would land anywhere in a seven-hour window.

### What this PR does

**1. `nightly-trigger.yml` (new): fire early, wait for the instant, then dispatch.** Two crons hours ahead of the target (16:05 and 19:05 UTC). The first run to exist computes the target — 20:05 on the Eastern clock, DST-agnostic — sleeps until it, and runs `gh workflow run nightly.yml`. A `workflow_dispatch` starts in seconds, and the dispatched run reads `main` *at dispatch time*, so the build carries the day's work up to 20:05. (Waiting inside `nightly.yml` instead would have frozen its `GITHUB_SHA` at whatever `main` was when the cron finally fired.)

- A run that would need to sleep longer than 5 h sleeps 5 h and hands over to a fresh run of itself (`-f hop=true`), so no job approaches the 6 h limit however early GitHub starts it.
- A run GitHub starts *after* the target dispatches at once (late, but the build still happens); one started after midnight is treated as late for the previous evening, not early for tonight.
- A run that finds an older trigger already in progress, or a `nightly.yml` dispatch already created in the hour before the target or later, exits — so two crons and a hand-over can never double-build, and a human dispatch near the target is respected.
- Needs `actions: write` on its `GITHUB_TOKEN` (dispatching is the one event the token *is* allowed to create).

Cost: one hosted runner sleeping for at most 5 h per run, free on a public repository.

**2. `nightly.yml`: the 03:23 twins become the fallback, and every nightly is named for its evening.** The crons stay exactly as #1038 left them, demoted: they build only when the evening produced no nightly. To make that safe, every build is now stamped with the **evening it belongs to** — from 19:00 one day to 19:00 the next — instead of the calendar date it happens to start on:

- the 03:23 fallback stands in for the evening before it, *under that evening's tag*, so the next evening's build never collides with a fallback's tag (with calendar-date naming, a fallback at 03:23 on the 10th and the evening build on the 10th would both be `nightly-20260910`, and the second would clobber the first — after the QA lane had walked it);
- a run GitHub started after midnight is late for last evening, not early for tonight;
- a re-run in the afternoon (`dispatch --force`) refreshes last night's release rather than pre-empting tonight's.

And the gate **skips an evening that already published** (`built-from:` stamped by `finalize`) — the lane has walked those bytes and a same-tag rebuild would replace them under it. A release that exists *without* `built-from:` is an evening build that died part-way, and rebuilding that is exactly the fallback's job. `force` rebuilds a finished evening on purpose, as before. The "main unchanged since the last nightly" skip is untouched.

19:00 rather than the trigger's own 20:05 as the boundary, so the two constants never have to agree to the minute.

**3. `docs/DEVELOPMENT.md`** — the "Nightly builds" paragraph describes the above.

### Not changed

- The DST twin-cron gate logic from #970/#1038 — byte-for-byte, only its comments now say "fallback".
- `finalize`, the pre-release body (`built-from:`, `date-tag:`), the prune rings, `dry_run`. Downstream consumers that read the release body see the same fields; only the *date* in the tag is now "the evening", which for a normal 20:05 build is the same calendar date it always was.
- ddi-pg's on-prem timer could dispatch `nightly.yml` at 20:05 as well; the trigger's "already dispatched" check makes that a no-op rather than a second build. Not part of this PR.

Considered and not taken: a single cron close to the target (lands in a seven-hour window, see above); a `wait-timer` environment (fixed duration from a variable start, no better); waiting inside `nightly.yml` (freezes `GITHUB_SHA` at cron time — the build would miss the afternoon's commits, which is the whole point of an evening build).

## Area

- [x] Deployment (Compose / K8s / Appliance) — CI only: `nightly.yml` gate + comments, new `nightly-trigger.yml`, `docs/DEVELOPMENT.md`

## Test plan

- [x] **Both scripts extracted byte-for-byte from these files and run under `faketime`** on a real `ubuntu-latest` runner (private `spatiumddi-qa` sandbox, run [34362139334](https://github.com/spatiumddi/spatiumddi-qa/actions/runs/34362139334), plain `run:` steps because that repo allows local actions only), with `gh` and `sleep` replaced by stubs that answer the exact calls the scripts make and record what they were asked. Every case asserts the decision, the evening the build is named for, and what got dispatched.

  <details><summary>18 gate cases — all pass</summary>

  ```
  PASS  evening-dispatch-20:06-EDT: build=true tag=nightly-20260909 release=nightly-2026.09.09
  PASS  evening-19:00-boundary: build=true tag=nightly-20260909 release=nightly-2026.09.09
  PASS  before-boundary-18:59: build=true tag=nightly-20260908 release=nightly-2026.09.08
  PASS  second-dispatch-published: build=false tag=nightly-20260909 release=nightly-2026.09.09
  PASS  second-dispatch-forced: build=true tag=nightly-20260909 release=nightly-2026.09.09
  PASS  after-midnight-late-dispatch: build=true tag=nightly-20260909 release=nightly-2026.09.09
  PASS  fallback-twin-0723-builds: build=true tag=nightly-20260909 release=nightly-2026.09.09
  PASS  fallback-twin-0823-skips: build=false tag=— release=—
  PASS  fallback-after-published: build=false tag=nightly-20260909 release=nightly-2026.09.09
  PASS  fallback-after-dead-evening: build=true tag=nightly-20260909 release=nightly-2026.09.09
  PASS  afternoon-dispatch-published: build=false tag=nightly-20260909 release=nightly-2026.09.09
  PASS  afternoon-dispatch-forced: build=true tag=nightly-20260909 release=nightly-2026.09.09
  PASS  quiet-day-unchanged-main: build=false tag=nightly-20260909 release=nightly-2026.09.09
  PASS  dst-fallback-nov1-0723-skips: build=false tag=— release=—
  PASS  dst-fallback-nov1-0823-builds: build=true tag=nightly-20261031 release=nightly-2026.10.31
  PASS  dst-evening-nov1-20:06-EST: build=true tag=nightly-20261101 release=nightly-2026.11.01
  PASS  dst-spring-mar14-0723-builds: build=true tag=nightly-20270313 release=nightly-2027.03.13
  PASS  dst-spring-mar14-0823-skips: build=false tag=— release=—
  ```
  </details>

  <details><summary>11 trigger cases — all pass (recorded stub calls)</summary>

  ```
  PASS  cron-early-hands-over: calls=[sleep 18000;workflow run nightly-trigger.yml -f target=20:05 -f hop=true;]
  PASS  hop-waits-then-dispatches: calls=[sleep 10620;workflow run nightly.yml;]
  PASS  cron-late-dispatches-now: calls=[workflow run nightly.yml;]
  PASS  after-midnight-is-last-eve: calls=[workflow run nightly.yml;]
  PASS  older-trigger-up-exits: calls=[]
  PASS  newer-trigger-ignored: calls=[sleep 17880;workflow run nightly.yml;]
  PASS  already-dispatched-exits: calls=[]
  PASS  afternoon-dispatch-ignored: calls=[sleep 3900;workflow run nightly.yml;]
  PASS  custom-target-19:30: calls=[sleep 1800;workflow run nightly.yml;]
  PASS  bad-target-fails: rc=1 calls=[]
  PASS  dst-est-evening: calls=[sleep 3900;workflow run nightly.yml;]
  ```
  </details>

- [x] **Live dispatch** on the sandbox: `nightly-trigger.yml` (this file, schedule block removed) registered next to a run-only stub `nightly.yml`; dispatched with `target=10:16` at 10:12 EDT → `sleeping 225s until the target` → `nightly.yml dispatched at 10:16:03 EDT` → the stub run was **created 3 s after the target** by `github-actions[bot]` via the job's own `GITHUB_TOKEN` under `permissions: actions: write` (run [34362047650](https://github.com/spatiumddi/spatiumddi-qa/actions/runs/34362047650)).
- [x] `actionlint` on all three workflows: no new findings (the pre-existing SC2129 style note on the gate's `$GITHUB_OUTPUT` echoes is unchanged).
- [ ] First real proof after merge: tonight's `nightly-trigger.yml` run (its crons are 16:05/19:05 UTC; a merge before then gets tonight, a merge after can be dispatched by hand once with any `target`) should log `sleeping …s until the target` and dispatch at 20:05 EDT; `nightly-2026.09.09`… i.e. that evening's pre-release, appears by ~21:00. The 03:23 fallback the next morning should log `nightly-2026.09.09 is already published … Skipping`.

Downstream: ddi-pg's nightly lane reads `date-tag:`/`built-from:` from the release body and stages by date tag — unchanged shape; with this it can start the evening walk at ~21:00 ET instead of the next morning.

## Related issues

Refs #1038 (the 03:23 reschedule this builds on), #970, #849, #805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
