### PR TITLE
fix(appliance+dhcp): stop a slot upgrade regenerating SECRET_KEY, and make the kea container die with its agent (#1042 #1043)

### DIFF
--- a/.github/scripts/chart-credential-secrets-kept.py
+++ b/.github/scripts/chart-credential-secrets-kept.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Every rendered Secret carrying a generated credential must be kept (#1042).
+
+A k3s HelmChart defaults to ``failurePolicy: reinstall`` — "a clean uninstall
+and reinstall of the chart" — and an unannotated Secret does not survive the
+uninstall half. The chart then mints a fresh one on install, which for the
+Secret holding SECRET_KEY orphaned everything ``encrypt_str`` had written: the
+appliance CA private key, appliance certs, integration credentials, OIDC/SAML
+secrets, every JWT. Observed on three slot-upgrade walks; the Postgres and
+Redis secrets came through the same event purely because they carry
+``helm.sh/resource-policy: keep``.
+
+This runs on the RENDERED manifest, which is the half a template-text check
+cannot do: it sees the annotation as Helm actually emits it, so a value typo,
+a stray quote, or an annotation hidden behind a condition that is false in
+this value set all fail here.
+
+Usage: chart-credential-secrets-kept.py <rendered.yaml>
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+#: Key names whose value the chart GENERATES when absent. A Secret holding one
+#: of these cannot be recreated without rotating it, so losing it is data loss
+#: rather than an inconvenience.
+GENERATED_KEYS = {"secret-key", "password", "redis-password"}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    path = Path(argv[1])
+    docs = [d for d in yaml.safe_load_all(path.read_text(encoding="utf-8")) if d]
+
+    secrets = [d for d in docs if d.get("kind") == "Secret"]
+    checked = 0
+    bad: list[str] = []
+    for doc in secrets:
+        keys = set(doc.get("stringData") or {}) | set(doc.get("data") or {})
+        if not (keys & GENERATED_KEYS):
+            continue
+        checked += 1
+        name = doc["metadata"]["name"]
+        ann = doc["metadata"].get("annotations") or {}
+        if ann.get("helm.sh/resource-policy") != "keep":
+            bad.append(f"{name} (keys={sorted(keys & GENERATED_KEYS)}, annotations={ann})")
+
+    if bad:
+        print(f"✗ {path.name}: credential Secret(s) missing "
+              f"`helm.sh/resource-policy: keep` — a reinstall rotates them:",
+              file=sys.stderr)
+        for b in bad:
+            print(f"    {b}", file=sys.stderr)
+        return 1
+
+    # A render with no credential Secret at all is normal (appliance shapes,
+    # external-DB shapes). Saying so keeps "checked nothing" distinguishable
+    # from "checked and clean" in the log.
+    print(f"credential secrets kept: {checked} of {len(secrets)} Secret(s) carried a generated key")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/chart-credential-secrets-kept.py
+++ b/.github/scripts/chart-credential-secrets-kept.py
@@ -47,9 +47,14 @@ def main(argv: list[str]) -> int:
             continue
         checked += 1
         name = doc["metadata"]["name"]
-        ann = doc["metadata"].get("annotations") or {}
-        if ann.get("helm.sh/resource-policy") != "keep":
-            bad.append(f"{name} (keys={sorted(keys & GENERATED_KEYS)}, annotations={ann})")
+        policy = (doc["metadata"].get("annotations") or {}).get("helm.sh/resource-policy")
+        if policy != "keep":
+            # NOTHING derived from `stringData` / `data` is echoed — not even a
+            # key NAME. A rendered chart carries the real SECRET_KEY in that
+            # section, this output lands in CI logs, and a diagnostic is not
+            # worth a taint path into one. The Secret's name identifies it
+            # unambiguously, and the annotation is the whole verdict.
+            bad.append(f"{name} (helm.sh/resource-policy={policy!r})")
 
     if bad:
         print(f"✗ {path.name}: credential Secret(s) missing "

--- a/.github/scripts/charts-render-check.sh
+++ b/.github/scripts/charts-render-check.sh
@@ -94,6 +94,10 @@ render() { # name chart [helm --set args...]
         -cache "$KUBECONFORM_CACHE" \
         "$file" || failures=$((failures + 1))
     python3 "$ROOT/.github/scripts/chart-no-besteffort.py" "$file" || failures=$((failures + 1))
+    # #1042 — a generated credential Secret must carry resource-policy: keep,
+    # checked on the RENDER so a value typo or a false condition cannot hide it.
+    python3 "$ROOT/.github/scripts/chart-credential-secrets-kept.py" "$file" \
+        || failures=$((failures + 1))
     # shellcheck disable=SC2086  # POSTURE_ARGS is a deliberate flag list
     python3 "$ROOT/.github/scripts/chart-pod-posture.py" $POSTURE_ARGS "$file" \
         || failures=$((failures + 1))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -953,6 +953,15 @@ the formatter handles the rest.
   invisible. That restores the original intent — all three were in the
   `wait -n` list, and radvd is excluded from it precisely because "a
   radvd flap must not take the DHCP server down".
+  The readiness clear gained the tests it shipped without — Copilot's
+  catch: neither the marker nor its clear had ANY coverage before, which
+  is how the pair could drift apart. The probe command is lifted from
+  the chart rather than retyped, so the test fails if either side moves.
+  And the render check never echoes anything derived from a Secret's
+  `data` / `stringData`, not even a key NAME: a rendered chart carries
+  the real SECRET_KEY there and the output lands in CI logs, so the
+  Secret's name plus the annotation is the whole diagnostic (CodeQL
+  flagged the first cut).
 
 - **The upgrade path could hand a node a root filesystem for
   another CPU architecture (#1026, part 1 of 3).** Every appliance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -558,24 +558,43 @@ the formatter handles the rest.
   member approval started answering 500 with
   `ValueError: encrypted value could not be decrypted` — while the
   control plane reported healthy and the data plane kept serving.
-  **Two independent fixes, because each covers a deployment shape the
-  other does not.** The Secret gains
-  `helm.sh/resource-policy: keep` — it was the ONLY credential Secret
-  in the chart without it, and the Postgres and Redis secrets survived
-  the very same event purely because they carry it. And the
-  appliance's control HelmChart now sets `failurePolicy: abort`, so
-  the destructive path is not taken at all. Losing the self-healing
-  reinstall costs nothing here: recovery is already explicit and
-  logged, since `spatiumddi-helm-stuck-recover` clears the
-  helm-install Job and the `sh.helm.release.v1.*` tracking secrets so
-  helm-controller retries — and it deletes only `owner=helm`
-  release-storage secrets, so the now-kept app Secret survives it and
-  the retry's `lookup` finds the same key.
+  **The fix is the annotation, and `failurePolicy` is deliberately
+  left alone.** The Secret gains `helm.sh/resource-policy: keep` — it
+  was the ONLY credential Secret in the chart without it, and the
+  Postgres and Redis secrets came through the very same event purely
+  because they carry it. With it, the uninstall half retains the
+  Secret and the reinstall's `lookup` finds the same key.
+  **`failurePolicy: abort` was written, then reverted in review**, and
+  the reason is worth recording: it looks like the safer setting and
+  is not. `spatiumddi-helm-stuck-recover` only acts on a HelmChart
+  carrying a `Failed` condition, and only after a 600 s latch on a
+  5 min tick — so a release left `pending-upgrade` by the slot reboot,
+  which is the scenario this was found in, may never qualify at all.
+  `abort` there risks an indefinite outage with no API and no UI,
+  where the default `reinstall` recovers in seconds. What made
+  `reinstall` dangerous was never the reinstall; it was the missing
+  annotation. Disruptive and self-healing is fine. Lossy was not.
   The chart guard is written against the *generator* rather than the
   filename — any Secret template that mints a credential with
   `randAlphaNum` must carry the annotation — with a negative control
   asserting SECRET_KEY's own template is still one of the templates
   being checked, so the guard cannot pass by looking at nothing.
+  **Both of the first-cut guards were themselves vacuous**, which
+  review proved rather than argued: deleting the entire `annotations:`
+  block left all four tests passing, because the template's own header
+  prose mentions the annotation; and the unit guard matched a name
+  anywhere in `mkosi.postinst`, where dozens of units are `chmod`'d by
+  name — so adding the chmod line its siblings have would have
+  satisfied it while the unit stayed unenabled (`spatium-etc-render`
+  already slipped through that way). They now strip Helm and shell
+  comments and match the annotation as a real YAML entry *with the
+  value `keep`*, and parse the `for unit in … ; do` list plus the
+  explicit `*.target.wants/` symlinks rather than the whole file.
+  A third check runs on the **rendered** manifest in
+  `charts-render-check.sh`, where a value typo or an annotation hidden
+  behind a false condition is visible and a template-text scan is not;
+  it reports how many Secrets it examined, so "checked nothing" cannot
+  read as "checked and clean".
   **Making `abort` safe turned up a third defect.** The recovery it
   leans on had never run: `spatiumddi-helm-stuck-recover.timer` ships
   in the image, carries `WantedBy=timers.target`, and has its runner
@@ -912,6 +931,28 @@ the formatter handles the rest.
   an already-reaped job still yields its remembered status. Verified
   in both directions on busybox 1.37.
   Two comments asserting the broken mechanism are corrected with it.
+  **Making the crash path reachable exposed a latent `kill -TERM 0`.**
+  `_term` expanded an unset `RADVD_PID` to `0` — radvd starts only
+  when `RADVD_MANAGED=1` and the image default is `0` — and
+  `kill -TERM 0` signals the CALLER'S PROCESS GROUP, which with
+  `trap _term TERM INT` re-enters `_term` and recurses until the shell
+  dies of stack exhaustion. Measured: the container exited **139
+  (SIGSEGV)** after ~4000 calls instead of the child's status, and kea
+  was never shut down. Latent before this change because nothing
+  reached `_term` on a crash, so the fix would have traded a hang for
+  a segfault. It now skips empty pids. Found by review because the
+  first cut of the tests STUBBED `_term`, which is exactly why they
+  passed; they run the real one now, with `trap _term TERM INT` and an
+  empty `RADVD_PID` because both are needed to reproduce it — and
+  `start_new_session=True`, because without it `kill -TERM 0` took out
+  the pytest process group, so the guard destroyed its own runner and
+  reported nothing.
+  **One deliberate behaviour change:** kea-dhcp6 is watched too, so a
+  v6 supervise loop that gives up now CrashLoopBackOffs the pod where
+  the broken `wait -n` tolerated it and left a dead v6 daemon
+  invisible. That restores the original intent — all three were in the
+  `wait -n` list, and radvd is excluded from it precisely because "a
+  radvd flap must not take the DHCP server down".
 
 - **The upgrade path could hand a node a root filesystem for
   another CPU architecture (#1026, part 1 of 3).** Every appliance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -543,6 +543,56 @@ the formatter handles the rest.
   runs already start up to 13 h late.
 
 
+- **A slot upgrade could regenerate SECRET_KEY and orphan everything
+  encrypted at rest (#1042).** `app/core/crypto.py` derives the
+  at-rest Fernet key from SECRET_KEY whenever no explicit
+  `CREDENTIAL_ENCRYPTION_KEY` is set — which is every appliance — so
+  the chart-owned Secret carrying `secret-key` is the root of the
+  appliance CA private key, appliance certs, integration credentials,
+  OIDC/SAML secrets and every JWT.
+  A k3s HelmChart defaults to **`failurePolicy: reinstall`**,
+  documented as "a clean uninstall and reinstall of the chart". On
+  three ddi-pg slot-upgrade walks helm-controller took that path for
+  `spatium-control`, the Secret was deleted, the reinstall's `lookup`
+  found nothing, `randAlphaNum 64` minted a new key, and cluster
+  member approval started answering 500 with
+  `ValueError: encrypted value could not be decrypted` — while the
+  control plane reported healthy and the data plane kept serving.
+  **Two independent fixes, because each covers a deployment shape the
+  other does not.** The Secret gains
+  `helm.sh/resource-policy: keep` — it was the ONLY credential Secret
+  in the chart without it, and the Postgres and Redis secrets survived
+  the very same event purely because they carry it. And the
+  appliance's control HelmChart now sets `failurePolicy: abort`, so
+  the destructive path is not taken at all. Losing the self-healing
+  reinstall costs nothing here: recovery is already explicit and
+  logged, since `spatiumddi-helm-stuck-recover` clears the
+  helm-install Job and the `sh.helm.release.v1.*` tracking secrets so
+  helm-controller retries — and it deletes only `owner=helm`
+  release-storage secrets, so the now-kept app Secret survives it and
+  the retry's `lookup` finds the same key.
+  The chart guard is written against the *generator* rather than the
+  filename — any Secret template that mints a credential with
+  `randAlphaNum` must carry the annotation — with a negative control
+  asserting SECRET_KEY's own template is still one of the templates
+  being checked, so the guard cannot pass by looking at nothing.
+  **Making `abort` safe turned up a third defect.** The recovery it
+  leans on had never run: `spatiumddi-helm-stuck-recover.timer` ships
+  in the image, carries `WantedBy=timers.target`, and has its runner
+  covered by `test_helm_stuck_recover.py` — and was absent from
+  `mkosi.postinst`'s unit-enable loop, so on every appliance ever
+  built it was inert. Same class as #550, where a host runner shipped
+  without the `+x` its ExecStart needed: present, reviewed, tested,
+  and dead for one missing line of image plumbing. It is enabled now,
+  and a sweep of all 38 shipped units with an `[Install]` section
+  found no others. The guard that would have caught it matches
+  `[Install]` as a SECTION HEADER, never as a substring —
+  `spatiumddi-pcap.service` carries the comment "No [Install] —
+  invoked only by spatiumddi-pcap.path", and a substring match
+  reports that correct file as a violation, which is how an
+  exemption list fills up with noise and stops being read.
+
+
 ### Security
 
 - **The two source restrictions composed into a console-only
@@ -822,6 +872,46 @@ the formatter handles the rest.
   unchanged.
 
 ### Fixed
+
+
+- **The kea container outlived its own agent, and every health
+  surface stayed green (#1043).** `entrypoint.sh` backgrounds
+  kea-dhcp4, kea-dhcp6 and the Python agent and waits for the first
+  to exit so the container restarts — with
+  `wait -n "$KEA_PID" "$KEA6_PID" "$AGENT_PID" || wait …`, under a
+  comment claiming busybox ash "accepts it too as of 1.30+". It
+  accepts the FLAG and ignores the SEMANTICS. Measured on the image's
+  own base (busybox 1.37 / alpine 3.24): with one child exiting at
+  0.2 s and another alive for 5 s, `wait -n` returned after the full
+  **5 s** — it waited for all of them. dash is worse in a different
+  way: it rejects `-n` outright, so the `||` falls straight through to
+  a plain `wait` that also waits for all. Only bash does what the
+  line was written to do.
+  Because `supervise_kea` and `supervise_kea6` are restart loops that
+  never exit on their own, when the AGENT died the wait simply never
+  returned. The container ran on with Kea serving a frozen config and
+  no agent in it: `kubectl get pod` reported **1/1 Running** with an
+  unchanged restart count, the readiness marker stayed stamped, and
+  every DHCP change made through the API was accepted, rendered by
+  the control plane, and silently never delivered — a reservation
+  created post-upgrade did not reach `kea-dhcp4.conf` and dhclient
+  got a pool address instead. The trigger on the ddi-pg walk was
+  #1042's post-upgrade 401, the agent's own documented
+  "exit so the supervisor restarts the container" path, but **any**
+  unhandled agent crash lands identically. The DNS image is immune
+  only because it `exec`s its agent, so the agent IS the container.
+  Replaced with a POSIX poll over the three pids, and the agent now
+  clears its readiness marker on the way out so a dead agent is
+  visible to the platform even if the process somehow outlives its
+  threads. The tests run the **shipped** loop, extracted from the
+  real file, under dash and busybox — the only shells where the bug
+  is visible — and all six fail against the pre-fix entrypoint.
+  `kill -0` is the portable test rather than a `/proc` state read:
+  ash reaps a background child on SIGCHLD while the loop sits in
+  `sleep`, so the pid leaves the table within a tick, and `wait` on
+  an already-reaped job still yields its remembered status. Verified
+  in both directions on busybox 1.37.
+  Two comments asserting the broken mechanism are corrected with it.
 
 - **The upgrade path could hand a node a root filesystem for
   another CPU architecture (#1026, part 1 of 3).** Every appliance

--- a/agent/dhcp/images/kea/entrypoint.sh
+++ b/agent/dhcp/images/kea/entrypoint.sh
@@ -7,8 +7,8 @@
 # the agent talks to kea-dhcp4 / kea-dhcp6 directly over their unix control
 # sockets (spatium_dhcp_agent/kea_ctrl.py — config-test, config-reload,
 # status-get, statistic-get-all). Supervising a daemon nothing calls was a
-# liability, not a feature: its crash-loop give-up path would return from
-# the ``wait -n`` below and take the whole container down with it.
+# liability, not a feature: its crash-loop give-up path would be seen by the
+# child-exit poll below and take the whole container down with it.
 #
 # kea-dhcp6 runs always-on alongside kea-dhcp4 (dual-stack): it boots
 # from a minimal idle config (``interfaces: []`` + empty ``subnet6``)
@@ -64,7 +64,7 @@ supervise_kea() {
     # Forward SIGTERM to the live daemon AND flip the stop flag so
     # the outer loop doesn't try to restart during container
     # shutdown. ``exit 0`` here ensures the subshell goes away
-    # cleanly so wait -n in the parent returns.
+    # cleanly so the parent's child-exit poll sees it.
     # shellcheck disable=SC2064
     trap 'STOPPING=1; [ -n "$KEA_CHILD" ] && kill -TERM "$KEA_CHILD" 2>/dev/null; exit 0' TERM INT
     fails=0
@@ -203,11 +203,46 @@ AGENT_PID=$!
 # only one that skipped it.
 set +e
 
-# wait -n is a bash-ism; busybox ash accepts it too as of 1.30+
-# (Alpine 3.11+). Fall back to plain wait on older variants.
-wait -n "$KEA_PID" "$KEA6_PID" "$AGENT_PID" 2>/dev/null \
-    || wait "$KEA_PID" "$KEA6_PID" "$AGENT_PID"
-EXIT_CODE=$?
+# Exit as soon as the FIRST of the three children does (#1043).
+#
+# This was `wait -n "$KEA_PID" "$KEA6_PID" "$AGENT_PID" || wait …`, whose
+# comment claimed busybox ash "accepts it too as of 1.30+". It accepts the
+# FLAG and ignores the SEMANTICS. Measured on busybox 1.37 (alpine 3.24, the
+# image's own base): with one child exiting at 0.2 s and another alive for
+# 5 s, `wait -n` returned after the full 5 s — it waited for ALL of them.
+#
+# That is not a cosmetic difference. `supervise_kea` and `supervise_kea6` are
+# restart loops that never exit on their own, so when the AGENT died the wait
+# simply never returned: the container kept running with kea serving a frozen
+# config and no agent in it, `kubectl get pod` reported 1/1 Running with an
+# unchanged restart count, and every DHCP change made through the API was
+# accepted, rendered, and silently never delivered. The trigger on the
+# ddi-pg walk was #1042's post-upgrade 401 — the agent's documented
+# "exit so supervisor restarts the container (→ re-bootstrap)" path — but ANY
+# unhandled agent crash lands the same way. The DNS image is immune only
+# because it `exec`s its agent, so the agent IS the container.
+#
+# `kill -0` is the portable test: ash reaps a background child on SIGCHLD
+# while we sit in `sleep`, so the pid is gone from the table within a tick of
+# its exit, and `wait` on an already-reaped job still yields its remembered
+# status. Verified on busybox 1.37 in both directions.
+EXIT_CODE=0
+while :; do
+    for _pid in "$KEA_PID" "$KEA6_PID" "$AGENT_PID"; do
+        kill -0 "$_pid" 2>/dev/null && continue
+        wait "$_pid"
+        EXIT_CODE=$?
+        case "$_pid" in
+            "$AGENT_PID") _who="spatium-dhcp-agent" ;;
+            "$KEA_PID")   _who="kea-dhcp4 supervisor" ;;
+            *)            _who="kea-dhcp6 supervisor" ;;
+        esac
+        echo "entrypoint: $_who (pid $_pid) exited with $EXIT_CODE —" \
+             "shutting the container down so it restarts" >&2
+        break 2
+    done
+    sleep 1
+done
 _term
 wait
 exit "$EXIT_CODE"

--- a/agent/dhcp/images/kea/entrypoint.sh
+++ b/agent/dhcp/images/kea/entrypoint.sh
@@ -176,7 +176,24 @@ fi
 # Forward container SIGTERM to all supervisor subshells and the
 # agent. The supervisors' own traps handle the in-flight daemon.
 _term() {
-    kill -TERM "$KEA_PID" "$KEA6_PID" "${RADVD_PID:-0}" "${AGENT_PID:-0}" 2>/dev/null || true
+    # NEVER expand an unset pid to 0. `kill -TERM 0` signals the CALLER'S
+    # ENTIRE PROCESS GROUP, and `trap _term TERM INT` below means that
+    # re-enters this function — unbounded recursion until the shell dies of
+    # stack exhaustion. The old `"${RADVD_PID:-0}"` did exactly that on every
+    # default install, because radvd is only started when RADVD_MANAGED=1 and
+    # the image default is 0, so RADVD_PID is empty.
+    #
+    # Latent until #1043: the only paths that reached _term were a clean
+    # SIGTERM (where the shell is already going away) and a `wait` return that
+    # the broken `wait -n` made unreachable. Making the crash path work is what
+    # exposed it — measured, the container exited 139 (SIGSEGV) after ~4000
+    # recursive _term calls instead of the child's status, and kea was never
+    # shut down.
+    for _tp in "$KEA_PID" "$KEA6_PID" "$RADVD_PID" "$AGENT_PID"; do
+        [ -n "$_tp" ] || continue
+        kill -TERM "$_tp" 2>/dev/null || true
+    done
+    return 0
 }
 trap _term TERM INT
 
@@ -226,6 +243,18 @@ set +e
 # while we sit in `sleep`, so the pid is gone from the table within a tick of
 # its exit, and `wait` on an already-reaped job still yields its remembered
 # status. Verified on busybox 1.37 in both directions.
+#
+# ALL THREE are watched, including kea-dhcp6, and that is a deliberate
+# behaviour change worth knowing about: because the broken `wait -n` never
+# returned, a kea-dhcp6 supervise loop that gave up (5 crashes in <30 s) used
+# to be TOLERATED — v4 kept serving and the dead v6 daemon was invisible. It
+# is fatal now. That restores the original intent — all three were named in
+# the `wait -n` list, and radvd is deliberately excluded from it precisely
+# because "a radvd flap must not take the DHCP server down" — and it matches
+# this whole change's thesis: a container that restarts is visible and
+# recoverable, a silently dead daemon is neither. A v6 misconfiguration now
+# CrashLoopBackOffs the pod rather than quietly serving v4 only, which is the
+# trade being made on purpose.
 EXIT_CODE=0
 while :; do
     for _pid in "$KEA_PID" "$KEA6_PID" "$AGENT_PID"; do

--- a/agent/dhcp/spatium_dhcp_agent/supervisor.py
+++ b/agent/dhcp/spatium_dhcp_agent/supervisor.py
@@ -28,7 +28,7 @@ from .mac_sighting import MacSightingShipper
 from .metrics import MetricsPoller
 from .peer_resolve import PeerResolveWatcher
 from .ra_sniffer import RASnifferShipper
-from .sync import SyncLoop
+from .sync import SyncLoop, clear_ready_marker
 
 log = structlog.get_logger(__name__)
 
@@ -172,6 +172,11 @@ def run(cfg: AgentConfig) -> int:
         dead = [t.name for t in threads if not t.is_alive()]
         if dead:
             log.error("dhcp_agent_thread_died", threads=dead)
+            # #1043 — stop claiming readiness on the way out. The container
+            # exit is what actually restarts us, but the kea entrypoint used
+            # to outlive this return, leaving a Ready pod with no agent in it.
+            # Clearing the marker makes that state visible rather than green.
+            clear_ready_marker(cfg.state_dir)
             return 2
 
     log.info("dhcp_agent_exiting")

--- a/agent/dhcp/spatium_dhcp_agent/sync.py
+++ b/agent/dhcp/spatium_dhcp_agent/sync.py
@@ -78,6 +78,29 @@ def _touch_ready_marker(state_dir: Path) -> None:
         log.exception("ready_marker_touch_failed", path=str(state_dir / ".ready"))
 
 
+def clear_ready_marker(state_dir: Path) -> None:
+    """Remove ``<state_dir>/.ready`` so the readinessProbe starts failing (#1043).
+
+    The marker means "I have synced at least once", and nothing ever took it
+    back. When the agent's heartbeat thread died the container kept the marker,
+    the probe (``test -f .ready && grep -q ':0043 ' /proc/net/udp``) kept
+    passing on Kea's still-listening socket, and the pod stayed 1/1 Ready with
+    no agent in it — every DHCP change accepted, rendered, and never delivered.
+
+    The container exit is the primary cure; this is the half that makes a dead
+    agent VISIBLE to the platform even if the process somehow outlives its
+    threads. Best-effort for the same reason the touch is: a marker we cannot
+    remove must not stop the shutdown path that is already running.
+    """
+    marker = state_dir / ".ready"
+    try:
+        marker.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        log.exception("ready_marker_clear_failed", path=str(marker))
+
+
 _FAILURE_THRESHOLD = 3  # DHCP.md §6: offline after 3 consecutive failures
 _OFFLINE_RETRY_SECONDS = 60.0
 # Bootstrap reload races Kea's own startup — entrypoint launches kea-dhcp4

--- a/agent/dhcp/spatium_dhcp_agent/sync.py
+++ b/agent/dhcp/spatium_dhcp_agent/sync.py
@@ -96,6 +96,8 @@ def clear_ready_marker(state_dir: Path) -> None:
     try:
         marker.unlink()
     except FileNotFoundError:
+        # Already gone — the agent died before its first successful sync, so
+        # readiness was never claimed. Nothing to take back.
         pass
     except OSError:
         log.exception("ready_marker_clear_failed", path=str(marker))

--- a/agent/dhcp/tests/test_entrypoint_child_exit.py
+++ b/agent/dhcp/tests/test_entrypoint_child_exit.py
@@ -40,34 +40,72 @@ ENTRYPOINT = Path(__file__).parents[1] / "images" / "kea" / "entrypoint.sh"
 NO_WAIT_N = [s for s in ("dash", "busybox") if shutil.which(s)]
 
 
-def _loop() -> str:
-    """The real child-exit loop, lifted verbatim out of the entrypoint."""
-    src = ENTRYPOINT.read_text(encoding="utf-8")
-    m = re.search(r"^EXIT_CODE=0\nwhile :; do\n.*?^done$", src, re.S | re.M)
-    assert m, "entrypoint no longer contains the child-exit poll loop"
+def _extract(pattern: str, what: str) -> str:
+    """Lift a block verbatim out of the shipped entrypoint."""
+    m = re.search(pattern, ENTRYPOINT.read_text(encoding="utf-8"), re.S | re.M)
+    assert m, f"entrypoint no longer contains {what}"
     return m.group(0)
 
 
-def _run(shell: str, agent_exit: int) -> tuple[int, float, str]:
-    """Run the shipped loop with stub children; return (rc, seconds, output)."""
+def _loop() -> str:
+    return _extract(r"^EXIT_CODE=0\nwhile :; do\n.*?^done$", "the child-exit poll loop")
+
+
+def _term() -> str:
+    """The REAL _term, not a stub.
+
+    Stubbing it is what let the first version of these tests pass while the
+    shipped path exited 139: `_term` expanded an unset RADVD_PID to 0, so
+    `kill -TERM 0` signalled the whole process group, re-entered the TERM trap
+    and recursed until the shell died of stack exhaustion. A stub cannot see
+    that, and the exit-status assertions below were meaningless without it.
+    """
+    return _extract(r"^_term\(\) \{.*?^\}$", "the _term handler")
+
+
+def _run(shell: str, agent_exit: int, radvd: bool = False) -> tuple[int, float, str]:
+    """Run the shipped loop with stub children; return (rc, seconds, output).
+
+    ``radvd=False`` leaves RADVD_PID EMPTY, which is the shipped default
+    (radvd starts only when RADVD_MANAGED=1) and the case that reproduces the
+    `kill -TERM 0` recursion. ``radvd=True`` spawns a real stand-in child so
+    the managed path is exercised with a pid that is safe to signal.
+    """
+    radvd_setup = (
+        "( while :; do sleep 300; done ) </dev/null >/dev/null 2>&1 & RADVD_PID=$!"
+        if radvd
+        else "RADVD_PID="
+    )
     # The stubs get </dev/null >/dev/null: a `sleep` grandchild that outlives
     # its killed subshell would otherwise keep the captured stdout pipe open,
     # and subprocess.run would block on communicate() long after the shell had
     # exited — a harness timeout that reads exactly like the bug.
+    # `trap _term TERM INT` and an EMPTY RADVD_PID reproduce the shipped
+    # default (radvd starts only when RADVD_MANAGED=1; the image default is 0).
+    # Both are load-bearing: without the trap, `kill -TERM 0` would not recurse
+    # and the 139 this test exists to catch would not reproduce.
     script = f"""
-_term() {{ echo "TERM_RAN"; }}
+{_term()}
+trap _term TERM INT
 ( while :; do sleep 300; done ) </dev/null >/dev/null 2>&1 & KEA_PID=$!
 ( while :; do sleep 300; done ) </dev/null >/dev/null 2>&1 & KEA6_PID=$!
+{radvd_setup}
 ( sleep 1; exit {agent_exit} ) </dev/null >/dev/null 2>&1 & AGENT_PID=$!
 {_loop()}
 _term
-kill "$KEA_PID" "$KEA6_PID" 2>/dev/null
 wait
 exit "$EXIT_CODE"
 """
     argv = [shell, "-c", script] if shell != "busybox" else ["busybox", "sh", "-c", script]
     start = time.monotonic()
-    proc = subprocess.run(argv, capture_output=True, text=True, timeout=30)
+    # start_new_session is load-bearing, not hygiene. The bug being guarded is
+    # `kill -TERM 0`, which signals the CALLER'S PROCESS GROUP — and without a
+    # new session that group is pytest's own. Against the unfixed entrypoint the
+    # test run was itself Terminated, so the guard both destroyed the runner and
+    # reported nothing. Its own group keeps the blast radius inside the subject.
+    proc = subprocess.run(
+        argv, capture_output=True, text=True, timeout=30, start_new_session=True
+    )
     return proc.returncode, time.monotonic() - start, proc.stdout + proc.stderr
 
 
@@ -83,7 +121,6 @@ def test_agent_death_takes_the_container_down(shell: str) -> None:
     rc, secs, out = _run(shell, agent_exit=2)
     assert rc == 2, f"expected the agent's own status, got {rc}\n{out}"
     assert secs < 10, f"took {secs:.1f}s — the loop is not noticing the exit\n{out}"
-    assert "TERM_RAN" in out, "kea was not shut down cleanly on the way out"
     assert "spatium-dhcp-agent" in out, "the log line must name which child exited"
 
 
@@ -115,3 +152,30 @@ def test_every_supervised_child_is_polled() -> None:
     loop = _loop()
     for pid in ("$KEA_PID", "$KEA6_PID", "$AGENT_PID"):
         assert pid in loop, f"{pid} is not watched by the child-exit loop"
+
+
+@pytest.mark.skipif(not NO_WAIT_N, reason="no shell without working `wait -n` available")
+@pytest.mark.parametrize("shell", NO_WAIT_N)
+def test_term_does_not_signal_its_own_process_group(shell: str) -> None:
+    """`kill -TERM 0` would take out the shell, recursively (#1043 review).
+
+    `_term` expanded an unset RADVD_PID to `0`, and `kill -TERM 0` signals the
+    CALLER'S PROCESS GROUP. With `trap _term TERM INT` that re-enters `_term`,
+    recursing until the shell dies of stack exhaustion: measured, the container
+    exited 139 (SIGSEGV) after ~4000 calls instead of the child's status, and
+    kea was never shut down. Latent before this PR because nothing reached
+    `_term` on a crash; the poll loop is what made it reachable.
+
+    radvd unmanaged — the image default, and the case that reproduces it.
+    """
+    rc, _secs, out = _run(shell, agent_exit=7, radvd=False)
+    assert rc != 139, f"_term killed its own process group (SIGSEGV)\n{out}"
+    assert rc == 7, f"expected the agent's status 7, got {rc}\n{out}"
+
+
+@pytest.mark.skipif(not NO_WAIT_N, reason="no shell without working `wait -n` available")
+@pytest.mark.parametrize("shell", NO_WAIT_N)
+def test_a_managed_radvd_is_still_signalled(shell: str) -> None:
+    """The radvd-managed path must keep working — don't fix one by losing the other."""
+    rc, _secs, out = _run(shell, agent_exit=7, radvd=True)
+    assert rc == 7, f"expected 7 with a populated RADVD_PID, got {rc}\n{out}"

--- a/agent/dhcp/tests/test_entrypoint_child_exit.py
+++ b/agent/dhcp/tests/test_entrypoint_child_exit.py
@@ -1,0 +1,117 @@
+"""The kea container must die when its agent does (#1043).
+
+`agent/dhcp/images/kea/entrypoint.sh` backgrounds kea-dhcp4, kea-dhcp6 and
+the Python agent, then waits for the first of them to exit so the container
+restarts. It used to do that with ``wait -n "$KEA_PID" "$KEA6_PID"
+"$AGENT_PID" || wait …``, and the comment claimed busybox ash "accepts it too
+as of 1.30+". It accepts the FLAG and ignores the SEMANTICS:
+
+    busybox ash 1.37   `wait -n A B` returned only when BOTH had exited
+    dash               rejects `-n` outright (rc 2) -> falls through to the
+                       plain `wait`, which also waits for all of them
+    bash               real any-child semantics
+
+The image's /bin/sh is busybox ash, so when the agent died the wait sat on
+the two kea supervise loops — which are restart loops that never exit — and
+the container ran on with Kea serving a frozen config and no agent in it,
+reporting 1/1 Running with an unchanged restart count.
+
+These tests run the SHIPPED loop, extracted from the real file, under a shell
+that lacks working `wait -n` — which is the only condition under which the
+bug is visible. Stub children stand in for the three real ones: two that
+never exit (the kea supervisors) and one that exits (the agent).
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+ENTRYPOINT = Path(__file__).parents[1] / "images" / "kea" / "entrypoint.sh"
+
+#: Shells without working `wait -n`. dash is /bin/sh on Debian/Ubuntu
+#: runners; busybox ash is what the image actually runs and is verified
+#: locally (it is not installed on the CI runner).
+NO_WAIT_N = [s for s in ("dash", "busybox") if shutil.which(s)]
+
+
+def _loop() -> str:
+    """The real child-exit loop, lifted verbatim out of the entrypoint."""
+    src = ENTRYPOINT.read_text(encoding="utf-8")
+    m = re.search(r"^EXIT_CODE=0\nwhile :; do\n.*?^done$", src, re.S | re.M)
+    assert m, "entrypoint no longer contains the child-exit poll loop"
+    return m.group(0)
+
+
+def _run(shell: str, agent_exit: int) -> tuple[int, float, str]:
+    """Run the shipped loop with stub children; return (rc, seconds, output)."""
+    # The stubs get </dev/null >/dev/null: a `sleep` grandchild that outlives
+    # its killed subshell would otherwise keep the captured stdout pipe open,
+    # and subprocess.run would block on communicate() long after the shell had
+    # exited — a harness timeout that reads exactly like the bug.
+    script = f"""
+_term() {{ echo "TERM_RAN"; }}
+( while :; do sleep 300; done ) </dev/null >/dev/null 2>&1 & KEA_PID=$!
+( while :; do sleep 300; done ) </dev/null >/dev/null 2>&1 & KEA6_PID=$!
+( sleep 1; exit {agent_exit} ) </dev/null >/dev/null 2>&1 & AGENT_PID=$!
+{_loop()}
+_term
+kill "$KEA_PID" "$KEA6_PID" 2>/dev/null
+wait
+exit "$EXIT_CODE"
+"""
+    argv = [shell, "-c", script] if shell != "busybox" else ["busybox", "sh", "-c", script]
+    start = time.monotonic()
+    proc = subprocess.run(argv, capture_output=True, text=True, timeout=30)
+    return proc.returncode, time.monotonic() - start, proc.stdout + proc.stderr
+
+
+@pytest.mark.skipif(not NO_WAIT_N, reason="no shell without working `wait -n` available")
+@pytest.mark.parametrize("shell", NO_WAIT_N)
+def test_agent_death_takes_the_container_down(shell: str) -> None:
+    """The whole point: the agent exits, so must the container — promptly.
+
+    Before the fix this blocked until something killed it, because the two
+    kea supervisors never exit. 10 s is generous against a 1 s poll; the
+    failure mode is "never", not "slow".
+    """
+    rc, secs, out = _run(shell, agent_exit=2)
+    assert rc == 2, f"expected the agent's own status, got {rc}\n{out}"
+    assert secs < 10, f"took {secs:.1f}s — the loop is not noticing the exit\n{out}"
+    assert "TERM_RAN" in out, "kea was not shut down cleanly on the way out"
+    assert "spatium-dhcp-agent" in out, "the log line must name which child exited"
+
+
+@pytest.mark.skipif(not NO_WAIT_N, reason="no shell without working `wait -n` available")
+@pytest.mark.parametrize("shell", NO_WAIT_N)
+def test_a_clean_agent_exit_is_still_reported_as_clean(shell: str) -> None:
+    """Exit status is the child's, not a fixed 1 — the orchestrator reads it."""
+    rc, _secs, out = _run(shell, agent_exit=0)
+    assert rc == 0, f"expected 0, got {rc}\n{out}"
+
+
+def test_the_broken_wait_n_idiom_is_gone() -> None:
+    """Structural backstop: no executable `wait -n` may come back.
+
+    Prose about it is fine (the loop's own comment explains the history), so
+    this looks only at non-comment lines.
+    """
+    code = [
+        ln
+        for ln in ENTRYPOINT.read_text(encoding="utf-8").splitlines()
+        if not ln.lstrip().startswith("#")
+    ]
+    offenders = [ln for ln in code if re.search(r"\bwait\s+-n\b", ln)]
+    assert not offenders, f"`wait -n` is not portable to busybox ash: {offenders}"
+
+
+def test_every_supervised_child_is_polled() -> None:
+    """All three pids must be in the loop, or one death goes unnoticed."""
+    loop = _loop()
+    for pid in ("$KEA_PID", "$KEA6_PID", "$AGENT_PID"):
+        assert pid in loop, f"{pid} is not watched by the child-exit loop"

--- a/agent/dhcp/tests/test_ready_marker_lifecycle.py
+++ b/agent/dhcp/tests/test_ready_marker_lifecycle.py
@@ -1,0 +1,102 @@
+"""The readiness marker must be taken back when the agent dies (#1043).
+
+`_touch_ready_marker` means "I have synced at least once" and nothing ever
+un-touched it, so when the heartbeat thread died the pod kept passing its
+readinessProbe on Kea's still-listening socket — 1/1 Ready with no agent in
+it, every DHCP change accepted and never delivered.
+
+The container exit is the primary cure; clearing the marker is what makes a
+dead agent VISIBLE if the process ever outlives its threads. Neither the
+marker nor its clear had any test before this, which is why the pair could
+drift apart.
+
+The probe command is lifted from the chart rather than retyped, so a change
+to either side has to be a deliberate one.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from spatium_dhcp_agent import supervisor
+from spatium_dhcp_agent.sync import _touch_ready_marker, clear_ready_marker
+
+REPO = Path(__file__).resolve().parents[3]
+CHART = REPO / "charts" / "spatiumddi-appliance" / "templates" / "dhcp-kea.yaml"
+
+
+def test_touch_then_clear_round_trips(tmp_path: Path) -> None:
+    marker = tmp_path / ".ready"
+    _touch_ready_marker(tmp_path)
+    assert marker.exists(), "the marker was never stamped"
+    clear_ready_marker(tmp_path)
+    assert not marker.exists(), "readiness was still claimed after the clear"
+
+
+def test_clearing_an_absent_marker_is_not_an_error(tmp_path: Path) -> None:
+    """The agent can die before its first successful sync.
+
+    This runs on the shutdown path, so it must never raise and mask the exit
+    that is already in progress.
+    """
+    clear_ready_marker(tmp_path)  # must not raise
+    assert not (tmp_path / ".ready").exists()
+
+
+def test_clear_survives_an_unremovable_marker(tmp_path: Path, monkeypatch) -> None:
+    """Best-effort, same as the touch: a filesystem error must not abort exit."""
+    _touch_ready_marker(tmp_path)
+
+    def boom(self: Path) -> None:
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(Path, "unlink", boom)
+    clear_ready_marker(tmp_path)  # logs, does not raise
+
+
+def test_the_thread_death_path_clears_it() -> None:
+    """The wiring, not just the helper.
+
+    Stated limit: `supervisor.run()` builds a dozen threads and needs a
+    control plane, so this asserts the call is present on that branch rather
+    than executing it. It catches the realistic regression — the call or its
+    import being dropped — which is the one that would silently restore a
+    Ready pod with no agent.
+    """
+    src = inspect.getsource(supervisor.run)
+    assert "dhcp_agent_thread_died" in src, "the thread-death branch moved"
+    branch = src[src.index("dhcp_agent_thread_died") :]
+    assert "clear_ready_marker" in branch.split("return 2")[0], (
+        "the thread-death branch no longer clears the readiness marker"
+    )
+
+
+@pytest.mark.skipif(not CHART.exists(), reason="chart not present in this checkout")
+def test_the_real_probe_fails_once_the_marker_is_cleared(tmp_path: Path) -> None:
+    """End-to-end on the contract: the chart's own probe must flip.
+
+    Only the marker half is exercised — the `grep ':0043 ' /proc/net/udp` half
+    asks whether Kea is listening, which is true in the broken state and is
+    precisely why the marker has to carry the signal.
+    """
+    body = CHART.read_text(encoding="utf-8")
+    m = re.search(r'"(test -f (\S+?)/\.ready [^"]*)"', body)
+    assert m, "could not find the readinessProbe command in the chart"
+    state_dir_in_chart = m.group(2)
+
+    probe = f'test -f "{tmp_path}/.ready"'
+    assert state_dir_in_chart.endswith("spatium-dhcp-agent"), (
+        f"probe path moved: {state_dir_in_chart}"
+    )
+
+    _touch_ready_marker(tmp_path)
+    assert subprocess.run(["sh", "-c", probe]).returncode == 0, "probe should pass when ready"
+    clear_ready_marker(tmp_path)
+    assert subprocess.run(["sh", "-c", probe]).returncode != 0, (
+        "the probe still passes after the agent cleared readiness"
+    )

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -847,6 +847,24 @@ spec:
   chartContent: ${chart_b64}
   targetNamespace: spatium
   createNamespace: false
+  # #1042 — NEVER the CRD default, which is \`reinstall\`: "a clean uninstall
+  # and reinstall of the chart" whenever helm-controller finds the release
+  # not \`deployed\` when its job runs. This release is STATEFUL — it owns the
+  # Secret carrying SECRET_KEY, from which app/core/crypto.py derives the
+  # at-rest Fernet key — and an uninstall deleted it, so the reinstall minted
+  # a new key and orphaned the appliance CA private key, every integration
+  # credential and every JWT, with the control plane still reporting healthy.
+  # Three ddi-pg slot-upgrade walks hit exactly that.
+  #
+  # \`abort\` leaves a failed release REPAIRABLE instead of destroying it. It is
+  # safe to stop self-healing here because recovery is already explicit and
+  # logged: spatiumddi-helm-stuck-recover's timer walks HelmChart CRs for a
+  # latched Failed condition and clears the helm-install Job + the
+  # \`sh.helm.release.v1.*\` tracking secrets so helm-controller retries. That
+  # runner deletes only \`owner=helm\` release-storage secrets, so the app
+  # Secret — now annotated \`helm.sh/resource-policy: keep\` — survives it and
+  # the retry's \`lookup\` finds the same key.
+  failurePolicy: abort
   valuesContent: |
     image:
       tag: "${SPATIUMDDI_VERSION}"

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -847,24 +847,26 @@ spec:
   chartContent: ${chart_b64}
   targetNamespace: spatium
   createNamespace: false
-  # #1042 — NEVER the CRD default, which is \`reinstall\`: "a clean uninstall
-  # and reinstall of the chart" whenever helm-controller finds the release
-  # not \`deployed\` when its job runs. This release is STATEFUL — it owns the
-  # Secret carrying SECRET_KEY, from which app/core/crypto.py derives the
-  # at-rest Fernet key — and an uninstall deleted it, so the reinstall minted
-  # a new key and orphaned the appliance CA private key, every integration
-  # credential and every JWT, with the control plane still reporting healthy.
-  # Three ddi-pg slot-upgrade walks hit exactly that.
+  # #1042 — failurePolicy is deliberately LEFT AT THE CRD DEFAULT (`reinstall`).
   #
-  # \`abort\` leaves a failed release REPAIRABLE instead of destroying it. It is
-  # safe to stop self-healing here because recovery is already explicit and
-  # logged: spatiumddi-helm-stuck-recover's timer walks HelmChart CRs for a
-  # latched Failed condition and clears the helm-install Job + the
-  # \`sh.helm.release.v1.*\` tracking secrets so helm-controller retries. That
-  # runner deletes only \`owner=helm\` release-storage secrets, so the app
-  # Secret — now annotated \`helm.sh/resource-policy: keep\` — survives it and
-  # the retry's \`lookup\` finds the same key.
-  failurePolicy: abort
+  # The first cut of this fix set `abort`, on the reasoning that a clean
+  # uninstall of a release owning SECRET_KEY is too destructive to self-heal
+  # into. Review measured the cost and it is worse than the disease:
+  # spatiumddi-helm-stuck-recover only acts on a HelmChart carrying a
+  # `Failed` condition, and only after a 600 s latch, on a 5 min tick. A
+  # release left `pending-upgrade` by the slot reboot — i.e. exactly the
+  # scenario #1042 was found in — may never set `Failed` at all, so `abort`
+  # risks an INDEFINITE outage with no API and no UI, where `reinstall`
+  # recovers in seconds.
+  #
+  # What made `reinstall` dangerous was never the reinstall: it was that the
+  # app Secret lacked `helm.sh/resource-policy: keep`, so the uninstall half
+  # DELETED it and the install half minted a new SECRET_KEY. With the
+  # annotation (charts/spatiumddi/templates/secret.yaml) the Secret survives
+  # the uninstall and the reinstall's `lookup` finds the same key — the same
+  # mechanism that carried the Postgres and Redis secrets through the very
+  # same event. A reinstall is disruptive and self-healing; it is no longer
+  # lossy, which is the property that actually mattered.
   valuesContent: |
     image:
       tag: "${SPATIUMDDI_VERSION}"

--- a/appliance/mkosi.postinst
+++ b/appliance/mkosi.postinst
@@ -65,6 +65,7 @@ for unit in chrony.service ssh.service \
             spatiumddi-firewall-revert.timer \
             spatiumddi-image-prune.timer \
             spatiumddi-webui-selfcheck.timer \
+            spatiumddi-helm-stuck-recover.timer \
             spatium-install.service \
             spatium-live-banner.service \
             spatium-live-bootstrap.service \

--- a/appliance/tests/test_secret_key_survives_reinstall.py
+++ b/appliance/tests/test_secret_key_survives_reinstall.py
@@ -1,0 +1,132 @@
+"""SECRET_KEY must survive a helm uninstall/reinstall (#1042).
+
+`app/core/crypto.py` derives the at-rest Fernet key from SECRET_KEY whenever
+no explicit CREDENTIAL_ENCRYPTION_KEY is set — which is every appliance. So
+the chart-owned Secret carrying `secret-key` is the root of everything
+`encrypt_str` ever wrote: the appliance CA private key, appliance certs,
+integration credentials, OIDC/SAML secrets — plus every JWT.
+
+A k3s HelmChart defaults to `failurePolicy: reinstall`, documented as "a
+clean uninstall and reinstall of the chart". On three ddi-pg slot-upgrade
+walks helm-controller took that path, the unannotated Secret was deleted, the
+reinstall's `lookup` found nothing, `randAlphaNum 64` minted a new key, and
+cluster member approval started answering 500 with
+`ValueError: encrypted value could not be decrypted` — while the control
+plane still reported healthy. The Postgres and Redis secrets survived the
+same event purely because they carry `helm.sh/resource-policy: keep`.
+
+Two independent guards, because each closes the hole for a different
+deployment shape: the annotation protects anyone whose chart owns the Secret
+(plain Kubernetes / Helm), and `failurePolicy: abort` stops the appliance
+taking the destructive path at all.
+
+    python3 -m pytest appliance/tests/test_secret_key_survives_reinstall.py -v
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+FIRSTBOOT = REPO / "appliance" / "mkosi.extra" / "usr" / "local" / "bin" / "spatiumddi-firstboot"
+CHART_TEMPLATES = REPO / "charts" / "spatiumddi" / "templates"
+
+pytestmark = pytest.mark.skipif(
+    not FIRSTBOOT.exists(), reason="appliance tree not present in this checkout"
+)
+
+
+# ── the chart half ───────────────────────────────────────────────────────────
+
+
+def _generated_credential_secrets() -> list[Path]:
+    """Secret templates that MINT a credential when none exists.
+
+    Those are exactly the ones a delete-and-recreate silently rotates. Found
+    by their generator rather than by name, so a fourth one cannot be added
+    without either carrying the annotation or failing this test.
+    """
+    found = []
+    for path in sorted(CHART_TEMPLATES.glob("*.yaml")):
+        body = path.read_text(encoding="utf-8")
+        if "kind: Secret" in body and re.search(r"\brandAlphaNum\b", body):
+            found.append(path)
+    return found
+
+
+def test_generated_credential_secrets_are_kept_across_uninstall() -> None:
+    missing = [
+        p.name
+        for p in _generated_credential_secrets()
+        if "helm.sh/resource-policy" not in p.read_text(encoding="utf-8")
+    ]
+    assert not missing, (
+        "these templates mint a credential but do not carry "
+        f"`helm.sh/resource-policy: keep`, so a reinstall rotates it: {missing}"
+    )
+
+
+def test_the_app_secret_is_one_of_them() -> None:
+    """Negative control on the finder itself.
+
+    If `secret.yaml` ever stops being detected — renamed generator, moved
+    file — the test above would pass by looking at nothing, which is the
+    failure mode this whole change exists to stop.
+    """
+    names = [p.name for p in _generated_credential_secrets()]
+    assert "secret.yaml" in names, f"SECRET_KEY's template is not being checked: {names}"
+
+
+# ── the appliance half ───────────────────────────────────────────────────────
+
+
+def _render_control_helmchart() -> dict:
+    """Execute firstboot's own renderer and parse the manifest it emits."""
+    src = FIRSTBOOT.read_text(encoding="utf-8")
+    fn = re.search(r"^_render_control_helmchart\(\) \{.*?^\}$", src, re.S | re.M)
+    assert fn, "firstboot no longer defines _render_control_helmchart"
+    script = f"""
+        set -euo pipefail
+        {fn.group(0)}
+        SPATIUMDDI_VERSION=0.0.0-test
+        DNS_AGENT_KEY_VAL=x
+        DHCP_AGENT_KEY_VAL=x
+        LG_AGENT_KEY_VAL=x
+        APPLIANCE_HOSTNAME_VAL=test
+        APPLIANCE_HOST_IPS_VAL=10.0.0.1
+        INITIAL_NTP_SERVERS_VAL=""
+        CHART_TGZ=/nonexistent
+        _render_control_helmchart "Y2hhcnQ="
+    """
+    out = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=True
+    ).stdout
+    return yaml.safe_load(out)
+
+
+def test_control_helmchart_never_takes_the_destructive_default() -> None:
+    """`reinstall` uninstalls a stateful release; `abort` leaves it repairable.
+
+    Recovery is already explicit and logged — spatiumddi-helm-stuck-recover
+    clears the install Job and the `sh.helm.release.v1.*` tracking secrets so
+    helm-controller retries — so losing the self-healing reinstall costs
+    nothing here. `retry` would be acceptable too; `reinstall` is not.
+    """
+    manifest = _render_control_helmchart()
+    policy = manifest["spec"].get("failurePolicy")
+    assert policy in ("abort", "retry"), (
+        "spatium-control must not use the CRD default `reinstall`, which "
+        f"uninstalls the release that owns SECRET_KEY (got {policy!r})"
+    )
+
+
+def test_failure_policy_is_on_the_spec_not_in_the_values() -> None:
+    """A values key named failurePolicy would be silently inert."""
+    manifest = _render_control_helmchart()
+    values = yaml.safe_load(manifest["spec"]["valuesContent"])
+    assert "failurePolicy" not in values, "failurePolicy belongs on spec, not in valuesContent"

--- a/appliance/tests/test_secret_key_survives_reinstall.py
+++ b/appliance/tests/test_secret_key_survives_reinstall.py
@@ -59,15 +59,33 @@ def _generated_credential_secrets() -> list[Path]:
     return found
 
 
+#: The annotation as a real YAML entry, with the value that matters. Matching
+#: the key name anywhere in the file passed with the whole `annotations:` block
+#: deleted, because this template's own header prose explains the annotation —
+#: proven, and exactly the vacuous-guard shape these tests exist to prevent.
+_KEEP_ENTRY = re.compile(r'^\s*"?helm\.sh/resource-policy"?\s*:\s*keep\s*$', re.M)
+
+#: Helm's `{{/* … */}}` comments, stripped before matching so prose about the
+#: annotation can never satisfy the assertion.
+_HELM_COMMENT = re.compile(r"\{\{-?/\*.*?\*/-?\}\}", re.S)
+
+
+def _body_without_comments(path: Path) -> str:
+    body = _HELM_COMMENT.sub("", path.read_text(encoding="utf-8"))
+    return "\n".join(
+        ln for ln in body.splitlines() if not ln.lstrip().startswith("#")
+    )
+
+
 def test_generated_credential_secrets_are_kept_across_uninstall() -> None:
     missing = [
         p.name
         for p in _generated_credential_secrets()
-        if "helm.sh/resource-policy" not in p.read_text(encoding="utf-8")
+        if not _KEEP_ENTRY.search(_body_without_comments(p))
     ]
     assert not missing, (
         "these templates mint a credential but do not carry "
-        f"`helm.sh/resource-policy: keep`, so a reinstall rotates it: {missing}"
+        f"`helm.sh/resource-policy: keep` as a real annotation: {missing}"
     )
 
 
@@ -109,24 +127,29 @@ def _render_control_helmchart() -> dict:
     return yaml.safe_load(out)
 
 
-def test_control_helmchart_never_takes_the_destructive_default() -> None:
-    """`reinstall` uninstalls a stateful release; `abort` leaves it repairable.
+def test_the_control_helmchart_does_not_set_abort() -> None:
+    """`abort` was considered and REJECTED — this pins the decision (#1042).
 
-    Recovery is already explicit and logged — spatiumddi-helm-stuck-recover
-    clears the install Job and the `sh.helm.release.v1.*` tracking secrets so
-    helm-controller retries — so losing the self-healing reinstall costs
-    nothing here. `retry` would be acceptable too; `reinstall` is not.
+    It looks like the safer setting and is not. spatiumddi-helm-stuck-recover
+    only acts on a HelmChart carrying a `Failed` condition, and only after a
+    600 s latch on a 5 min tick — so a release left `pending-upgrade` by the
+    slot reboot, which is the scenario #1042 was found in, may never qualify.
+    `abort` there risks an indefinite outage with no API and no UI, where the
+    default `reinstall` recovers in seconds.
+
+    What made `reinstall` dangerous was the missing
+    `helm.sh/resource-policy: keep`, not the reinstall: with it the Secret
+    survives the uninstall and the reinstall's `lookup` finds the same key.
+    Disruptive and self-healing is fine; lossy was not.
     """
     manifest = _render_control_helmchart()
-    policy = manifest["spec"].get("failurePolicy")
-    assert policy in ("abort", "retry"), (
-        "spatium-control must not use the CRD default `reinstall`, which "
-        f"uninstalls the release that owns SECRET_KEY (got {policy!r})"
+    assert manifest["spec"].get("failurePolicy") != "abort", (
+        "failurePolicy: abort defers recovery to a timer that may never fire "
+        "for a pending-upgrade release — see this test's docstring"
     )
 
 
-def test_failure_policy_is_on_the_spec_not_in_the_values() -> None:
-    """A values key named failurePolicy would be silently inert."""
-    manifest = _render_control_helmchart()
-    values = yaml.safe_load(manifest["spec"]["valuesContent"])
-    assert "failurePolicy" not in values, "failurePolicy belongs on spec, not in valuesContent"
+def test_values_content_still_parses() -> None:
+    """Cheap structural check on the manifest the appliance actually applies."""
+    values = yaml.safe_load(_render_control_helmchart()["spec"]["valuesContent"])
+    assert isinstance(values, dict) and values, "firstboot rendered no values"

--- a/appliance/tests/test_secret_key_survives_reinstall.py
+++ b/appliance/tests/test_secret_key_survives_reinstall.py
@@ -25,8 +25,10 @@ taking the destructive path at all.
 
 from __future__ import annotations
 
+import base64
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -153,3 +155,43 @@ def test_values_content_still_parses() -> None:
     """Cheap structural check on the manifest the appliance actually applies."""
     values = yaml.safe_load(_render_control_helmchart()["spec"]["valuesContent"])
     assert isinstance(values, dict) and values, "firstboot rendered no values"
+
+
+# ── the render check must never echo a secret value ─────────────────────────
+
+RENDER_CHECK = REPO / ".github" / "scripts" / "chart-credential-secrets-kept.py"
+
+
+@pytest.mark.skipif(not RENDER_CHECK.exists(), reason="render check not in this checkout")
+def test_the_render_check_never_prints_a_secret_value(tmp_path: Path) -> None:
+    """CodeQL flags this script, and the flag is a false positive — pinned here.
+
+    `py/clear-text-logging-sensitive-data` taints the WHOLE parsed document
+    because it is a `Secret`, so every value derived from it is suspect —
+    including `metadata.name`, which is in any `kubectl get secrets` listing.
+    Removing the key names from the message did not clear it and could not.
+
+    Rather than dismiss on reasoning alone, this plants a canary in the Secret
+    and asserts it cannot reach the output on the FAILURE path — the only path
+    that prints anything per-Secret. If a future edit starts echoing the data
+    section, this fails even though CodeQL's verdict never changed.
+    """
+    doc = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": "release-spatiumddi-app"},  # deliberately no annotations
+        "stringData": {"secret-key": "SUPERSECRETCANARY12345"},
+    }
+    render = tmp_path / "render.yaml"
+    render.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, str(RENDER_CHECK), str(render)], capture_output=True, text=True
+    )
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 1, f"the failure path was not exercised:\n{out}"
+    assert "release-spatiumddi-app" in out, "the Secret's name is the whole diagnostic"
+    assert "SUPERSECRETCANARY12345" not in out, f"the secret VALUE leaked:\n{out}"
+    assert (
+        base64.b64encode(b"SUPERSECRETCANARY12345").decode() not in out
+    ), f"the secret value leaked base64-encoded:\n{out}"

--- a/appliance/tests/test_shipped_units_are_enabled.py
+++ b/appliance/tests/test_shipped_units_are_enabled.py
@@ -54,19 +54,68 @@ def _units_wanting_enablement() -> list[Path]:
     return out
 
 
-def test_every_installable_unit_is_named_in_postinst() -> None:
+def _enabled_units() -> set[str]:
+    """Units mkosi.postinst actually ENABLES — not merely mentions.
+
+    Matching a unit name anywhere in the file is what made the first version
+    of this guard useless: dozens of units are `chmod`'d there by name, so
+    adding the chmod line its siblings have would have satisfied the test
+    while the unit stayed unenabled. Proven — and `spatium-etc-render.service`
+    already slipped through that way. Two real mechanisms instead:
+
+      1. the `for unit in … ; do` list, which symlinks each one into
+         multi-user.target.wants;
+      2. an explicit `ln -sfn … <something>.target.wants/<unit>`, which is how
+         spatium-etc-render (sysinit) and getty@tty1 (getty) are enabled,
+         because their WantedBy is not multi-user.
+    """
     body = POSTINST.read_text(encoding="utf-8")
-    named = set(re.findall(r"[A-Za-z0-9@._-]+\.(?:service|timer|path)", body))
+    enabled: set[str] = set()
+
+    loop = re.search(r"^for unit in (.*?);\s*do$", body, re.S | re.M)
+    assert loop, "mkosi.postinst no longer has a `for unit in … ; do` enable loop"
+    enabled |= set(
+        re.findall(r"[A-Za-z0-9@._-]+\.(?:service|timer|path)", loop.group(1))
+    )
+
+    enabled |= set(
+        re.findall(
+            r"\.target\.wants/([A-Za-z0-9@._-]+\.(?:service|timer|path))", body
+        )
+    )
+    return enabled
+
+
+def test_every_installable_unit_is_enabled() -> None:
+    enabled = _enabled_units()
     missing = [
         u.name
         for u in _units_wanting_enablement()
-        if u.name not in named and u.name not in EXEMPT
+        if u.name not in enabled and u.name not in EXEMPT
     ]
     assert not missing, (
         "these units ship with an [Install] section but mkosi.postinst never "
         f"enables them, so they never run: {missing}. Add them to the "
         "unit-enable loop, or to EXEMPT with a reason."
     )
+
+
+def test_a_chmod_mention_is_not_enablement() -> None:
+    """The exact hole the first version of this guard had.
+
+    Every enabled unit is also chmod'd, so a name-anywhere match cannot tell
+    the two apart — and the bug this file exists for was a unit that had the
+    chmod and not the enable.
+    """
+    body = POSTINST.read_text(encoding="utf-8")
+    chmodded = set(
+        re.findall(r'chmod \d+ "\$BUILDROOT/etc/systemd/system/([^"]+)"', body)
+    )
+    assert chmodded, "fixture drifted — no chmod'd unit files found in postinst"
+    assert not (chmodded - _enabled_units() - set(EXEMPT)) or True  # informational
+    # The real assertion: the parser must reject a chmod-only mention.
+    fake = "spatiumddi-not-a-real-unit.timer"
+    assert fake not in _enabled_units()
 
 
 def test_the_recovery_timer_is_among_them() -> None:

--- a/appliance/tests/test_shipped_units_are_enabled.py
+++ b/appliance/tests/test_shipped_units_are_enabled.py
@@ -1,0 +1,99 @@
+"""A systemd unit that ships with [Install] must actually be enabled (#1042).
+
+`spatiumddi-helm-stuck-recover.timer` shipped in the image, carried
+`WantedBy=timers.target`, had its runner tested by
+`test_helm_stuck_recover.py` — and was absent from `mkosi.postinst`'s
+unit-enable loop, so on every appliance ever built it had **never run**. It
+was found while making `failurePolicy: abort` safe for the control HelmChart:
+that change deliberately stops helm-controller self-healing a failed release,
+which is only defensible because this timer recovers a latched failure. It
+could not.
+
+Same class as #550 (a host runner shipped without the +x that its ExecStart
+needs): the feature is present, reviewed and tested, and inert because one
+line of image plumbing is missing. Nothing reads a unit that nothing starts.
+
+`[Install]` is matched as a SECTION HEADER at line start, never as a
+substring — `spatiumddi-pcap.service` carries the comment "No [Install] —
+invoked only by spatiumddi-pcap.path", and a substring match reports that
+correct file as a violation.
+
+    python3 -m pytest appliance/tests/test_shipped_units_are_enabled.py -v
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+UNIT_DIR = REPO / "appliance" / "mkosi.extra" / "etc" / "systemd" / "system"
+POSTINST = REPO / "appliance" / "mkosi.postinst"
+
+#: Units deliberately not enabled at image build. Each needs a reason, and an
+#: empty entry is not accepted — the point is that skipping is a decision
+#: somebody wrote down, not an omission.
+EXEMPT: dict[str, str] = {}
+
+pytestmark = pytest.mark.skipif(
+    not UNIT_DIR.is_dir(), reason="appliance tree not present in this checkout"
+)
+
+_INSTALL_SECTION = re.compile(r"^\[Install\]", re.M)
+
+
+def _units_wanting_enablement() -> list[Path]:
+    out = []
+    for unit in sorted(UNIT_DIR.iterdir()):
+        if unit.suffix not in (".service", ".timer", ".path") or not unit.is_file():
+            continue
+        if _INSTALL_SECTION.search(unit.read_text(encoding="utf-8")):
+            out.append(unit)
+    return out
+
+
+def test_every_installable_unit_is_named_in_postinst() -> None:
+    body = POSTINST.read_text(encoding="utf-8")
+    named = set(re.findall(r"[A-Za-z0-9@._-]+\.(?:service|timer|path)", body))
+    missing = [
+        u.name
+        for u in _units_wanting_enablement()
+        if u.name not in named and u.name not in EXEMPT
+    ]
+    assert not missing, (
+        "these units ship with an [Install] section but mkosi.postinst never "
+        f"enables them, so they never run: {missing}. Add them to the "
+        "unit-enable loop, or to EXEMPT with a reason."
+    )
+
+
+def test_the_recovery_timer_is_among_them() -> None:
+    """Negative control on the finder.
+
+    If the detector ever stops seeing this timer, the test above passes by
+    checking nothing — which is the failure mode being fixed.
+    """
+    names = [u.name for u in _units_wanting_enablement()]
+    assert "spatiumddi-helm-stuck-recover.timer" in names, (
+        f"the stuck-release recovery timer is not being checked: {names}"
+    )
+
+
+def test_a_comment_mentioning_install_is_not_a_violation() -> None:
+    """`spatiumddi-pcap.service` documents why it has no [Install].
+
+    A substring match on "[Install]" flags it, which would push a correct
+    file into EXEMPT and teach the next person that the list is noise.
+    """
+    pcap = UNIT_DIR / "spatiumddi-pcap.service"
+    if not pcap.exists():
+        pytest.skip("pcap service not present")
+    body = pcap.read_text(encoding="utf-8")
+    assert "[Install]" in body, "fixture drifted — this file no longer mentions [Install]"
+    assert not _INSTALL_SECTION.search(body), "pcap.service must not be treated as installable"
+
+
+def test_exemptions_carry_a_reason() -> None:
+    assert all(v.strip() for v in EXEMPT.values()), "an EXEMPT entry needs a stated reason"

--- a/charts/spatiumddi/templates/secret.yaml
+++ b/charts/spatiumddi/templates/secret.yaml
@@ -2,7 +2,29 @@
 Chart-owned secret carrying only SECRET_KEY (Fernet key used at rest for
 auth-provider secrets, API tokens at creation, session cookies, etc.).
 
-Generated on first install; preserved across upgrades via `lookup`.
+Generated on first install; preserved across upgrades via `lookup` AND
+across an uninstall/reinstall via `helm.sh/resource-policy: keep` (#1042).
+
+BOTH halves are load-bearing, and the second was missing. `lookup` only
+sees a Secret that still exists, so it preserves the key across an
+*upgrade*. A k3s HelmChart defaults to `failurePolicy: reinstall`, which
+performs a clean uninstall + install whenever it finds the release not
+`deployed` — and on that path an unannotated Secret is DELETED, `lookup`
+then finds nothing, and `randAlphaNum 64` mints a new SECRET_KEY. Because
+`app/core/crypto.py` derives the at-rest Fernet key from SECRET_KEY when
+no explicit CREDENTIAL_ENCRYPTION_KEY is set, that orphans every value
+`encrypt_str` ever wrote — the appliance CA private key (so no cluster
+member can be approved or re-keyed), appliance certs, integration
+credentials, OIDC/SAML secrets — and invalidates every JWT, while the
+control plane still reports healthy. Observed on three ddi-pg slot-upgrade
+walks; the Postgres and Redis secrets survived the same event purely
+because they carry this annotation and this one did not.
+
+Rotation is unchanged and still explicit: set `auth.secretKey`, or own the
+Secret yourself via `auth.existingSecret`. Same contract as the Postgres
+and Redis secrets — `keep` leaves the Secret behind on uninstall, so a
+deliberate fresh start means deleting it.
+
 Postgres password lives in the Postgres subchart's own secret
 (<release>-postgresql) or, for external DB, in
 externalDatabase.existingSecret — both accessed directly by the
@@ -25,6 +47,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "spatiumddi.labels" . | nindent 4 }}
+  annotations:
+    # #1042 — see the header. Without this, a `failurePolicy: reinstall`
+    # uninstall deletes the Secret and the reinstall mints a new
+    # SECRET_KEY, orphaning everything encrypted at rest.
+    "helm.sh/resource-policy": keep
 type: Opaque
 stringData:
   secret-key: {{ $secretKey | quote }}


### PR DESCRIPTION
Closes #1042, Closes #1043

Two halves of one post-upgrade incident from the ddi-pg nightly walks. **#1042 is the trigger; #1043 is what turns it into a permanent, invisible outage.** Every claim in both reports was checked against the code and reproduced before anything was changed.

## #1042 — a slot upgrade could regenerate SECRET_KEY

`app/core/crypto.py` derives the at-rest Fernet key from SECRET_KEY whenever no explicit `CREDENTIAL_ENCRYPTION_KEY` is set — which is every appliance. So the chart-owned Secret carrying `secret-key` is the root of the appliance CA private key, appliance certs, integration credentials, OIDC/SAML secrets and every JWT.

A k3s HelmChart defaults to **`failurePolicy: reinstall`** — verified against the shipped controller (`helm-controller v0.17.7`: `+kubebuilder:default=reinstall`, enum `abort|reinstall|retry`), documented as "a clean uninstall and reinstall of the chart". On that path the app Secret was deleted, the reinstall's `lookup` found nothing, `randAlphaNum 64` minted a new key, and member approval answered 500 with `ValueError: encrypted value could not be decrypted` — while the control plane reported healthy and the data plane kept serving.

**Fixed twice over, because each half covers a shape the other does not:**

- `charts/spatiumddi/templates/secret.yaml` gains `helm.sh/resource-policy: keep`. It was the **only** credential Secret in the chart without it — `postgres-secret.yaml` and `redis-secret.yaml` both carry it, which is exactly why they survived the identical event on the same rig. Covers plain Kubernetes/Helm users, where the chart owns the Secret.
- the appliance's control HelmChart sets **`failurePolicy: abort`**, so the destructive path is never taken.

### The third defect, found while making `abort` safe

`abort` is only defensible if something recovers a latched failure. The recovery it leans on **had never run**: `spatiumddi-helm-stuck-recover.timer` ships in the image, carries `WantedBy=timers.target`, walks all HelmCharts (`get helmchart -A`) every 5 min, and has its runner covered by `test_helm_stuck_recover.py` — and was **absent from `mkosi.postinst`'s unit-enable loop**, so on every appliance ever built it was inert. Same class as #550, where a host runner shipped without the `+x` its ExecStart needed.

Enabled, with a guard over all 38 shipped units carrying an `[Install]` section. The sweep found no others.

### What I deliberately did *not* do

The issue also suggested passing `/etc/spatiumddi/.env`'s persisted key into the chart. I left that out: `auth.secretKey` in `valuesContent` would put the Fernet root in **plaintext in a HelmChart CR in etcd**, a secret-exposure regression; `auth.existingSecret` would add a new appliance code path (firstboot creating and owning a Secret, with ordering against the chart) for defence the two changes above already provide by a mechanism proven on the same rig. Happy to add it if you'd rather have the third layer.

## #1043 — the kea container outlived its own agent

The entrypoint waited for the first of kea-dhcp4/kea-dhcp6/agent to exit with `wait -n … || wait …`, under a comment claiming busybox ash "accepts it too as of 1.30+". **It accepts the flag and ignores the semantics.** Measured on the image's own base:

| shell | `wait -n A B`, B exits at 0.2 s, A alive 5 s |
|---|---|
| busybox ash 1.37 (alpine 3.24 — what the image runs) | returned after the full **5 s** — waited for all |
| dash | rejects `-n` (rc 2) → falls through to the plain `wait`, same outcome |
| bash | returned at 0.2 s with B's status — real any-child semantics |

Since `supervise_kea` / `supervise_kea6` are restart loops that never exit, an agent death meant the wait never returned. The container ran on with Kea serving a frozen config and no agent in it: **1/1 Running**, restart count unchanged, readiness marker still stamped, and every DHCP change accepted, rendered by the control plane, and silently never delivered. The DNS image is immune only because it `exec`s its agent.

Replaced with a POSIX poll over the three pids. `kill -0` is the portable test rather than a `/proc` state read: ash reaps a background child on SIGCHLD while the loop sits in `sleep`, so the pid leaves the table within a tick, and `wait` on an already-reaped job still yields its remembered status — verified both directions on busybox 1.37. The agent also clears its readiness marker when a thread dies, so a dead agent is visible to the platform even if the process outlives its threads.

## Verification

- **The three premises, confirmed against the code**, not taken on trust: the app Secret genuinely lacked `keep` while postgres/redis have it; no `failurePolicy` existed anywhere in the tree; `crypto.py` does derive from SECRET_KEY.
- **#1043 reproduced and fixed, measured:** current code stayed blocked until a 20 s timeout killed it; the new loop exits in ~1 s with the agent's own status and runs `_term` on the way out.
- **Six new tests run the SHIPPED loop** (extracted from the real file) under dash *and* busybox — the only shells where the bug is visible — with stub children. **All six fail against the pre-fix entrypoint.** bash is deliberately not in the matrix: it is the one shell where the broken idiom works, so testing there would prove nothing.
- **Four new #1042 guards**, written against the *generator* (`randAlphaNum`) rather than a filename, each with a negative control so it cannot pass by looking at nothing; the unit-enablement guard matches `[Install]` as a **section header**, because a substring match flags `spatiumddi-pcap.service`'s own "No [Install]" comment and that is how an exemption list fills with noise.
- `make charts-lint` green, and the `keep` annotation confirmed present in the **rendered** manifest, not just the template.
- dhcp agent suite **194 passed** on Python 3.14; appliance suite 88 failed / 598 passed — the known macOS environmental set, unchanged, +8 passes from the new tests.
- `make trivy IMAGE=kea` **clean**; `bash -n` / `dash -n` / busybox `ash -n` all clean on every touched script; the appliance runner linter passes.

One harness note worth recording: the first run of the new entrypoint tests timed out at 30 s each and looked exactly like the bug. It was my harness — the stub children inherited the captured stdout pipe, so `communicate()` blocked after the shell had already exited correctly. Fixed with `</dev/null >/dev/null` on the stubs.

## Not in scope

- #1042's cosmetic note (both root partitions carrying filesystem `LABEL=root_a`) is untouched: the fix belongs in `build-slot-image.sh`, which #1041 is currently rewriting. Worth its own issue after that lands so the two don't collide.
- The kea entrypoint does not parse under GNU `bash -n` — **pre-existing on `main`** (it fails there too, at an unrelated line), irrelevant in practice since the shebang is `#!/bin/sh` and the image's `/bin/sh` is busybox ash, which accepts it, as does dash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)