### PR TITLE
fix(appliance): wrap-iso.sh + build-slot-image.sh — unmount the chroot binds recursively and prove it; never rm -rf across a live mount

### DIFF
--- a/appliance/scripts/build-slot-image.sh
+++ b/appliance/scripts/build-slot-image.sh
@@ -70,7 +70,12 @@ WORK=$(mktemp -d)
 # loop device. `umount -R` tears the submounts down first; `rm -rf
 # --one-file-system` is a belt-and-braces stop so rm never crosses a
 # still-mounted boundary even if an unmount failed.
-trap 'for mp in "$WORK/slot-mnt" "$WORK/src-mnt"; do umount -R "$mp" 2>/dev/null || umount "$mp" 2>/dev/null || true; done; rm -rf --one-file-system "$WORK"' EXIT
+# unmount_tree (mount-lib.sh, shared with wrap-iso.sh) is the recursive
+# unmount above plus a lazy-detach fallback and a findmnt proof, loud on
+# every failure — the same busy /sys that took wrap-iso.sh down on
+# nightly-20260909 stopped this script's bare `umount` one step later.
+. "$(dirname "$0")/mount-lib.sh"
+trap 'for mp in "$WORK/slot-mnt" "$WORK/src-mnt"; do unmount_tree "$mp" || true; done; rm -rf --one-file-system "$WORK"' EXIT
 
 mkdir -p "$WORK/src-mnt" "$WORK/slot-mnt"
 
@@ -229,9 +234,12 @@ ln -sf "initrd.img-$KVER" "$WORK/slot-mnt/boot/initrd.img"
 # dpkg-diverts update-initramfs into a no-op. Undivert it first so
 # the actual binary runs, then regenerate.
 echo "→ Regenerating initrd inside slot…"
-mount --bind /proc "$WORK/slot-mnt/proc"
-mount --bind /sys  "$WORK/slot-mnt/sys"
-mount --bind /dev  "$WORK/slot-mnt/dev"
+for d in proc sys dev; do
+    mount --bind "/$d" "$WORK/slot-mnt/$d"
+    # Private: nothing that appears under the builder's own /$d after this
+    # point may propagate into the tree we are about to image.
+    mount --make-rprivate "$WORK/slot-mnt/$d"
+done
 
 # Force virtio + ext4 modules into the initrd so the slot can find
 # its root partition on common VM hypervisors (Proxmox/QEMU/libvirt).
@@ -261,12 +269,21 @@ if [ ! -f "$WORK/slot-mnt/boot/initrd.img-$KVER" ]; then
     exit 1
 fi
 
-umount "$WORK/slot-mnt/proc"
-umount "$WORK/slot-mnt/sys"
-umount "$WORK/slot-mnt/dev"
+# Verified, recursive, lazy-fallback unmounts (see mount-lib.sh) — a
+# plain `umount "$WORK/slot-mnt/sys"` here returned "target is busy"
+# after the chroot's update-initramfs in the nightly-20260909 replay.
+for d in dev sys proc; do
+    unmount_tree "$WORK/slot-mnt/$d" || exit 1
+done
+for d in proc sys dev; do
+    if mountpoint -q "$WORK/slot-mnt/$d" 2>/dev/null; then
+        echo "ERROR: $WORK/slot-mnt/$d is still a mount point; refusing to image the slot" >&2
+        exit 1
+    fi
+done
 
-umount "$WORK/slot-mnt"
-umount "$WORK/src-mnt"
+unmount_tree "$WORK/slot-mnt" || exit 1
+unmount_tree "$WORK/src-mnt" || exit 1
 
 # Run an fsck pass so the image lands in a clean state. e2fsck -fy
 # trims unused-but-allocated blocks too, which helps xz compress.

--- a/appliance/scripts/mount-lib.sh
+++ b/appliance/scripts/mount-lib.sh
@@ -31,7 +31,8 @@
 # `umount -R` takes sub-mounts down first; a lazy `-l -R` detach is the
 # fallback for a mount something still holds open (the tree is gone from
 # our namespace either way, which is all mksquashfs, rsync and rm need);
-# `findmnt` is the proof. build-slot-image.sh's #553 exit trap already
+# the mount-table scan is the proof — NOT `findmnt`, which cannot see a mount
+# below a plain directory at all. build-slot-image.sh's #553 exit trap already
 # had the recursive half of this; wrap-iso.sh never had any of it.
 
 # Processes (in this namespace) whose cwd, root or an open fd is under $1.
@@ -48,19 +49,59 @@ holders_of() {
     done
 }
 
-# Is anything mounted AT or BELOW $1? Reads /proc/mounts rather than asking
+# Where the mount table is read from. Overridable ONLY so the path-matching
+# below can be tested against a synthetic table without root — every caller
+# uses the default.
+: "${MOUNT_LIB_MOUNTS_FILE:=/proc/mounts}"
+
+# Canonicalise a path the way /proc/mounts already has. Without this the
+# comparison is a literal string match against the kernel's canonical target,
+# so a symlinked ancestor (a symlinked TMPDIR is enough) or a trailing slash
+# makes every mount invisible — and this helper is BOTH the gate and the
+# post-unmount proof, so a miss reads as "nothing mounted, safe to rm -rf".
+# Measured: without it, `unmount_tree "$W/link/mnt"` left the tmpfs mounted and
+# returned 0, where resolving first clears it.
+#
+# `realpath -m` does not require the path to exist (it may already be gone by
+# the time cleanup runs); `readlink -f` is the fallback, and the raw path the
+# last resort so a coreutils-less shell degrades to the old behaviour rather
+# than to an exception.
+_canon_path() {
+    realpath -m "$1" 2>/dev/null \
+        || readlink -f "$1" 2>/dev/null \
+        || printf '%s' "$1"
+}
+
+# Is anything mounted AT or BELOW $1? Reads the mount table rather than asking
 # findmnt, because `findmnt -R <path>` resolves <path> to its own mountpoint
 # and reports nothing at all when <path> is a plain directory with mounts
 # underneath it — so it cannot answer this question, which is the one that
 # matters before an `rm -rf`.
 anything_mounted_under() {
-    local under=$1 target
+    local under target
+    under=$(_canon_path "$1")
     while read -r _dev target _rest; do
+        # /proc/mounts octal-escapes space (\040), tab, newline and backslash.
+        # `printf %b` is what turns those back into the path we were handed.
+        target=$(printf '%b' "$target")
         case "$target" in
             "$under"|"$under"/*) return 0 ;;
         esac
-    done < /proc/mounts
+    done < "$MOUNT_LIB_MOUNTS_FILE"
     return 1
+}
+
+# Every mount at or below $1, deepest first — the order umount needs, since a
+# parent refuses while a child is mounted on it.
+mounts_under() {
+    local under target
+    under=$(_canon_path "$1")
+    while read -r _dev target _rest; do
+        target=$(printf '%b' "$target")
+        case "$target" in
+            "$under"|"$under"/*) printf '%s\t%s\n' "${#target}" "$target" ;;
+        esac
+    done < "$MOUNT_LIB_MOUNTS_FILE" | sort -rn | cut -f2-
 }
 
 unmount_tree() {
@@ -75,20 +116,32 @@ unmount_tree() {
     # to check.
     anything_mounted_under "$mp" || return 0
     mountpoint -q "$mp" 2>/dev/null || {
-        # Sub-mounts but no mount at $mp itself: umount -R needs a mount
-        # point, so take them deepest-first by path length.
-        local target rc=0
-        for target in $(awk -v u="$mp" '$2 == u || index($2, u "/") == 1 {print length($2), $2}' \
-                            /proc/mounts | sort -rn | cut -d" " -f2-); do
-            umount -R "$target" 2>/dev/null || umount -l -R "$target" || rc=1
+        # Sub-mounts but no mount at $mp itself: `umount -R` needs a mount
+        # point, so walk them deepest-first.
+        #
+        # The list is RE-READ every pass rather than snapshotted. One
+        # `umount -R` can take several entries down at once (stacked mounts at
+        # one target, or a subtree), and a stale entry then fails both attempts
+        # and latched a failure on a tree that was already clean — reporting
+        # ERROR with nothing of our own in the log, while every caller is
+        # `|| exit 1`. Bounded so a mount that genuinely will not go never
+        # spins; the verdict is the proof below, not the loop.
+        local target pass=0
+        while [ "$pass" -lt 20 ] && anything_mounted_under "$mp"; do
+            pass=$((pass + 1))
+            target=$(mounts_under "$mp" | head -n1)
+            [ -n "$target" ] || break
+            umount -R "$target" 2>/dev/null \
+                || umount -l -R "$target" 2>/dev/null \
+                || true
         done
         if anything_mounted_under "$mp"; then
-            echo "ERROR: mounts remain under $mp:" >&2
-            grep -F " $mp" /proc/mounts >&2 || true
+            echo "ERROR: mounts remain under $mp after $pass pass(es):" >&2
+            mounts_under "$mp" >&2 || true
             holders_of "$mp" >&2 || true
             return 1
         fi
-        return "$rc"
+        return 0
     }
     if ! umount -R "$mp"; then
         echo "  umount -R $mp failed; still mounted underneath it:" >&2
@@ -100,8 +153,8 @@ unmount_tree() {
     fi
     if anything_mounted_under "$mp"; then
         echo "ERROR: $mp is still mounted after umount -R and a lazy detach:" >&2
-        findmnt -R "$mp" >&2 || true
-        grep -F " $mp" /proc/mounts >&2 || true
+        mounts_under "$mp" >&2 || true
+        holders_of "$mp" >&2 || true
         return 1
     fi
 }

--- a/appliance/scripts/mount-lib.sh
+++ b/appliance/scripts/mount-lib.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# mount-lib.sh — shared by wrap-iso.sh (bash) and build-slot-image.sh (dash;
+# `local` is a dash builtin), which both
+# bind-mount the builder's /proc, /sys and /dev into a loop-mounted
+# appliance rootfs to chroot `update-initramfs`, and both have to get
+# those binds OFF again before they snapshot the tree and remove the
+# work directory.
+#
+#   . "$(dirname "$0")/mount-lib.sh"
+#
+# unmount_tree <path>
+#   Unmount everything mounted at or below <path> — deepest first — and
+#   PROVE it is gone before returning 0. Loud on every failure; returns 1
+#   (after printing what is still there and who holds it) if the mount
+#   survives both a recursive and a lazy detach.
+#
+# Why this is not just `umount`: after the chroot's update-initramfs the
+# bound /sys refuses a plain, non-recursive umount with EBUSY on the
+# nightly runners (it did on both architectures of nightly-20260909 and
+# in the sandbox replay), and the two scripts handled that in the two
+# worst ways available —
+#   wrap-iso.sh:  `umount … 2>/dev/null || true` swallowed it, mksquashfs
+#                 then walked the builder's live /sys through the bind
+#                 ("Failed to read file …/mnt/sys/…, creating empty file"
+#                 ×24k), the ISO built and verified, and the exit trap's
+#                 `rm -rf "$WORKDIR"` died on the same sysfs — after
+#                 unlinking the appliance rootfs on the raw image through
+#                 the rw loop mount on its way there. Exit 1, 20 minutes in.
+#   build-slot-image.sh: a bare `umount` under set -e: exit 32 at
+#                 "Regenerating initrd inside slot…", right after.
+# `umount -R` takes sub-mounts down first; a lazy `-l -R` detach is the
+# fallback for a mount something still holds open (the tree is gone from
+# our namespace either way, which is all mksquashfs, rsync and rm need);
+# `findmnt` is the proof. build-slot-image.sh's #553 exit trap already
+# had the recursive half of this; wrap-iso.sh never had any of it.
+
+# Processes (in this namespace) whose cwd, root or an open fd is under $1.
+holders_of() {
+    local under=$1 p target
+    for p in /proc/[0-9]*; do
+        for target in "$p/cwd" "$p/root" "$p"/fd/*; do
+            case "$(readlink "$target" 2>/dev/null)" in
+                "$under"|"$under"/*)
+                    echo "  pid ${p#/proc/} ($(tr -d '\0' < "$p/comm" 2>/dev/null)) holds $(readlink "$target")"
+                    break ;;
+            esac
+        done
+    done
+}
+
+unmount_tree() {
+    local mp=$1
+    mountpoint -q "$mp" 2>/dev/null || return 0
+    if ! umount -R "$mp"; then
+        echo "  umount -R $mp failed; still mounted underneath it:" >&2
+        findmnt -R "$mp" >&2 || true
+        echo "  holders:" >&2
+        holders_of "$mp" >&2 || true
+        echo "  detaching lazily" >&2
+        umount -l -R "$mp" || true
+    fi
+    if [ -n "$(findmnt -R -n -o TARGET "$mp" 2>/dev/null)" ]; then
+        echo "ERROR: $mp is still mounted after umount -R and a lazy detach:" >&2
+        findmnt -R "$mp" >&2 || true
+        return 1
+    fi
+}

--- a/appliance/scripts/mount-lib.sh
+++ b/appliance/scripts/mount-lib.sh
@@ -48,9 +48,48 @@ holders_of() {
     done
 }
 
+# Is anything mounted AT or BELOW $1? Reads /proc/mounts rather than asking
+# findmnt, because `findmnt -R <path>` resolves <path> to its own mountpoint
+# and reports nothing at all when <path> is a plain directory with mounts
+# underneath it — so it cannot answer this question, which is the one that
+# matters before an `rm -rf`.
+anything_mounted_under() {
+    local under=$1 target
+    while read -r _dev target _rest; do
+        case "$target" in
+            "$under"|"$under"/*) return 0 ;;
+        esac
+    done < /proc/mounts
+    return 1
+}
+
 unmount_tree() {
     local mp=$1
-    mountpoint -q "$mp" 2>/dev/null || return 0
+    # NOT `mountpoint -q || return 0`. That returned SUCCESS for a directory
+    # that is not itself a mount but has live mounts beneath it — and the
+    # findmnt "proof" below is blind the same way, so the function reported a
+    # clean tree while a bind was still up. Harmless at today's call sites
+    # (every one is a mount point) and exactly wrong for the next caller who
+    # passes $WORKDIR, which is the natural thing for "clean up everything"
+    # and what cleanup()'s own "live mounts under it" message already claims
+    # to check.
+    anything_mounted_under "$mp" || return 0
+    mountpoint -q "$mp" 2>/dev/null || {
+        # Sub-mounts but no mount at $mp itself: umount -R needs a mount
+        # point, so take them deepest-first by path length.
+        local target rc=0
+        for target in $(awk -v u="$mp" '$2 == u || index($2, u "/") == 1 {print length($2), $2}' \
+                            /proc/mounts | sort -rn | cut -d" " -f2-); do
+            umount -R "$target" 2>/dev/null || umount -l -R "$target" || rc=1
+        done
+        if anything_mounted_under "$mp"; then
+            echo "ERROR: mounts remain under $mp:" >&2
+            grep -F " $mp" /proc/mounts >&2 || true
+            holders_of "$mp" >&2 || true
+            return 1
+        fi
+        return "$rc"
+    }
     if ! umount -R "$mp"; then
         echo "  umount -R $mp failed; still mounted underneath it:" >&2
         findmnt -R "$mp" >&2 || true
@@ -59,9 +98,10 @@ unmount_tree() {
         echo "  detaching lazily" >&2
         umount -l -R "$mp" || true
     fi
-    if [ -n "$(findmnt -R -n -o TARGET "$mp" 2>/dev/null)" ]; then
+    if anything_mounted_under "$mp"; then
         echo "ERROR: $mp is still mounted after umount -R and a lazy detach:" >&2
         findmnt -R "$mp" >&2 || true
+        grep -F " $mp" /proc/mounts >&2 || true
         return 1
     fi
 }

--- a/appliance/scripts/wrap-iso.sh
+++ b/appliance/scripts/wrap-iso.sh
@@ -56,7 +56,16 @@ MOUNT_DIR=
 . "$(dirname "$0")/mount-lib.sh"
 
 cleanup() {
-    local rc=$?
+    # ``${1:-$?}`` — the status is PASSED IN over the composite-trap window,
+    # because there ``$?`` is not the script's status. ``trap 'cleanup_chroot;
+    # cleanup' EXIT`` runs cleanup_chroot first, and its ``unmount_tree … ||
+    # true`` leaves ``$?`` at 0, so the bare ``$?`` exited 0 on every failure
+    # between the bind mounts and the squashfs — including the three refusals
+    # this script newly adds (``unmount_tree || exit 1``, "still a mount
+    # point", "not empty") and the two that predate it ("could not determine
+    # kernel version", "initrd was not created"). Seven paths printed ERROR
+    # and returned success; main exits 1 correctly, so it was a regression.
+    local rc=${1:-$?}
     if [ -n "$MOUNT_DIR" ] && ! unmount_tree "$MOUNT_DIR"; then
         echo "ERROR: refusing to rm -rf $WORKDIR with live mounts under it" >&2
         exit 1
@@ -136,7 +145,7 @@ cleanup_chroot() {
         unmount_tree "$MOUNT_DIR/$d" || true
     done
 }
-trap 'cleanup_chroot; cleanup' EXIT
+trap 'rc=$?; cleanup_chroot; cleanup "$rc"' EXIT
 
 # Pick the kernel version from /lib/modules/<kver>/. update-initramfs
 # needs an explicit version when /boot/vmlinuz isn't there — mkosi

--- a/appliance/scripts/wrap-iso.sh
+++ b/appliance/scripts/wrap-iso.sh
@@ -50,11 +50,21 @@ INITRD="${RAW%.raw}.initrd"
 
 WORKDIR=$(mktemp -d)
 MOUNT_DIR=
+
+# unmount_tree (+ the story of nightly-20260909) lives in mount-lib.sh,
+# shared with build-slot-image.sh, which hit the same wall one step later.
+. "$(dirname "$0")/mount-lib.sh"
+
 cleanup() {
-    if [ -n "$MOUNT_DIR" ] && mountpoint -q "$MOUNT_DIR" 2>/dev/null; then
-        umount "$MOUNT_DIR" || true
+    local rc=$?
+    if [ -n "$MOUNT_DIR" ] && ! unmount_tree "$MOUNT_DIR"; then
+        echo "ERROR: refusing to rm -rf $WORKDIR with live mounts under it" >&2
+        exit 1
     fi
-    rm -rf "$WORKDIR"
+    # --one-file-system: even if a mount slipped past the check above,
+    # never delete across it (#553).
+    rm -rf --one-file-system "$WORKDIR"
+    exit "$rc"
 }
 trap cleanup EXIT
 
@@ -116,10 +126,14 @@ mount -o rw,loop,offset=$ROOT_OFFSET,sizelimit=$ROOT_SIZE "$RAW" "$MOUNT_DIR"
 echo "→ Regenerating initrd with live-boot hooks (chroot into rootfs)…"
 for d in proc sys dev; do
     mount --bind "/$d" "$MOUNT_DIR/$d"
+    # Private: whatever the builder's own /$d does after this point (a
+    # mount appearing under a shared /sys, say) must not propagate into
+    # the tree we are about to squash — see unmount_tree above.
+    mount --make-rprivate "$MOUNT_DIR/$d"
 done
 cleanup_chroot() {
     for d in dev sys proc; do
-        umount "$MOUNT_DIR/$d" 2>/dev/null || true
+        unmount_tree "$MOUNT_DIR/$d" || true
     done
 }
 trap 'cleanup_chroot; cleanup' EXIT
@@ -163,9 +177,29 @@ echo "→ Live initrd: $(ls -lh "$ISO_ROOT/live/initrd.img" | awk '{print $5}')"
 # ── Squashfs of the rootfs ────────────────────────────────────────────────────
 # Unmount the bind mounts before snapshotting — squashfs would
 # otherwise descend into /proc and /sys and try to pack their
-# contents, which fails on synthetic kernel files.
+# contents — and REFUSE to snapshot if any of them is still there.
+# The old ``umount … 2>/dev/null || true`` here is the line that turned
+# nightly-20260909 into a 24,000-line log and an exit 1 after a valid
+# ISO had been written (see unmount_tree).
 for d in dev sys proc; do
-    umount "$MOUNT_DIR/$d" 2>/dev/null || true
+    unmount_tree "$MOUNT_DIR/$d" || exit 1
+done
+for d in proc sys dev; do
+    if mountpoint -q "$MOUNT_DIR/$d" 2>/dev/null; then
+        echo "ERROR: $MOUNT_DIR/$d is still a mount point — refusing to squash a" >&2
+        echo "       rootfs with the builder's kernel filesystems in it." >&2
+        findmnt -R "$MOUNT_DIR/$d" >&2 || true
+        exit 1
+    fi
+done
+# The rootfs's own /proc and /sys are empty directories; anything in
+# them now is the builder's, not the appliance's.
+for d in proc sys; do
+    if [ -n "$(ls -A "$MOUNT_DIR/$d" 2>/dev/null)" ]; then
+        echo "ERROR: $MOUNT_DIR/$d is not empty — a kernel filesystem leaked into the rootfs:" >&2
+        ls -A "$MOUNT_DIR/$d" | head >&2
+        exit 1
+    fi
 done
 trap cleanup EXIT
 

--- a/appliance/scripts/wrap-iso.sh
+++ b/appliance/scripts/wrap-iso.sh
@@ -66,7 +66,12 @@ cleanup() {
     # kernel version", "initrd was not created"). Seven paths printed ERROR
     # and returned success; main exits 1 correctly, so it was a regression.
     local rc=${1:-$?}
-    if [ -n "$MOUNT_DIR" ] && ! unmount_tree "$MOUNT_DIR"; then
+    # $WORKDIR, not $MOUNT_DIR — the refusal below says "with live mounts under
+    # $WORKDIR" and `rm -rf` is about to walk exactly that, so that is what has
+    # to be clear. Checking only $MOUNT_DIR made the claim wider than the check
+    # and left the non-mountpoint branch in unmount_tree unreachable from any
+    # call site. MOUNT_DIR lives under WORKDIR, so this is a superset.
+    if ! unmount_tree "$WORKDIR"; then
         echo "ERROR: refusing to rm -rf $WORKDIR with live mounts under it" >&2
         exit 1
     fi

--- a/appliance/tests/test_wrap_iso_unmount_contract.py
+++ b/appliance/tests/test_wrap_iso_unmount_contract.py
@@ -115,6 +115,77 @@ def test_the_composite_trap_passes_the_status_in() -> None:
 # ── 2. unmount_tree must see mounts BELOW a plain directory ──────────────────
 
 
+def _mounted_under(mounts_table: str, query: str, tmp_path: Path) -> bool:
+    """Ask the SHIPPED `anything_mounted_under` about a synthetic mount table.
+
+    `MOUNT_LIB_MOUNTS_FILE` exists for exactly this: the path-matching is where
+    the regression was, and it needs no root to exercise. The behavioural
+    unmount test below needs real mounts and skips where it cannot get them, so
+    without this seam the logic that actually broke had no coverage at all
+    anywhere it runs.
+    """
+    table = tmp_path / "mounts"
+    table.write_text(mounts_table, encoding="utf-8")
+    proc = subprocess.run(
+        ["bash", "-c", f'. "{MOUNT_LIB}"\nanything_mounted_under "{query}"'],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin:/usr/sbin:/sbin", "MOUNT_LIB_MOUNTS_FILE": str(table)},
+    )
+    assert proc.returncode in (0, 1), f"unexpected rc {proc.returncode}: {proc.stderr}"
+    return proc.returncode == 0
+
+
+def test_a_mount_below_a_plain_directory_is_seen(tmp_path: Path) -> None:
+    """The gate `mountpoint -q … || return 0` could not see this at all."""
+    d = tmp_path / "work"
+    (d / "mnt").mkdir(parents=True)
+    assert _mounted_under(f"none {d}/mnt tmpfs rw 0 0\n", str(d), tmp_path)
+
+
+def test_a_trailing_slash_does_not_hide_a_mount(tmp_path: Path) -> None:
+    d = tmp_path / "work"
+    (d / "mnt").mkdir(parents=True)
+    assert _mounted_under(f"none {d}/mnt tmpfs rw 0 0\n", f"{d}/", tmp_path)
+
+
+def test_a_symlinked_ancestor_does_not_hide_a_mount(tmp_path: Path) -> None:
+    """The regression this contract test exists for.
+
+    /proc/mounts records the kernel's CANONICAL target, so a literal compare
+    against a path reached through a symlink matches nothing — and because the
+    same helper is also the post-unmount proof, a miss reads as "clean, safe to
+    rm -rf". The first cut of this fix had exactly that, and it was a
+    regression: the original `mountpoint -q` form resolved symlinks for free.
+    """
+    real = tmp_path / "real"
+    (real / "mnt").mkdir(parents=True)
+    link = tmp_path / "link"
+    link.symlink_to(real)
+    assert _mounted_under(f"none {real}/mnt tmpfs rw 0 0\n", f"{link}/mnt", tmp_path)
+
+
+def test_an_escaped_space_does_not_hide_a_mount(tmp_path: Path) -> None:
+    """/proc/mounts octal-escapes space as `\\040`."""
+    d = tmp_path / "sp ace"
+    (d / "mnt").mkdir(parents=True)
+    escaped = str(d / "mnt").replace(" ", "\\040")
+    assert _mounted_under(f"none {escaped} tmpfs rw 0 0\n", str(d), tmp_path)
+
+
+def test_an_unrelated_mount_is_not_claimed(tmp_path: Path) -> None:
+    """Negative control: the matcher must not be a blanket yes.
+
+    A sibling whose path merely shares a prefix (`/x/work2` vs `/x/work`) is
+    not under it — a plain `index(target, under) == 1` would say it is.
+    """
+    d = tmp_path / "work"
+    d.mkdir()
+    sibling = tmp_path / "work2"
+    (sibling / "mnt").mkdir(parents=True)
+    assert not _mounted_under(f"none {sibling}/mnt tmpfs rw 0 0\n", str(d), tmp_path)
+
+
 def test_unmount_tree_does_not_early_return_on_a_non_mountpoint() -> None:
     """The `mountpoint -q … || return 0` guard is what made it blind."""
     body = MOUNT_LIB.read_text(encoding="utf-8")

--- a/appliance/tests/test_wrap_iso_unmount_contract.py
+++ b/appliance/tests/test_wrap_iso_unmount_contract.py
@@ -1,0 +1,158 @@
+"""Two contracts the #1039 unmount fix depends on, neither self-evident.
+
+`wrap-iso.sh` and `build-slot-image.sh` share `mount-lib.sh`'s `unmount_tree`,
+whose whole selling point is that it PROVES the tree is gone before a
+`rm -rf`. Review of the original patch found both halves of that claim broken:
+
+1. `cleanup()` captured `$?` itself, but over the chroot window the trap is
+   COMPOSITE — `trap 'cleanup_chroot; cleanup' EXIT` — so `$?` was
+   `cleanup_chroot`'s status, pinned to 0 by its own `|| true`. Every failure
+   between the bind mounts and the squashfs exited 0, including the three
+   refusals the patch newly added and the two that predate it. `main` exits 1
+   correctly, so it was a regression, in the window that contains the guards.
+
+2. `unmount_tree` early-returned success when its argument was not itself a
+   mount point, and the `findmnt -R` proof was blind the same way — so a
+   directory with live mounts beneath it reported clean. `findmnt -R` cannot
+   answer that question: it resolves the path to its own mountpoint and
+   reports nothing for a plain directory.
+
+Both are asserted against the SHIPPED scripts, with the mount half exercised
+against real mounts where available.
+
+    python3 -m pytest appliance/tests/test_wrap_iso_unmount_contract.py -v
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "appliance" / "scripts"
+WRAP = SCRIPTS / "wrap-iso.sh"
+MOUNT_LIB = SCRIPTS / "mount-lib.sh"
+
+pytestmark = pytest.mark.skipif(
+    not WRAP.exists() or not MOUNT_LIB.exists(),
+    reason="appliance scripts not present in this checkout",
+)
+
+#: `cleanup()` ends in `rm -rf --one-file-system` (#553), which is GNU-only —
+#: BSD rm exits 64 on it. The builder and the CI runner are both GNU; a macOS
+#: dev box is not, and without this the exit-status tests fail there for a
+#: reason that has nothing to do with what they assert. Skipping beats a
+#: misleading red, and the check is explicit so nobody "fixes" it by weakening
+#: the assertion.
+_GNU_RM = (
+    subprocess.run(
+        ["sh", "-c", "rm -rf --one-file-system /nonexistent-gnu-rm-probe"],
+        capture_output=True,
+    ).returncode
+    == 0
+)
+
+
+def _block(path: Path, pattern: str, what: str) -> str:
+    m = re.search(pattern, path.read_text(encoding="utf-8"), re.S | re.M)
+    assert m, f"{path.name} no longer contains {what}"
+    return m.group(0)
+
+
+# ── 1. the exit status must survive the composite trap ───────────────────────
+
+
+@pytest.mark.skipif(not _GNU_RM, reason="cleanup() needs GNU rm --one-file-system")
+@pytest.mark.parametrize(
+    ("mode", "want"),
+    [("setE", 1), ("guard", 1), ("ok", 0)],
+)
+def test_failures_in_the_chroot_window_do_not_exit_zero(mode: str, want: int) -> None:
+    """Runs the SHIPPED cleanup + chroot trap, not a paraphrase of them."""
+    cleanup = _block(WRAP, r"^cleanup\(\) \{.*?^\}$", "cleanup()")
+    chroot = _block(WRAP, r"^cleanup_chroot\(\) \{.*?^\}$", "cleanup_chroot()")
+    composite = _block(
+        WRAP, r"^trap '.*cleanup_chroot.*' EXIT$", "the composite chroot-window trap"
+    )
+    script = f"""
+set -euo pipefail
+WORKDIR=$(mktemp -d); MOUNT_DIR=
+unmount_tree() {{ return 0; }}
+{cleanup}
+trap cleanup EXIT
+{chroot}
+{composite}
+case "{mode}" in
+  setE)  false ;;
+  guard) echo "ERROR: refusing to squash" >&2; exit 1 ;;
+  ok)    : ;;
+esac
+exit 0
+"""
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert proc.returncode == want, (
+        f"mode={mode} exited {proc.returncode}, want {want} — the composite trap "
+        f"is swallowing the status again\n{proc.stdout}{proc.stderr}"
+    )
+
+
+def test_the_composite_trap_passes_the_status_in() -> None:
+    """Structural backstop: the shape that made the bug possible must not return.
+
+    `trap 'cleanup_chroot; cleanup' EXIT` with a `$?`-reading cleanup is the
+    broken pairing; the status has to be captured before cleanup_chroot runs.
+    """
+    composite = _block(WRAP, r"^trap '.*cleanup_chroot.*' EXIT$", "the chroot trap")
+    assert "rc=$?" in composite, (
+        f"the composite trap must capture $? before cleanup_chroot: {composite}"
+    )
+
+
+# ── 2. unmount_tree must see mounts BELOW a plain directory ──────────────────
+
+
+def test_unmount_tree_does_not_early_return_on_a_non_mountpoint() -> None:
+    """The `mountpoint -q … || return 0` guard is what made it blind."""
+    body = MOUNT_LIB.read_text(encoding="utf-8")
+    fn = _block(MOUNT_LIB, r"^unmount_tree\(\) \{.*?^\}$", "unmount_tree()")
+    assert 'mountpoint -q "$mp" 2>/dev/null || return 0' not in fn, (
+        "unmount_tree early-returns success when $mp is not itself a mount "
+        "point, leaving any mount beneath it live"
+    )
+    assert "anything_mounted_under" in body, (
+        "mount-lib no longer has a /proc/mounts check that can see sub-mounts"
+    )
+
+
+@pytest.mark.skipif(shutil.which("mount") is None, reason="no mount(8) available")
+@pytest.mark.skipif(
+    subprocess.run(["sh", "-c", "[ -r /proc/mounts ]"]).returncode != 0,
+    reason="no /proc/mounts (not Linux)",
+)
+def test_unmount_tree_clears_a_submount_under_a_plain_directory(tmp_path: Path) -> None:
+    """The behavioural half — needs real mounts, so it skips off Linux/CI-root.
+
+    Verified in a privileged container during the fix: the original left the
+    tmpfs mounted and returned 0; this clears it.
+    """
+    target = tmp_path / "work" / "mnt"
+    target.mkdir(parents=True)
+    mounted = subprocess.run(
+        ["mount", "-t", "tmpfs", "none", str(target)], capture_output=True, text=True
+    )
+    if mounted.returncode != 0:
+        pytest.skip(f"cannot mount here: {mounted.stderr.strip()}")
+    try:
+        script = f'. "{MOUNT_LIB}"\nunmount_tree "{tmp_path / "work"}"'
+        proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+        still = subprocess.run(
+            ["sh", "-c", f"grep -F ' {target} ' /proc/mounts"], capture_output=True
+        )
+        assert proc.returncode == 0, f"unmount_tree failed: {proc.stderr}"
+        assert still.returncode != 0, "the sub-mount is still live after a success return"
+    finally:
+        subprocess.run(["umount", "-l", "-R", str(target)], capture_output=True)


### PR DESCRIPTION
## Summary

**nightly-20260909 died at "Wrap as hybrid USB/CD ISO" on both architecture legs** — run [34350700498](https://github.com/spatiumddi/spatiumddi/actions/runs/34350700498), the first nightly to run the #1033 appliance matrix; #1039 is its tracking issue. The mkosi build had succeeded, and on both legs a valid ISO **had already been written and had passed the script's own boot-catalog verification** before the step went red. The 60,000-line log is one mechanism, in four parts:

1. **`umount "$MOUNT_DIR/sys" 2>/dev/null || true` refused, silently.** `wrap-iso.sh` bind-mounts the builder's `/proc`, `/sys` and `/dev` into the loop-mounted rootfs to chroot `update-initramfs`, then unmounts them one by one with errors discarded. After the chroot the bound `/sys` is *busy* — a plain, non-recursive `umount` returns EBUSY — it has picked up sub-mounts during the chroot (see the reproduction below: the recursive form clears it outright) — and `|| true` hid it.
2. **mksquashfs walked the builder's live `/sys` through the bind**: `Failed to read file …/mnt/sys/…, creating empty file` — 23,605 lines on amd64, 24,737 on arm64 — plus `Read failed because Input/output error` on the synthetic files. The squashfs finished, grub-mkrescue ran, `✓ boot catalog verified`, `✓ ISO: … 1.5G`.
3. **The exit trap then died on the same mount.** `umount "$MOUNT_DIR"` → `target is busy` (swallowed), `rm -rf "$WORKDIR"` recursed into the sysfs still bound underneath: `rm: cannot remove '…/mnt/sys/module/garp/sections/…': Operation not permitted` × 27,347 → exit 1, twenty minutes into the job.
4. **Quieter, and found only by reproducing it:** on its way to that sysfs the `rm -rf` had walked **into the read-write loop mount of the raw image and unlinked the appliance rootfs** — the sandbox found the raw's root partition gutted afterwards (`mount: …/mnt/proc: mount point does not exist` from the next script to touch it). Anything built from the raw after that point would have been built from an empty tree, silently.

Identical on amd64 (`ubuntu-latest`) and arm64 (`ubuntu-24.04-arm`). The 09-08 nightly unmounted cleanly with the same script; between the two nights both the builder image (rebuilt for #1033 at 00:13Z) and the rootfs's package set (#1027: mdadm, multipath-tools and their initramfs hooks) changed, and the replay reproduces it with today's both.

**And the next step was waiting behind it.** Replaying the job by hand on the sandbox — a fixed `wrap-iso.sh` and then `build-slot-image.sh` on the same raw — `build-slot-image.sh` regenerates the initrd the same way and unmounts with a bare `umount` under `set -e`: `umount: …/slot-mnt/sys: target is busy`, **exit 32**, at "Regenerating initrd inside slot…". So with the wrap script alone fixed, tonight's nightly would have failed one step later, on both legs. Its #553 exit trap already had the recursive half of the cure (`umount -R`, `rm -rf --one-file-system`) and its comment describes this exact failure; its chroot-window unmounts never got it, and `wrap-iso.sh` had none of it.

Also on 09-09, run [34346117553](https://github.com/spatiumddi/spatiumddi/actions/runs/34346117553) (the first twin, on `4e9a9a08`) failed earlier, at `looking-glass`'s scan gate: `google.golang.org/grpc v1.83.1 — CVE-2026-84445 (HIGH), fixed 1.83.2` — a real finding, correctly refused, already cleared by #1038's bump to 1.83.2 (the second run's looking-glass passed). Nothing to do there.

### What this PR does — `appliance/scripts/` only

- **`mount-lib.sh` (new, sourced by both scripts): one `unmount_tree()`** — `umount -R` (sub-mounts first), a lazy `umount -l -R` as the fallback for a mount something still holds open (the tree is gone from our namespace either way, which is all mksquashfs, rsync and rm need), and `findmnt` as the proof; a mount that survives both is a hard error. On failure it prints the sub-mounts *and the holding processes* — found via `/proc/*/{cwd,root,fd}`, since the builder ships no `fuser`/`lsof` — so the next time this happens the log says who.
- **`wrap-iso.sh`:** `unmount_tree` for the chroot binds, before the squashfs, and in the exit trap; the binds are made `rprivate`; the squashfs step **refuses to run** while any of `proc`/`sys`/`dev` is still a mount point or `proc`/`sys` are not the rootfs's own empty directories; cleanup refuses to `rm -rf` while anything is mounted under the work dir, removes with `--one-file-system` (#553), and preserves the script's exit status.
- **`build-slot-image.sh`:** the same `unmount_tree` for its chroot-window binds and the two top-level mounts, `rprivate` binds, a refusal to image the slot while a bind is still mounted, and the #553 trap now using `unmount_tree` too.

No change to what the ISO or slot image contains on a clean run. Nothing else in the appliance build is touched.

## Area

- [x] Deployment (Compose / K8s / Appliance) — `appliance/scripts/{mount-lib.sh,wrap-iso.sh,build-slot-image.sh}`

## Test plan

All on the private `spatiumddi-qa` sandbox with plain `run:` steps (that repo allows local actions only).

- [x] **The mechanism, deterministically**, inside `appliance-builder:latest`: bind `/sys` into a loop-mounted tree, park a process with its cwd inside the bind, then — plain `umount`: `target is busy`, rc 32 (the slot script's exact failure); `unmount_tree`: prints the surviving mount, `pid 13 (sleep) holds …/sys/fs`, `detaching lazily`, rc 0, `findmnt` shows nothing left under the tree.
- [x] **Runner probes** on `ubuntu-latest` *and* `ubuntu-24.04-arm` (run [34361057976](https://github.com/spatiumddi/spatiumddi-qa/actions/runs/34361057976)): the bind/unmount sequence in isolation is clean on both, with or without the fix — the busy `/sys` needs what the real chroot does, which is why the end-to-end replay below is the test that matters.
- [x] **End-to-end amd64 appliance build**, `build-appliance.yml`'s steps replayed by hand (stamp, k3s, charts, bake at `nightly-20260908`, mkosi) on the same runner class:
  - run [34366427148](https://github.com/spatiumddi/spatiumddi-qa/actions/runs/34366427148): the **original `wrap-iso.sh`** from `c5f18762` on the fresh raw — `rc=1`, `sysfs leak lines: 22226`, `rm errors: 25846`, `target is busy`, after `✓ boot catalog verified` and a 1.5 G ISO: nightly-20260909's failure, reproduced. The next script found the raw's rootfs gone (part 4 above).
  - run [34369346645](https://github.com/spatiumddi/spatiumddi-qa/actions/runs/34369346645): the **fixed `wrap-iso.sh`** on a fresh raw — `rc=0`, 0 leak lines, 0 rm errors, `✓ boot catalog verified`, 1.5 G ISO; then the **original `build-slot-image.sh`** on that raw — `umount: …/slot-mnt/sys: target is busy`, **exit 32** (the latent second failure).
  - run [34372506781](https://github.com/spatiumddi/spatiumddi-qa/actions/runs/34372506781): **this branch's three files** — fixed wrap: `rc=0`, `sysfs leak lines: 0`, `rm errors: 0`, `✓ boot catalog verified (BIOS=yes, bootx64.efi present)`, 1.5 G ISO — and **no lazy detach was needed**: `umount -R` cleared the binds outright, i.e. the busy `/sys` carries *sub-mounts* after the chroot, not a lingering process; fixed slot image: the slot image builds from that raw (→ Writing image-baseline /etc/fstab into slot… → Snapshotting /etc → /usr/lib/etc.image (overlay lower)… → Installing kernel 6.12.107+deb13-amd64 into slot's /boot/… → Regenerating initrd inside slot… → Fsck + trim unused blocks… → Compressing → /work/build/spatiumddi-appliance-slot-0.1.0.raw.xz (xz -6, threads=all)… → Writing SHA-256 → /work/build/spatiumddi-appliance-slot-0.1.0.sha256 ✓ Slot image: /work/build/spatiumddi-appliance-slot-0.1.0.raw.xz -rw-r--r-- 1 root root 1.5G Sep 9 16:21 /work/build/spatiumddi-appliance-slot-0.1.0.raw.xz ✓ Checksum: /work/build/spatiumddi-appliance-slot-0.1.0.sha256 1b31f9502bc50ba95358130ff5311eb246b784c9c4d84ec733fe13b1ecb7b1fa spatiumddi-appliance-slot-0.1.0.raw.xz -rw-r--r-- 1 root root 1.5G Sep 9 16:21 appliance/build/spatiumddi-appliance-slot-0.1.0.raw.xz -rw-r--r-- 1 root root 105 Sep 9 16:21 appliance/build/spatiumddi-appliance-slot-0.1.0.sha256); then the original wrap script run last on the same raw as the control: `rc=1`, `sysfs leak lines: 22235`, `rm errors: 25859`, after `✓ boot catalog verified` and a 1.5 G ISO — the nightly, reproduced a second time; and the raw's root partition inspected afterwards: **one entry, `sys`, 8.0K** — the appliance rootfs is gone (part 4 above).
- [x] `shellcheck` on all three (`-x`; the slot script as `sh`): no new findings beyond the pre-existing SC2034/SC3040 notes and the `local`-in-POSIX pedantry (`local` is a dash builtin and the slot script runs under dash in the builder).
- [ ] First real proof after merge: the next nightly — both appliance legs reach "Build slot-upgrade image" and "Upload appliance artifacts", and that evening's pre-release carries both architectures' ISO + slot image. Then #1039 can close.

Downstream: ddi-pg's nightly lane has had nothing to walk since nightly-2026.09.08.

## Related issues

Closes #1039. Refs #1033 (the arm64 matrix that exposed it), #553 (the same fix in `build-slot-image.sh`'s exit trap), #991.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
