### PR TITLE
fix(appliance): relabel an upgraded slot's filesystem, and match slots by GPT name (#1045)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -980,8 +980,15 @@ the formatter handles the rest.
   was in that comment — so the guard was passing on the explanation
   while the code it describes had changed underneath it. Rewritten to
   assert on the calls.
-  33 new appliance tests plus that rewrite, every one of them run
-  against the unpatched scripts first — all 33 fail there, and the
+  The Copilot reviewer named two more without generating a comment for
+  either. One was moot — a mirror never reaches the relabel, since
+  `cmd_apply` aborts at slot detection first, and every write goes to
+  the device the `dd` already used. Chasing the other turned up a real
+  gap of its own: the active-slot repair was gated on a TRUTHY current
+  label, so a slot carrying no label at all — a missing label, which is
+  the thing being repaired — was skipped.
+  34 new appliance tests plus that rewrite, every one of them run
+  against the unpatched scripts first — all 34 fail there, and the
   rewritten guard fails while its 19 neighbours still pass. No
   migration, no API change.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -893,6 +893,98 @@ the formatter handles the rest.
 ### Fixed
 
 
+- **Both OS slots ended up labelled `root_a` after an A/B upgrade, and
+  the #995 "Keep /var" reinstall silently stopped being offered
+  (#1045).** `build-slot-image.sh` builds ONE image for both slots and
+  bakes `mkfs.ext4 -L root_a` into it, so every upgrade wrote `root_a`
+  onto whichever slot it targeted. `spatium-upgrade-slot` already knew
+  the baked-in filesystem identity was wrong for the target and fixed
+  half of it — `tune2fs -U random`, because a duplicate UUID wedges
+  slot detection — and left the label alone under a comment
+  ("PARTLABEL is preserved because it lives in the GPT header, not the
+  filesystem") showing it was never considered. So slot B came out of
+  its first upgrade labelled `root_a` and **no partition on the disk
+  carried `root_b` again, ever.**
+  **Nothing on the boot path notices**, which is why it survived
+  releases: `grub.cfg` renders `root=UUID=`, and the image-baseline
+  fstab carries no root entry — only `var` / `state` / `ESP`, none of
+  which a slot upgrade rewrites. What noticed was the INSTALLER.
+  `_layout_is_reusable` required all five labels, `root_b` among them,
+  so it refused every disk that had ever upgraded — withdrawing the
+  "Keep /var" offer and erasing the database of anyone reinstalling a
+  long-lived appliance. Silently: every `return 1` in it was bare, so
+  "a label is missing" and "this disk is not ours" produced identical
+  output. Proven against the shipped script rather than argued —
+  main's own `_layout_is_reusable`, run against the post-upgrade layout
+  #1042 reported, returns 1 and says nothing.
+  **Two halves, because they fail separately.**
+  `spatium-upgrade-slot` now labels the target from its own GPT name,
+  beside the UUID randomisation that already existed for the other half
+  of the same problem — derived from the PARTLABEL, never a literal,
+  because the GPT name is what genuinely identifies a slot, is what the
+  script already matches slots on, and is the one thing a `dd` of a
+  filesystem image cannot overwrite. The label is read back off the
+  device afterwards: on a MOUNTED filesystem `tune2fs` goes through
+  `FS_IOC_SETFSLABEL` and "accepted" is not "applied". And
+  `spatium-install` now matches the two slots by GPT name, which is the
+  half that repairs the fleet — a disk written by an older appliance
+  keeps working without anyone touching it. A pre-#1045 disk's ACTIVE
+  slot is repaired on its next upgrade too; never fatal, since the
+  label is on no boot path and the installer no longer depends on it.
+  **ESP / state / var deliberately keep the filesystem label as their
+  identity** — that is what fstab resolves them by — so the split is
+  per-partition-role rather than wholesale.
+  **Two more found on the way.** The KEEP_VAR reinstall resolved all
+  five devices with `blkid -L`, which searches **every disk on the
+  machine**: with a second SpatiumDDI disk attached it could answer
+  with the wrong one and `mkfs` a `/var` the operator never picked.
+  Now resolved against the target disk only, with an assertion that the
+  two slots are two different partitions. And
+  `_existing_install_version` gave up after the first slot it could
+  mount, so a slot that mounts and carries no release file
+  short-circuited the whole function to "unknown version" — which is
+  the state slot B is in on every freshly installed appliance, and is
+  also why a #999 mirror reported `unknown version` for a perfectly
+  good install (the raid member is tried first and cannot be mounted as
+  ext4). It now tries every candidate. Where both slots hold a release
+  it still reports slot A's, which on a node booted from B is the
+  older, inactive one; left as it is, and said so in the code, because
+  determining the active slot from the ISO means reading grubenv off
+  the ESP and this string only decides how a prompt is worded.
+  **/code-review found five, and two were about guards rather than
+  code.** `_layout_is_reusable` had no distinctness check of its own, so
+  a disk whose two slots resolve to the SAME device was offered "Keep
+  /var", the operator answered four more screens, and the install
+  aborted at the wipe — a refusal has to live where the offer is made,
+  not only in `do_install` (it is in both now; a preseeded install sets
+  KEEP_VAR without going through the picker at all).
+  `_existing_install_version` mounted slot B **twice** on a duplicated
+  disk, since it answers to both names, tripling the 10 s stall that
+  bound exists to cap — in the enumeration that runs before the
+  operator has picked anything. The active-slot repair sat after the one
+  `udevadm trigger --settle`, so its `by-label` link stayed stale until
+  the next reboot while a comment claimed one settle covered both; and
+  `_relabel_slot_filesystem`'s verification result was **discarded at
+  both call sites**, so a label that provably did not stick produced one
+  stderr line and an apply that still reported success (the #882
+  reporting lesson) — it now names the consequence and the one-line
+  manual fix. Plus two stale comments that had become load-bearing: the
+  #999 md-gate's justification described a `blkid`-by-label hazard that
+  no longer exists and whose direction has **inverted** (on a mirror
+  only the live raid MEMBERS carry a GPT name, so without that gate mkfs
+  would land on a disk the array is still using), and
+  `_layout_is_reusable`'s header still asserted the premise this issue
+  disproves. That second one mattered more than prose usually does:
+  `test_the_layout_check_goes_by_label_not_partition_number` asserted
+  `"LABEL" in fn`, and the only uppercase `LABEL` left in the function
+  was in that comment — so the guard was passing on the explanation
+  while the code it describes had changed underneath it. Rewritten to
+  assert on the calls.
+  33 new appliance tests plus that rewrite, every one of them run
+  against the unpatched scripts first — all 33 fail there, and the
+  rewritten guard fails while its 19 neighbours still pass. No
+  migration, no API change.
+
 - **The kea container outlived its own agent, and every health
   surface stayed green (#1043).** `entrypoint.sh` backgrounds
   kea-dhcp4, kea-dhcp6 and the Python agent and waits for the first

--- a/appliance/mkosi.extra/usr/local/bin/spatium-install
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-install
@@ -1505,6 +1505,64 @@ _md_array_is_ours() {
     esac
 }
 
+# #1045 — resolve a partition of THIS disk by its ext4 filesystem label.
+#
+# Deliberately not `blkid -L`, which searches every disk on the machine: with
+# a second SpatiumDDI disk attached it answers with the OTHER disk's
+# partition, and on the KEEP_VAR path that is a `mkfs` on a /var the operator
+# never chose. Every caller here has already settled which disk it means.
+_labelled_device_on() {
+    local dev="$1" want="$2" part label
+    for part in $(lsblk -nro NAME "$dev" 2>/dev/null | tail -n +2); do
+        label=$(lsblk -nro LABEL "/dev/$part" 2>/dev/null | head -1)
+        [ "$label" = "$want" ] && { printf '/dev/%s' "$part"; return 0; }
+    done
+    return 1
+}
+
+# #1045 — every device on this disk that could be one of the two OS slots,
+# GPT-name matches first.
+#
+# The two slots are identified by their GPT PARTLABEL (`root_A` / `root_B`,
+# written by `sgdisk -c4:` / `-c5:` below), NOT by the ext4 filesystem label
+# the rest of the layout uses. build-slot-image.sh bakes `root_a` into the
+# one image both slots are dd'd from, so an upgraded slot B carries `root_a`
+# too and NO partition on the disk is labelled `root_b` any more. The GPT
+# name survives, because a slot upgrade writes a filesystem, not a table.
+# (spatium-upgrade-slot now relabels the filesystem as well, so a disk
+# upgraded by a current appliance is consistent — this keeps the installer
+# working on every disk written before that.)
+#
+# The filesystem label is still checked as a fallback, for the #999 mirror:
+# the md devices carry the labels and are not partitions, so they have no
+# GPT name to match at all.
+_slot_candidates_on() {
+    local dev="$1" want="$2" part partlabel label
+    for part in $(lsblk -nro NAME "$dev" 2>/dev/null | tail -n +2); do
+        partlabel=$(lsblk -nro PARTLABEL "/dev/$part" 2>/dev/null | head -1 \
+                      | tr '[:upper:]' '[:lower:]')
+        [ "$partlabel" = "$want" ] && printf '/dev/%s\n' "$part"
+    done
+    for part in $(lsblk -nro NAME "$dev" 2>/dev/null | tail -n +2); do
+        partlabel=$(lsblk -nro PARTLABEL "/dev/$part" 2>/dev/null | head -1 \
+                      | tr '[:upper:]' '[:lower:]')
+        # Already printed above; listing it twice would make a caller that
+        # stops at the first hit look like it tried two.
+        [ "$partlabel" = "$want" ] && continue
+        label=$(lsblk -nro LABEL "/dev/$part" 2>/dev/null | head -1)
+        [ "$label" = "$want" ] && printf '/dev/%s\n' "$part"
+    done
+}
+
+# The single best device for one slot, or nothing. `head -1` and not a
+# `return` inside the loop: _slot_candidates_on is a pipeline source.
+_slot_device_on() {
+    local first
+    first=$(_slot_candidates_on "$1" "$2" | head -1)
+    [ -n "$first" ] || return 1
+    printf '%s' "$first"
+}
+
 # Is there already a SpatiumDDI install on this disk? Prints its version
 # when there is (#995 item 25).
 _existing_install_version() {
@@ -1513,47 +1571,81 @@ _existing_install_version() {
     # the command-substitution subshell, so the caller silently got "" and
     # the whole "Keep /var" offer disappeared. A dirty ext4 that will not
     # mount read-only is exactly when someone reinstalls.
-    local dev="$1" part label ver="" mnt
-    for part in $(lsblk -nro NAME "$dev" 2>/dev/null | tail -n +2); do
-        label=$(lsblk -nro LABEL "/dev/$part" 2>/dev/null | head -1)
-        [ "$label" = "root_a" ] || continue
-        mnt=$(mktemp -d) || return 1
-        # noload: a plain `mount -o ro` on ext4 REPLAYS THE JOURNAL, so
-        # merely enumerating disks would write to one the operator has not
-        # chosen. Timeout because an unresponsive LUN or USB stick blocks
-        # in uninterruptible D state for the SCSI timeout with the console
-        # showing nothing.
-        if timeout 10 mount -o ro,noload -t ext4 "/dev/$part" "$mnt" 2>/dev/null; then
-            ver=$(_appliance_version_from "$mnt/etc/spatiumddi/appliance-release")
-            umount "$mnt" 2>/dev/null || true
-        fi
-        rmdir "$mnt" 2>/dev/null || true
-        [ -n "$ver" ] && { printf '%s' "$ver"; return 0; }
-        printf '%s' "unknown version"
-        return 0
+    local dev="$1" slot cand ver="" mnt found=0 tried=""
+    # #1045 — both slots, and by GPT name as well as by filesystem label.
+    # Slot A alone was not enough on two counts: an upgraded disk carries
+    # `root_a` on BOTH slots (so the label says nothing about which is
+    # which), and a slot that mounts but carries no release file used to
+    # short-circuit the whole function to "unknown version" without ever
+    # looking at the other one — which is the state slot B is in on every
+    # freshly installed appliance that has not upgraded yet.
+    #
+    # Slot A is still tried first, so the common answer does not change.
+    # When both slots hold a release this reports A's, which on a node
+    # booted from B is the older, inactive one. Left as it is: determining
+    # the active slot from the ISO means reading grubenv off the ESP, and
+    # this string only decides how a "there is an install here" prompt is
+    # WORDED — the prompt itself is gated on the layout, not the version.
+    for slot in root_a root_b; do
+        for cand in $(_slot_candidates_on "$dev" "$slot"); do
+            # On a disk carrying the #1045 duplicate, slot B answers to BOTH
+            # names — so without this it is mounted twice and the 10 s stall
+            # this loop is bounded by is paid three times per disk, in the
+            # enumeration that runs before the operator has picked anything.
+            case " $tried " in *" $cand "*) continue ;; esac
+            tried="$tried $cand"
+            found=1
+            mnt=$(mktemp -d) || return 1
+            # noload: a plain `mount -o ro` on ext4 REPLAYS THE JOURNAL, so
+            # merely enumerating disks would write to one the operator has not
+            # chosen. Timeout because an unresponsive LUN or USB stick blocks
+            # in uninterruptible D state for the SCSI timeout with the console
+            # showing nothing.
+            if timeout 10 mount -o ro,noload -t ext4 "$cand" "$mnt" 2>/dev/null; then
+                ver=$(_appliance_version_from "$mnt/etc/spatiumddi/appliance-release")
+                umount "$mnt" 2>/dev/null || true
+            fi
+            rmdir "$mnt" 2>/dev/null || true
+            [ -n "$ver" ] && { printf '%s' "$ver"; return 0; }
+        done
     done
+    # A slot is there but nothing in it says what it is — still an install,
+    # and still worth marking the disk.
+    [ "$found" = 1 ] && { printf '%s' "unknown version"; return 0; }
     printf ''
 }
 
 # Does this disk already carry the six-partition layout do_install
 # creates, with a /var big enough to be worth keeping (#995 item 25)?
 #
-# Checked by LABEL rather than by partition number: the labels are what
-# fstab and spatium-upgrade-slot address, and a disk that has the right
-# labels in the right roles is one this installer can reuse whatever
-# numbering it happens to use.
+# Checked by IDENTITY rather than by partition number, so a disk carrying
+# the layout at other indices is still reusable — but the identity is not
+# one thing (#1045). ESP / state / var go by filesystem label, which is
+# what the image-baseline fstab addresses them by. The two OS slots go by
+# GPT name, because a slot upgrade overwrites the filesystem and with it
+# the label: the header this replaced claimed the labels were "what fstab
+# and spatium-upgrade-slot address", and for the slots neither was ever
+# true — fstab has no root entry at all, and spatium-upgrade-slot matches
+# on PARTLABEL. Believing it cost every upgraded appliance the offer
+# below.
 _layout_is_reusable() {
-    local dev="$1" want found part label
+    local dev="$1" want
     # #999 Part C2 — NOT reusable when the labels live on an md array.
     #
     # lsblk walks holders, so on a mirrored install the md devices show
-    # up here carrying the five labels and the layout looks reusable. It
-    # is not, and the failure is not the obvious one: the KEEP_VAR branch
-    # resolves each device by LABEL, so blkid correctly returns
-    # /dev/md/root_a and the mkfs targets the ARRAY rather than a live
-    # member. What breaks is downstream — KEEP_VAR forces MIRROR_MODE
+    # up here carrying the labels and the layout looks reusable. It is
+    # not, and what breaks is downstream: KEEP_VAR forces MIRROR_MODE
     # off, so the reinstalled slot gets an initrd with no md_mod, no
     # raid1 and no mdadm.conf, and the box does not come back.
+    #
+    # The hazard on the way there INVERTED with #1045, which matters to
+    # whoever implements the mirror-preserving reinstall below. This used
+    # to say the KEEP_VAR branch resolved by LABEL and so would mkfs the
+    # ARRAY instead of a member. It no longer resolves by label at all,
+    # and on a mirror only the live raid MEMBERS carry a GPT name — so
+    # without this gate the slots would resolve to the members and the
+    # mkfs would land on a disk the array is still using, destroying the
+    # mirror rather than merely writing to the wrong level of it.
     #
     # Carrying the mirror through a reinstall is a real capability and a
     # bigger change than this: it has to rediscover the second member
@@ -1564,14 +1656,41 @@ _layout_is_reusable() {
         log "Layout on $dev sits on an md array — 'keep /var' is not offered (#999)"
         return 1
     fi
-    for want in ESP state root_a root_b var; do
-        found=0
-        for part in $(lsblk -nro NAME "$dev" 2>/dev/null | tail -n +2); do
-            label=$(lsblk -nro LABEL "/dev/$part" 2>/dev/null | head -1)
-            [ "$label" = "$want" ] && { found=1; break; }
-        done
-        [ "$found" = 1 ] || return 1
+    # ESP / state / var keep the filesystem label as their identity, because
+    # that is what the image-baseline fstab resolves them by. The two OS
+    # slots do NOT (#1045): a slot upgrade rewrites the filesystem and with
+    # it the label, so `root_b` is absent on every disk that has ever
+    # upgraded, and gating on it here silently withdrew the whole "Keep
+    # /var" offer from exactly the long-lived appliances most likely to
+    # want it. The GPT name is the thing a slot upgrade cannot touch.
+    for want in ESP state var; do
+        if ! _labelled_device_on "$dev" "$want" >/dev/null; then
+            # Every return below used to be bare, so a missing label was
+            # indistinguishable from "this disk is not ours" — which is how
+            # #1045 went unnoticed through a release. Name it.
+            log "Layout on $dev is not reusable — no partition labelled '$want'"
+            return 1
+        fi
     done
+    local _a _b
+    for want in root_a root_b; do
+        if ! _slot_device_on "$dev" "$want" >/dev/null; then
+            log "Layout on $dev is not reusable — no OS slot '$want' (no GPT name, no filesystem label)"
+            return 1
+        fi
+    done
+    # Both slots resolved, but to the same device? Only a disk with one GPT
+    # name and the other slot identified by a filesystem label can do that,
+    # and do_install refuses it outright. Refuse HERE too: the alternative
+    # is offering "Keep /var", letting the operator answer hostname, admin
+    # account, network and timezone, and then aborting at the wipe — the
+    # refusal has to be where the offer is made.
+    _a=$(_slot_device_on "$dev" root_a) || return 1
+    _b=$(_slot_device_on "$dev" root_b) || return 1
+    if [ "$_a" = "$_b" ]; then
+        log "Layout on $dev is not reusable — both OS slots resolve to $_a"
+        return 1
+    fi
     return 0
 }
 
@@ -3926,23 +4045,53 @@ do_install() {
     fi
     # #995 item 25 — on the KEEP_VAR path the table is NOT rewritten, so
     # the positional names above are whatever the disk already has.
-    # _layout_is_reusable gates on the five LABELs and its comment even
-    # promises numbering-independence, so a disk carrying them at other
+    # _layout_is_reusable gates on all five being findable and its comment
+    # even promises numbering-independence, so a disk carrying them at other
     # indices would get `mkfs -L root_a` written over the var the operator
-    # asked to keep. Resolve by label, and refuse if any is missing rather
+    # asked to keep. Resolve each one, and refuse if any is missing rather
     # than falling back to a position that could be anything.
     if [ "$KEEP_VAR" = "yes" ]; then
-        local _l _dev
-        for _l in ESP:ESP state:STATE root_a:ROOT_A root_b:ROOT_B var:VAR; do
-            _dev=$(blkid -L "${_l%%:*}" 2>/dev/null || true)
+        local _l _dev _name
+        # Resolved against THIS disk only. `blkid -L` searched every disk on
+        # the machine, so a box with a second SpatiumDDI disk attached could
+        # resolve `var` to the wrong one and mkfs the slots of a disk the
+        # operator never picked (#1045).
+        #
+        # ESP / state / var by filesystem label, the two OS slots by GPT name
+        # — same split, and for the same reason, as _layout_is_reusable.
+        for _l in ESP:ESP state:STATE var:VAR; do
+            _name="${_l%%:*}"
+            _dev=$(_labelled_device_on "$TARGET_DISK" "$_name" || true)
             if [ -z "$_dev" ] || [ ! -b "$_dev" ]; then
-                log "FATAL: reinstall keeping /var, but no partition is labelled '${_l%%:*}'."
+                log "FATAL: reinstall keeping /var, but no partition of $TARGET_DISK is labelled '$_name'."
                 log "  Refusing rather than guessing a partition number. Nothing has been written."
                 exit 1
             fi
             printf -v "${_l##*:}" '%s' "$_dev"
             log "Reinstall: ${_l##*:} resolved by label to $_dev"
         done
+        for _l in root_a:ROOT_A root_b:ROOT_B; do
+            _name="${_l%%:*}"
+            _dev=$(_slot_device_on "$TARGET_DISK" "$_name" || true)
+            if [ -z "$_dev" ] || [ ! -b "$_dev" ]; then
+                log "FATAL: reinstall keeping /var, but $TARGET_DISK has no OS slot '$_name'."
+                log "  Refusing rather than guessing a partition number. Nothing has been written."
+                exit 1
+            fi
+            printf -v "${_l##*:}" '%s' "$_dev"
+            log "Reinstall: ${_l##*:} resolved to $_dev"
+        done
+        # A disk carrying the #1045 duplicate resolves both slots by GPT name
+        # above, so they are two different partitions and the mkfs a few
+        # steps below writes each its correct label — the reinstall leaves
+        # the disk consistent. Assert it rather than trust it: installing
+        # both slots onto one partition would produce a box with no
+        # rollback and nothing would say so.
+        if [ "$ROOT_A" = "$ROOT_B" ]; then
+            log "FATAL: both OS slots of $TARGET_DISK resolved to $ROOT_A."
+            log "  Refusing rather than installing both slots onto one partition."
+            exit 1
+        fi
     fi
 
     # Disk-size validation lives in ``pick_disk`` now (fires right
@@ -4146,11 +4295,19 @@ EOF
         # avoid. The OS slots are replaced either way.
         if [ "$KEEP_VAR" != "yes" ]; then
         mkfs.ext4 -F -L state "$STATE"      >> "$INSTALL_LOG" 2>&1
-        # Label the slots distinctly so the boot loader / sysupdate
-        # can pick them by label rather than position. root_a is the
-        # active slot for this install; root_b is empty until 8b's
-        # `spatium-update` writes the next image there.
         fi
+        # Label the slots distinctly. NOT because anything boots by this
+        # label — grub.cfg renders `root=UUID=` and the image-baseline fstab
+        # carries no root entry — but so that `blkid` output, a support
+        # bundle and a human at a console all read honestly. The thing that
+        # actually identifies a slot is its GPT name (`-c4:root_A` /
+        # `-c5:root_B` above), which is what spatium-upgrade-slot matches on
+        # and what survives a slot being overwritten with a filesystem image.
+        #
+        # Both run on the KEEP_VAR path too: the OS slots are replaced either
+        # way, which is also what repairs the #1045 duplicate on a disk
+        # upgraded by an appliance that predates the fix. root_b is empty
+        # until `spatium-upgrade-slot` writes the next image there.
         mkfs.ext4 -F -L root_a "$ROOT_A"    >> "$INSTALL_LOG" 2>&1
         mkfs.ext4 -F -L root_b "$ROOT_B"    >> "$INSTALL_LOG" 2>&1
         if [ "$KEEP_VAR" != "yes" ]; then

--- a/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
@@ -42,8 +42,9 @@ from pathlib import Path
 
 
 # Standard slot locations on a Phase 8a appliance install. These are
-# GPT partition names set by `sgdisk -c3:root_A -c4:root_B` in
-# spatium-install — distinct from the ext4 filesystem labels.
+# GPT partition names set by `sgdisk -c4:root_A -c5:root_B` in
+# spatium-install — distinct from the ext4 filesystem labels, which
+# ``_relabel_slot_filesystem`` below keeps in step with these (#1045).
 SLOT_PARTLABELS = {"root_a", "root_b"}
 
 
@@ -414,12 +415,62 @@ def cmd_apply(args) -> int:
     # filesystem's UUID before reading it so each slot stays unique.
     print(f"  randomising filesystem UUID on {target_dev} (tune2fs -U random)…")
     subprocess.run(["tune2fs", "-U", "random", target_dev], check=False)
-    # udev tag files cache UUIDs; nudge a re-read so the next blkid
-    # call doesn't return the stale baked-in value.
-    subprocess.run(["udevadm", "trigger", "--settle", target_dev], check=False)
+    # ...and the SAME argument applies to the filesystem LABEL, which is
+    # baked to `root_a` for both slots by build-slot-image.sh because it
+    # builds one image for both (#1045). Left alone, slot B comes out of
+    # its first upgrade labelled `root_a` and no partition on the disk
+    # carries `root_b` again, ever.
+    #
+    # Nothing on the boot path notices: grub.cfg renders `root=UUID=` and
+    # fstab has no root entry (only var / state / ESP, none of which a slot
+    # upgrade rewrites). What notices is the INSTALLER — spatium-install's
+    # `_layout_is_reusable` looked for a `root_b` label and silently stopped
+    # offering the #995 "Keep /var" reinstall. That side now matches slots
+    # by PARTLABEL so an already-duplicated disk still works; this is the
+    # fix for the cause rather than the symptom.
+    relabelled = _relabel_slot_filesystem(target_dev, inactive["partlabel"])
+
+    # Repair a disk written before that fix: the ACTIVE slot keeps whatever
+    # label a pre-#1045 upgrade left on it, and only becomes a target on a
+    # later upgrade. Safe to do live — it is one superblock field, on no
+    # boot path, and nothing reads it between here and the reboot; worst
+    # case the kernel's cached superblock wins and the label reverts, which
+    # is exactly the state we are already in. Never fatal for the same
+    # reason.
+    repaired_active = True
+    if active.get("fslabel") and active["fslabel"] != active["partlabel"]:
+        print(
+            f"  repairing active slot's filesystem label "
+            f"({active['fslabel']} → {active['partlabel']}, #1045)…"
+        )
+        repaired_active = _relabel_slot_filesystem(
+            active["device"], active["partlabel"]
+        )
+
+    # udev tag files cache the UUID *and* the LABEL, so one settle covers
+    # every metadata change above — which is why it comes after BOTH
+    # relabels and not just the target's: a stale /dev/disk/by-label link
+    # for the active slot would otherwise survive until the next reboot.
+    for _dev in {target_dev, active["device"]}:
+        subprocess.run(["udevadm", "trigger", "--settle", _dev], check=False)
+
+    # Non-fatal, but not silent either. A label that provably did not stick
+    # is a real consequence the operator can act on — and a warning buried
+    # in a line that is followed by "upgrade complete" is one nobody reads,
+    # which is the #882 reporting lesson.
+    if not relabelled or not repaired_active:
+        print(
+            "  NOTE: a slot filesystem label could not be set (#1045). The "
+            "upgrade itself is unaffected — nothing boots by this label — "
+            "but a later reinstall of this box may not offer to keep /var. "
+            "`tune2fs -L <root_a|root_b> <slot device>` fixes it by hand.",
+            file=sys.stderr,
+        )
 
     # Re-read the partition's now-unique UUID. PARTLABEL is preserved because
-    # it lives in the GPT header, not the filesystem.
+    # it lives in the GPT header, not the filesystem — which is exactly the
+    # reasoning that missed the filesystem LABEL (#1045):
+    # that one IS inside the image, and is set explicitly above.
     new_uuid = _blkid_uuid(target_dev)
     if new_uuid:
         # Refresh our cached view so set-next-boot reflects the new UUID.
@@ -600,6 +651,67 @@ def _parent_disk(part_dev: str) -> str:
     if re.search(r"\dp\d+$", base):  # nvme0n1p5 / mmcblk0p5 / loop0p1
         return "/dev/" + re.sub(r"p\d+$", "", base)
     return "/dev/" + re.sub(r"\d+$", "", base)  # sda5 / vdb3
+
+
+def _relabel_slot_filesystem(device: str, partlabel: str) -> bool:
+    """Set ``device``'s ext4 label to ``partlabel``, its own GPT name (#1045).
+
+    Derived from the PARTLABEL rather than from a literal on purpose: the GPT
+    name is what genuinely identifies a slot, it is what ``find_slot_partitions``
+    already matches on, and it cannot be overwritten by a ``dd`` of a
+    filesystem image — which is the whole reason the filesystem label drifts.
+
+    Never fatal. The label is on no boot path (``root=UUID=`` on the kernel
+    cmdline, and fstab carries no root entry), and spatium-install matches the
+    slots by PARTLABEL, so a failure here costs nothing that is not already
+    the status quo. Returns whether the label now reads as intended.
+    """
+    if not device or partlabel not in SLOT_PARTLABELS:
+        return False
+    print(f"  labelling {device} filesystem '{partlabel}' (tune2fs -L)…")
+    proc = subprocess.run(
+        ["tune2fs", "-L", partlabel, device],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        # stderr, not stdout: tune2fs reports a refusal there, and an
+        # unexplained "label not applied" is the thing that wastes an hour.
+        print(
+            f"  WARNING: could not label {device} '{partlabel}' "
+            f"(rc={proc.returncode}): {(proc.stderr or proc.stdout).strip()}",
+            file=sys.stderr,
+        )
+        return False
+    # Read it back off the device. On a MOUNTED filesystem tune2fs goes
+    # through FS_IOC_SETFSLABEL and the kernel owns the write, so this is
+    # also the only thing that distinguishes "applied" from "accepted and
+    # silently dropped".
+    actual = _blkid_label(device)
+    if actual != partlabel:
+        print(
+            f"  WARNING: {device} still reads LABEL={actual or '(none)'} "
+            f"after labelling it '{partlabel}'",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def _blkid_label(device: str) -> str | None:
+    """Return the filesystem LABEL of the given block device, or None.
+
+    ``-p`` bypasses blkid's cache: the cache is exactly what is stale right
+    after a ``dd`` plus a relabel, and reading it would report the value we
+    are trying to verify has changed.
+    """
+    try:
+        proc = subprocess.run(
+            ["blkid", "-p", "-s", "LABEL", "-o", "value", device],
+            capture_output=True, text=True, check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    return proc.stdout.strip() or None
 
 
 def _blkid_uuid(device: str) -> str | None:

--- a/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
@@ -437,11 +437,17 @@ def cmd_apply(args) -> int:
     # case the kernel's cached superblock wins and the label reverts, which
     # is exactly the state we are already in. Never fatal for the same
     # reason.
+    # The condition is the disagreement alone. An earlier draft required a
+    # truthy fslabel first, which skipped the repair on a slot carrying NO
+    # label at all — and "no label" is a missing label, the very thing being
+    # repaired, not a value to be cautious about. find_slot_partitions always
+    # sets the key (to "" when blkid reports none), so there is no third
+    # "unknown" state to protect here.
     repaired_active = True
-    if active.get("fslabel") and active["fslabel"] != active["partlabel"]:
+    if active["fslabel"] != active["partlabel"]:
         print(
             f"  repairing active slot's filesystem label "
-            f"({active['fslabel']} → {active['partlabel']}, #1045)…"
+            f"({active['fslabel'] or '(none)'} → {active['partlabel']}, #1045)…"
         )
         repaired_active = _relabel_slot_filesystem(
             active["device"], active["partlabel"]

--- a/appliance/tests/test_install_phase45_storage_polish.py
+++ b/appliance/tests/test_install_phase45_storage_polish.py
@@ -18,6 +18,8 @@ HOW TO RUN (from the repo root):
 
 from __future__ import annotations
 
+import re
+
 from _installer_source import CODE, extract_fn
 
 # ── Items 23 + 24 — the trap ──────────────────────────────────────────
@@ -67,11 +69,29 @@ def test_reinstall_keeping_var_is_offered_only_on_a_reusable_layout():
     assert "_existing_install_version" in fn
 
 
-def test_the_layout_check_goes_by_label_not_partition_number():
+def test_the_layout_check_goes_by_identity_not_partition_number():
+    """All five parts of the layout are found by identity, so a disk
+    carrying them at other indices is still reusable.
+
+    ``assert "LABEL" in fn`` was the original form, and by #1045 the only
+    uppercase ``LABEL`` left in the function was in its own comments — so
+    the guard passed on prose while the code it describes had changed
+    underneath it. It now asserts on the calls, and on there being no
+    partition NUMBER, which is the property the name claims.
+    """
     fn = extract_fn("_layout_is_reusable")
-    assert "LABEL" in fn
-    for label in ("ESP", "state", "root_a", "root_b", "var"):
-        assert label in fn, label
+    code = "\n".join(ln.split("#", 1)[0] for ln in fn.splitlines())
+    for part in ("ESP", "state", "var"):
+        assert part in code, part
+    # ESP / state / var by filesystem label; the two OS slots by GPT name,
+    # which a slot upgrade cannot overwrite (#1045).
+    assert "_labelled_device_on" in code
+    for slot in ("root_a", "root_b"):
+        assert slot in code, slot
+    assert "_slot_device_on" in code
+    assert not re.search(r"\$\{?dev\}?[0-9]|partition_node", code), (
+        "the check must not reach for a partition number"
+    )
 
 
 def test_keeping_var_skips_the_partition_table_and_the_two_filesystems():

--- a/appliance/tests/test_slot_filesystem_labels.py
+++ b/appliance/tests/test_slot_filesystem_labels.py
@@ -1,0 +1,608 @@
+"""The two OS slots never share a filesystem label (#1045).
+
+``build-slot-image.sh`` builds ONE image for both slots and bakes
+``mkfs.ext4 -L root_a`` into it, so every slot upgrade writes ``root_a``
+onto whichever slot it targets. ``spatium-upgrade-slot`` already knew the
+baked-in filesystem identity was wrong for the target and fixed half of
+it — ``tune2fs -U random``, because a duplicate UUID wedges slot
+detection — and left the label alone, with a comment ("PARTLABEL is
+preserved because it lives in the GPT header, not the filesystem") that
+shows it was never considered.
+
+So slot B came out of its first upgrade labelled ``root_a`` and NO
+partition on the disk carried ``root_b`` again, ever. Nothing on the boot
+path noticed (``root=UUID=`` on the cmdline, and the image-baseline fstab
+has no root entry), which is why it survived releases. What noticed was
+the INSTALLER: ``_layout_is_reusable`` required a ``root_b`` label, so the
+#995 item 25 "Keep /var" reinstall stopped being offered — silently, and
+indistinguishably from "this disk is not ours" — on exactly the
+long-lived appliances most likely to want it.
+
+Two halves, and they are tested separately because they fail separately:
+
+* ``spatium-upgrade-slot`` labels the target from its own GPT name, so no
+  NEW disk drifts. Executed, not grepped: the point is that the label is
+  read back off the device afterwards, since on a mounted filesystem
+  ``tune2fs`` goes through ``FS_IOC_SETFSLABEL`` and "accepted" is not
+  the same as "applied".
+* ``spatium-install`` matches the two slots by GPT name, so disks ALREADY
+  written by an older appliance keep working. That is the half that
+  repairs the fleet, and it has to be tested against a duplicated-label
+  fixture, because a correct installer and a correct upgrade script both
+  pass on a freshly installed disk.
+
+HOW TO RUN (from the repo root):
+    python3 -m pytest appliance/tests/test_slot_filesystem_labels.py -v
+
+No root, no partitions, no appliance.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import shutil
+import subprocess
+import textwrap
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+from _installer_source import BIN, CODE, SRC as INSTALL_SRC, extract_fn as _extract
+
+SLOT_CLI = BIN / "spatium-upgrade-slot"
+SLOT_SRC = SLOT_CLI.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def slot_cli():
+    loader = SourceFileLoader("spatium_upgrade_slot_labels", str(SLOT_CLI))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def _needs_bash():
+    if not shutil.which("bash"):
+        pytest.skip("bash not available")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# spatium-upgrade-slot — the relabel itself
+# ══════════════════════════════════════════════════════════════════════
+
+
+def _record(slot_cli, monkeypatch, *, label_after: str | None, tune2fs_rc: int = 0):
+    """Stub tune2fs + blkid; return the list of argv lists attempted."""
+    calls: list[list[str]] = []
+
+    def _fake_run(argv, **kw):
+        calls.append(list(argv))
+        if argv[0] == "tune2fs":
+            return subprocess.CompletedProcess(argv, tune2fs_rc, "", "tune2fs: nope")
+        if argv[0] == "blkid":
+            if label_after is None:
+                raise subprocess.CalledProcessError(2, argv)
+            return subprocess.CompletedProcess(argv, 0, label_after + "\n", "")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(slot_cli.subprocess, "run", _fake_run)
+    return calls
+
+
+def test_the_target_is_labelled_from_its_own_gpt_name(slot_cli, monkeypatch) -> None:
+    calls = _record(slot_cli, monkeypatch, label_after="root_b")
+    assert slot_cli._relabel_slot_filesystem("/dev/vda5", "root_b") is True
+    assert ["tune2fs", "-L", "root_b", "/dev/vda5"] in calls
+
+
+def test_a_label_that_did_not_stick_is_reported_not_assumed(
+    slot_cli, monkeypatch, capsys
+) -> None:
+    """The whole reason the label is read back. ``tune2fs`` exiting 0 on a
+    MOUNTED filesystem means the ioctl was accepted; it does not mean the
+    kernel's cached superblock will not win."""
+    _record(slot_cli, monkeypatch, label_after="root_a")
+    assert slot_cli._relabel_slot_filesystem("/dev/vda5", "root_b") is False
+    assert "still reads LABEL=root_a" in capsys.readouterr().err
+
+
+def test_a_tune2fs_refusal_is_reported_with_its_own_stderr(
+    slot_cli, monkeypatch, capsys
+) -> None:
+    _record(slot_cli, monkeypatch, label_after=None, tune2fs_rc=1)
+    assert slot_cli._relabel_slot_filesystem("/dev/vda5", "root_b") is False
+    err = capsys.readouterr().err
+    assert "could not label" in err and "tune2fs: nope" in err
+
+
+@pytest.mark.parametrize("bad", ["", "var", "root_c", "ROOT_B"])
+def test_only_the_two_slot_names_are_ever_written(slot_cli, monkeypatch, bad) -> None:
+    """The value comes from a GPT name read off the disk. An unexpected one
+    is not a label to write — ``mkfs -L`` on the wrong filesystem is how
+    the #999 mirror path describes losing a /var."""
+    calls = _record(slot_cli, monkeypatch, label_after=bad)
+    assert slot_cli._relabel_slot_filesystem("/dev/vda5", bad) is False
+    assert not any(c[0] == "tune2fs" for c in calls)
+
+
+def test_an_empty_device_writes_nothing(slot_cli, monkeypatch) -> None:
+    calls = _record(slot_cli, monkeypatch, label_after="root_b")
+    assert slot_cli._relabel_slot_filesystem("", "root_b") is False
+    assert not any(c[0] == "tune2fs" for c in calls)
+
+
+def test_the_readback_bypasses_blkids_cache(slot_cli, monkeypatch) -> None:
+    """The cache is stale by construction here — a ``dd`` plus a relabel is
+    exactly the sequence that invalidates it, so reading it would confirm
+    the value we are checking has changed."""
+    calls = _record(slot_cli, monkeypatch, label_after="root_b")
+    slot_cli._relabel_slot_filesystem("/dev/vda5", "root_b")
+    blkid = next(c for c in calls if c[0] == "blkid")
+    assert "-p" in blkid
+
+
+# ── where the relabel sits in cmd_apply ──────────────────────────────
+
+
+def _apply_body() -> str:
+    m = re.search(r"^def cmd_apply\(.*?(?=^def )", SLOT_SRC, re.M | re.S)
+    assert m, "cmd_apply not found"
+    return m.group(0)
+
+
+def test_the_relabel_is_between_the_write_and_the_bootloader() -> None:
+    """Before the ``dd`` there is nothing to label; after the grub render
+    the disk has already been advertised as bootable with the wrong
+    identity. Anchored on the render, not on the ``"bootloader"`` progress
+    label, which is emitted several steps earlier (#1026's lesson).
+    """
+    body = _apply_body()
+    write = body.index('"dd"')
+    relabel = body.index("_relabel_slot_filesystem")
+    render = body.index('"spatium-grub-render"')
+    assert write < relabel < render, (write, relabel, render)
+
+
+def test_the_target_relabel_is_not_conditional() -> None:
+    """Every applied image carries ``root_a``, so the target always needs
+    this — a guard comparing the label to the partlabel first would skip
+    precisely slot A, whose baked label happens to be right, and leave
+    the verification unrun on the one slot that can be checked."""
+    body = _apply_body()
+    call = re.search(
+        r"^(\s*)\w+ = _relabel_slot_filesystem\(target_dev, inactive\[.partlabel.\]\)",
+        body,
+        re.M,
+    )
+    assert call, body[body.index("_relabel_slot_filesystem") - 400 :][:600]
+    assert len(call.group(1)) == 4, "the target relabel must not sit inside an if"
+
+
+def test_the_active_slot_is_repaired_only_when_it_disagrees() -> None:
+    """The repair for disks written before this fix. Conditional on
+    purpose — relabelling a live root that is already correct is a
+    superblock write for nothing."""
+    body = _apply_body()
+    assert re.search(
+        r'if active\.get\("fslabel"\) and active\["fslabel"\] != active\["partlabel"\]:',
+        body,
+    ), "the active-slot repair must be gated on an actual disagreement"
+
+
+def test_the_stale_sgdisk_indices_in_the_comment_are_fixed() -> None:
+    """The comment named ``-c3:root_A -c4:root_B``; the installer writes
+    ``-c4:`` and ``-c5:``. Wrong prose about which partition is which is
+    how somebody reaches for the wrong one at 03:00."""
+    assert "-c3:root_A" not in SLOT_SRC
+    assert "sgdisk -c4:root_A -c5:root_B" in SLOT_SRC
+    assert "-c4:root_A" in INSTALL_SRC and "-c5:root_B" in INSTALL_SRC
+
+
+# ══════════════════════════════════════════════════════════════════════
+# spatium-install — the half that repairs an already-duplicated disk
+# ══════════════════════════════════════════════════════════════════════
+
+#: A disk in the post-upgrade state #1042 reported: the GPT names are
+#: intact, and BOTH slots' filesystems say ``root_a``.
+DUPLICATED = {
+    "vda": [
+        ("vda1", "", ""),
+        ("vda2", "ESP", "ESP"),
+        ("vda3", "STATE", "state"),
+        ("vda4", "root_A", "root_a"),
+        ("vda5", "root_B", "root_a"),   # ← the bug
+        ("vda6", "VAR", "var"),
+    ],
+}
+#: The same disk as a fresh install leaves it.
+PRISTINE = {
+    "vda": [
+        ("vda1", "", ""),
+        ("vda2", "ESP", "ESP"),
+        ("vda3", "STATE", "state"),
+        ("vda4", "root_A", "root_a"),
+        ("vda5", "root_B", "root_b"),
+        ("vda6", "VAR", "var"),
+    ],
+}
+#: A #999 mirror: the member partitions carry GPT names and raid
+#: superblocks, and the ext4 labels live on the md devices, which are not
+#: partitions and so have no GPT name at all.
+MIRRORED = {
+    "vda": [
+        ("vda1", "", ""),
+        ("vda2", "ESP", "ESP"),
+        ("vda3", "STATE", ""),
+        ("vda4", "root_A", ""),
+        ("vda5", "root_B", ""),
+        ("vda6", "VAR", ""),
+        ("md125", "", "state"),
+        ("md126", "", "root_a"),
+        ("md127", "", "root_b"),
+        ("md124", "", "var"),
+    ],
+}
+
+
+def _lsblk_stub(d: Path, topology: dict) -> None:
+    """``lsblk -nro <COL> <dev>``: a disk lists its children, a single
+    partition answers for itself. Mirrors the real tool closely enough
+    that the functions under test are exercised rather than a fiction —
+    `-nro NAME <disk>` includes the disk itself as the first row, which
+    is why every caller pipes through ``tail -n +2``.
+    """
+    cases = []
+    for disk, parts in topology.items():
+        names = [disk] + [p[0] for p in parts]
+        cases.append(f'    /dev/{disk}) col_NAME="{" ".join(names)}" ;;')
+        for name, partlabel, label in parts:
+            cases.append(
+                f'    /dev/{name}) col_NAME="{name}"; '
+                f'col_PARTLABEL="{partlabel}"; col_LABEL="{label}" ;;'
+            )
+    body = "\n".join(cases)
+    (d / "lsblk").write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/sh
+            # argv: -nro COL DEV
+            col="$2"; dev="$3"
+            col_NAME=""; col_PARTLABEL=""; col_LABEL=""
+            case "$dev" in
+            {body}
+                *) exit 1 ;;
+            esac
+            eval "printf '%s\\n' \\$col_$col" | tr ' ' '\\n' | sed '/^$/d'
+            """
+        )
+    )
+    (d / "lsblk").chmod(0o755)
+
+
+def _run_fn(tmp_path: Path, topology: dict, fns: list[str], call: str, extra: str = ""):
+    d = tmp_path / "stub"
+    d.mkdir(exist_ok=True)
+    _lsblk_stub(d, topology)
+    script = tmp_path / "run.sh"
+    script.write_text(
+        "set -uo pipefail\n"
+        'log() { echo "LOG: $*" >&2; }\n'
+        + extra
+        + "\n"
+        + "\n".join(_extract(f) for f in fns)
+        + f"\n{call}\n"
+    )
+    return subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env={"PATH": f"{d}:/usr/bin:/bin:/usr/sbin:/sbin"},
+    )
+
+
+# ── _slot_candidates_on / _slot_device_on ────────────────────────────
+
+
+def test_the_two_slots_resolve_to_different_partitions_when_labels_collide(tmp_path):
+    """The property the whole fix rests on. Both filesystems say
+    ``root_a``; the GPT names still say which is which."""
+    fns = ["_labelled_device_on", "_slot_candidates_on", "_slot_device_on"]
+    a = _run_fn(tmp_path, DUPLICATED, fns, '_slot_device_on "/dev/vda" root_a')
+    b = _run_fn(tmp_path, DUPLICATED, fns, '_slot_device_on "/dev/vda" root_b')
+    assert a.stdout.strip() == "/dev/vda4", a.stderr
+    assert b.stdout.strip() == "/dev/vda5", b.stderr
+
+
+def test_a_pristine_disk_resolves_the_same_way(tmp_path):
+    """Control: the fix must not move the answer on a disk that was never
+    upgraded, or every fresh install is the regression."""
+    fns = ["_labelled_device_on", "_slot_candidates_on", "_slot_device_on"]
+    a = _run_fn(tmp_path, PRISTINE, fns, '_slot_device_on "/dev/vda" root_a')
+    b = _run_fn(tmp_path, PRISTINE, fns, '_slot_device_on "/dev/vda" root_b')
+    assert a.stdout.strip() == "/dev/vda4"
+    assert b.stdout.strip() == "/dev/vda5"
+
+
+def test_a_mirror_resolves_to_the_md_device_via_the_filesystem_label(tmp_path):
+    """An md device is not a partition, so it has no GPT name. Dropping
+    the label fallback would make the #999 mirror unreadable — and the
+    picker would report ``unknown version`` for a perfectly good install.
+    """
+    fns = ["_labelled_device_on", "_slot_candidates_on", "_slot_device_on"]
+    out = _run_fn(
+        tmp_path, MIRRORED, fns, '_slot_candidates_on "/dev/vda" root_b'
+    ).stdout.split()
+    assert "/dev/md127" in out
+    # The raid MEMBER carries the GPT name and cannot be mounted as ext4,
+    # so it is listed — first, even — and the caller has to keep looking.
+    assert out.index("/dev/vda5") < out.index("/dev/md127")
+
+
+def test_a_candidate_is_never_listed_twice(tmp_path):
+    """A caller that stops at the first hit would otherwise look like it
+    tried two devices when it tried one."""
+    fns = ["_labelled_device_on", "_slot_candidates_on"]
+    out = _run_fn(
+        tmp_path, PRISTINE, fns, '_slot_candidates_on "/dev/vda" root_a'
+    ).stdout.split()
+    assert out == ["/dev/vda4"], out
+
+
+def test_a_foreign_disk_yields_no_slots(tmp_path):
+    topology = {"vdb": [("vdb1", "", "backups")]}
+    fns = ["_labelled_device_on", "_slot_candidates_on", "_slot_device_on"]
+    r = _run_fn(tmp_path, topology, fns, '_slot_device_on "/dev/vdb" root_a')
+    assert r.returncode != 0 and r.stdout.strip() == ""
+
+
+# ── _labelled_device_on is scoped to one disk ────────────────────────
+
+
+def test_a_label_is_resolved_on_the_named_disk_only(tmp_path):
+    """``blkid -L var`` searched every disk on the machine. With a second
+    SpatiumDDI disk attached that answers with the wrong one — and on the
+    KEEP_VAR path the installer then mkfs'd a /var the operator never
+    picked.
+    """
+    topology = {
+        "vda": PRISTINE["vda"],
+        "vdb": [("vdb1", "VAR", "var")],
+    }
+    fns = ["_labelled_device_on"]
+    assert (
+        _run_fn(tmp_path, topology, fns, '_labelled_device_on "/dev/vda" var').stdout
+        == "/dev/vda6"
+    )
+    assert (
+        _run_fn(tmp_path, topology, fns, '_labelled_device_on "/dev/vdb" var').stdout
+        == "/dev/vdb1"
+    )
+
+
+def test_the_keep_var_resolution_no_longer_uses_blkid_L() -> None:
+    """Structural, because the block lives inside ``do_install`` and cannot
+    be extracted: a single surviving ``blkid -L`` there would reintroduce
+    the cross-disk hazard for whichever label kept it.
+
+    Scoped to that block rather than to the whole script, because the
+    preseed scan's ``blkid -L CIDATA`` is machine-wide ON PURPOSE — a
+    NoCloud volume is handed to the installer on whatever device the
+    operator attached, and there is no target disk to scope it to yet.
+    """
+    # Anchored on its own `local` line: there is a second, unrelated
+    # `if [ "$KEEP_VAR" = "yes" ]` in pick_disk that suppresses the mirror
+    # offer, and it appears first.
+    block = re.search(
+        r'if \[ "\$KEEP_VAR" = "yes" \]; then\n\s+local _l _dev _name.*?\n    fi\n',
+        CODE,
+        re.S,
+    )
+    assert block, "the KEEP_VAR resolution block moved — re-anchor this test"
+    assert "blkid" not in block.group(0)
+    assert "_labelled_device_on" in block.group(0)
+    assert "_slot_device_on" in block.group(0)
+
+
+# ── _layout_is_reusable ──────────────────────────────────────────────
+
+_REUSABLE = ["_labelled_device_on", "_slot_candidates_on", "_slot_device_on",
+             "_layout_is_on_md", "_layout_is_reusable"]
+#: _layout_is_on_md walks /sys; stub it away so these cases are about labels.
+_NOT_MD = "_layout_is_on_md() { return 1; }\n"
+
+
+def _reusable(tmp_path: Path, topology: dict, disk: str = "/dev/vda"):
+    fns = [f for f in _REUSABLE if f != "_layout_is_on_md"]
+    return _run_fn(tmp_path, topology, fns, f'_layout_is_reusable "{disk}"',
+                   extra=_NOT_MD)
+
+
+def test_an_upgraded_disk_is_still_reusable(tmp_path):
+    """THE regression. This disk has no ``root_b`` filesystem label, and
+    the old five-label loop therefore refused it — withdrawing the "Keep
+    /var" offer and silently erasing the database of anyone who
+    reinstalled a box that had ever taken an upgrade."""
+    assert _reusable(tmp_path, DUPLICATED).returncode == 0
+
+
+def test_a_pristine_disk_is_reusable(tmp_path):
+    assert _reusable(tmp_path, PRISTINE).returncode == 0
+
+
+def test_a_disk_missing_a_slot_entirely_is_not_reusable(tmp_path):
+    """The refusal still has to work, or this stops being a gate. Slot B
+    is gone from the TABLE here, not merely mislabelled."""
+    topology = {"vda": [p for p in PRISTINE["vda"] if p[0] != "vda5"]}
+    r = _reusable(tmp_path, topology)
+    assert r.returncode == 1
+    assert "no OS slot 'root_b'" in r.stderr
+
+
+def test_a_disk_missing_var_is_not_reusable(tmp_path):
+    topology = {"vda": [p for p in PRISTINE["vda"] if p[0] != "vda6"]}
+    r = _reusable(tmp_path, topology)
+    assert r.returncode == 1
+    assert "no partition labelled 'var'" in r.stderr
+
+
+def test_an_asymmetric_disk_is_refused_at_the_offer_not_at_the_wipe(tmp_path):
+    """One GPT name present and the other slot identified only by a
+    filesystem label resolves BOTH slots to the same device. do_install
+    refuses that — but it refuses minutes later, after the operator has
+    answered hostname, admin account, network and timezone. The refusal has
+    to be where the offer is made.
+    """
+    topology = {
+        "vda": [
+            ("vda1", "", ""),
+            ("vda2", "ESP", "ESP"),
+            ("vda3", "STATE", "state"),
+            # Slot A lost both its GPT name and its label; slot B kept its
+            # GPT name and carries the baked-in `root_a` from an upgrade. So
+            # vda5 is the only candidate for EITHER slot.
+            ("vda4", "", ""),
+            ("vda5", "root_B", "root_a"),
+            ("vda6", "VAR", "var"),
+        ],
+    }
+    r = _reusable(tmp_path, topology)
+    assert r.returncode == 1
+    assert "both OS slots resolve to" in r.stderr, r.stderr
+
+
+def test_do_install_still_carries_the_same_refusal() -> None:
+    """Belt and braces, and they are not redundant: preseeded installs set
+    KEEP_VAR without going through pick_disk at all."""
+    block = re.search(
+        r'if \[ "\$KEEP_VAR" = "yes" \]; then\n\s+local _l _dev _name.*?\n    fi\n',
+        CODE,
+        re.S,
+    )
+    assert block and '[ "$ROOT_A" = "$ROOT_B" ]' in block.group(0)
+
+
+def test_a_duplicated_disk_is_never_mounted_twice(tmp_path):
+    """Slot B answers to both names on a #1045 disk, so the candidate lists
+    overlap. Each `timeout 10 mount` is a 10 s stall in the enumeration that
+    runs before the operator has picked anything — paying it twice for one
+    device is the bound quietly tripling.
+    """
+    mounts = _existing_mount_log(
+        tmp_path, DUPLICATED, {"/dev/vda4": "", "/dev/vda5": ""}
+    )
+    assert sorted(mounts) == ["/dev/vda4", "/dev/vda5"], mounts
+
+
+def test_every_refusal_says_what_was_missing(tmp_path):
+    """Each ``return 1`` used to be bare, so "a label is missing" and
+    "this disk is not ours" produced identical output — which is how
+    #1045 went unnoticed through a release."""
+    for drop in ("vda2", "vda3", "vda5", "vda6"):
+        topology = {"vda": [p for p in PRISTINE["vda"] if p[0] != drop]}
+        r = _reusable(tmp_path, topology)
+        assert r.returncode == 1, drop
+        assert "not reusable" in r.stderr, (drop, r.stderr)
+
+
+# ── _existing_install_version ────────────────────────────────────────
+
+_EXISTING = ["_labelled_device_on", "_slot_candidates_on", "_existing_install_version"]
+
+
+def _existing(tmp_path: Path, topology: dict, releases: dict[str, str | None]):
+    """``releases`` maps device → appliance-release body, or None for a
+    partition that will not mount."""
+    d = tmp_path / "stub"
+    d.mkdir(exist_ok=True)
+    roots = tmp_path / "roots"
+    for dev, body in releases.items():
+        if body is None:
+            continue
+        rel = roots / dev.replace("/", "_") / "etc" / "spatiumddi"
+        rel.mkdir(parents=True, exist_ok=True)
+        (rel / "appliance-release").write_text(body)
+    mountable = " ".join(k for k, v in releases.items() if v is not None)
+    # `mount` copies the staged tree in; `umount` empties it again. Both
+    # are what the function actually calls, so the control flow under test
+    # is the real one rather than a stubbed-out success.
+    (d / "mount").write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/sh
+            for a in "$@"; do last=$a; prev=$before; before=$a; done
+            src=$prev; dst=$last
+            echo "$src" >> {tmp_path}/mount-attempts
+            for m in {mountable}; do
+              if [ "$m" = "$src" ]; then
+                cp -R "{roots}/$(echo "$m" | tr / _)/." "$dst/" 2>/dev/null || true
+                exit 0
+              fi
+            done
+            exit 32
+            """
+        )
+    )
+    (d / "umount").write_text('#!/bin/sh\nrm -rf "$1"/* 2>/dev/null; exit 0\n')
+    (d / "timeout").write_text('#!/bin/sh\nshift; exec "$@"\n')
+    for f in ("mount", "umount", "timeout"):
+        (d / f).chmod(0o755)
+    return _run_fn(
+        tmp_path,
+        topology,
+        _EXISTING,
+        '_existing_install_version "/dev/vda"',
+        extra=_extract("_appliance_version_from") + "\n",
+    )
+
+
+def _existing_mount_log(tmp_path: Path, topology: dict, releases: dict):
+    """Every device ``_existing_install_version`` tried to mount, in order."""
+    _existing(tmp_path, topology, releases)
+    log = tmp_path / "mount-attempts"
+    return log.read_text().split() if log.exists() else []
+
+
+def test_the_version_comes_from_slot_a_when_it_has_one(tmp_path):
+    out = _existing(
+        tmp_path,
+        PRISTINE,
+        {"/dev/vda4": 'APPLIANCE_VERSION="2026.09.04-1"\n', "/dev/vda5": None},
+    )
+    assert out.stdout == "2026.09.04-1", out.stderr
+
+
+def test_slot_b_is_consulted_when_slot_a_carries_no_release(tmp_path):
+    """Slot A mounts and has no release file — which used to short-circuit
+    the whole function to "unknown version" without ever looking at B."""
+    out = _existing(
+        tmp_path,
+        PRISTINE,
+        {"/dev/vda4": "", "/dev/vda5": 'APPLIANCE_VERSION="2026.09.04-1"\n'},
+    )
+    assert out.stdout == "2026.09.04-1", out.stderr
+
+
+def test_a_mirror_reports_its_version_from_the_md_device(tmp_path):
+    """The raid member is tried first and will not mount; the array does.
+    Giving up after one candidate would report ``unknown version`` for
+    every mirrored install."""
+    out = _existing(
+        tmp_path,
+        MIRRORED,
+        {"/dev/md126": 'APPLIANCE_VERSION="2026.09.04-1"\n'},
+    )
+    assert out.stdout == "2026.09.04-1", out.stderr
+
+
+def test_a_slot_that_says_nothing_is_still_an_install(tmp_path):
+    out = _existing(tmp_path, PRISTINE, {"/dev/vda4": "", "/dev/vda5": ""})
+    assert out.stdout == "unknown version", out.stderr
+
+
+def test_a_disk_with_no_slots_reports_nothing(tmp_path):
+    out = _existing(tmp_path, {"vdb": [("vdb1", "", "backups")]}, {})
+    assert out.stdout == "", out.stderr

--- a/appliance/tests/test_slot_filesystem_labels.py
+++ b/appliance/tests/test_slot_filesystem_labels.py
@@ -188,9 +188,22 @@ def test_the_active_slot_is_repaired_only_when_it_disagrees() -> None:
     superblock write for nothing."""
     body = _apply_body()
     assert re.search(
-        r'if active\.get\("fslabel"\) and active\["fslabel"\] != active\["partlabel"\]:',
-        body,
+        r'if active\["fslabel"\] != active\["partlabel"\]:', body
     ), "the active-slot repair must be gated on an actual disagreement"
+
+
+def test_an_unlabelled_active_slot_is_still_repaired() -> None:
+    """``active.get("fslabel") and …`` was the first draft, and it skipped
+    the repair on a slot carrying NO label — which is a missing label, i.e.
+    the thing being repaired, not a value to be careful about.
+    ``find_slot_partitions`` always sets the key, so there is no third
+    "unknown" state the truthiness check could have been protecting.
+    """
+    body = _apply_body()
+    assert 'active.get("fslabel") and' not in body
+    # And the message has to survive an empty value rather than printing
+    # "( → root_a)".
+    assert "active['fslabel'] or '(none)'" in body
 
 
 def test_the_stale_sgdisk_indices_in_the_comment_are_fixed() -> None:


### PR DESCRIPTION
Closes #1045

## The bug

`build-slot-image.sh:136` builds **one** image for both slots and bakes `mkfs.ext4 -F -L root_a` into it, so every slot upgrade wrote `root_a` onto whichever slot it targeted.

`spatium-upgrade-slot` already knew the baked-in filesystem identity was wrong for the target and fixed *half* of it — `tune2fs -U random`, because a duplicate UUID wedges slot detection — and left the label alone, under a comment that shows it was never considered:

```python
# Re-read the partition's now-unique UUID. PARTLABEL is preserved because
# it lives in the GPT header, not the filesystem.
```

PARTLABEL *is* preserved. The filesystem label is not. So slot B came out of its first upgrade labelled `root_a`, and **no partition on the disk carried `root_b` again, ever** — the node boots A and upgrades B, then boots B and upgrades A, which was already `root_a`.

## Why nothing noticed

Boot does not use these labels: `spatium-grub-render` emits `root=UUID=`, and the image-baseline fstab carries no root entry — only `var` / `state` / `ESP`, none of which a slot upgrade rewrites. An upgraded appliance boots, upgrades again and serves indefinitely with the duplicate in place.

What noticed was the **installer**. `_layout_is_reusable` required all five labels:

```sh
for want in ESP state root_a root_b var; do
```

`root_b` does not exist on an upgraded disk, so it returned 1 and the #995 item 25 "Keep /var" reinstall was never offered — the operator got a full wipe, losing `/var`, with no message explaining why, because every `return 1` in that function was bare and so indistinguishable from "this disk is not ours".

**Proven against the shipped script, not argued.** Running `main`'s own `_layout_is_reusable` against the post-upgrade layout #1042 reported:

```
MAIN _layout_is_reusable on an UPGRADED disk -> rc=1  (REFUSED — the bug reproduces)
   stderr: (silent — indistinguishable from a foreign disk)
MAIN _layout_is_reusable on a PRISTINE disk  -> rc=0  (control)
MAIN _existing_install_version, slot A blank + slot B 2026.09.04-1 -> 'unknown version'
```

## The fix — two halves, because they fail separately

**`spatium-upgrade-slot`** labels the target from its own GPT name, beside the UUID randomisation that already existed for the other half of the same problem. Derived from the PARTLABEL rather than a literal: the GPT name is what genuinely identifies a slot, is what `find_slot_partitions` already matches on, and is the one thing a `dd` of a filesystem image cannot overwrite. The label is **read back off the device** afterwards — on a mounted filesystem `tune2fs` goes through `FS_IOC_SETFSLABEL`, and "accepted" is not "applied". A pre-#1045 disk's *active* slot is repaired on its next upgrade too; never fatal, since the label is on no boot path.

**`spatium-install`** matches the two OS slots by GPT name. This is the half that repairs the field fleet — a disk written by an older appliance keeps working with nobody touching it. `ESP` / `state` / `var` deliberately keep the filesystem label as their identity, because that is what fstab resolves them by, so the split is per-partition-role rather than wholesale. The `#999` mirror keeps a filesystem-label fallback: an md device is not a partition and has no GPT name at all.

## Two more found on the way

- The KEEP_VAR reinstall resolved all five devices with `blkid -L`, which searches **every disk on the machine** — with a second SpatiumDDI disk attached it could answer with the wrong one and `mkfs` a `/var` the operator never picked. Now scoped to the target disk, with an assertion that the two slots are two different partitions.
- `_existing_install_version` gave up after the first slot it could mount, so a slot that mounts with no release file short-circuited the whole function to `unknown version` — the state slot B is in on every freshly installed appliance, and why a `#999` mirror reported `unknown version` for a perfectly good install (the raid member is tried first and cannot be mounted as ext4).

## /code-review — five findings, all fixed

Two were about guards rather than code:

1. **`_layout_is_reusable` had no distinctness check**, so a disk whose two slots resolve to the same device was offered "Keep /var", the operator answered four more screens, and the install aborted at the wipe. The refusal now lives where the offer is made *and* in `do_install` — not redundant, since a preseeded install sets `KEEP_VAR` without going through the picker.
2. **`_existing_install_version` mounted slot B twice** on a duplicated disk (it answers to both names), tripling the 10 s stall that bound exists to cap, in the enumeration that runs *before* the operator has picked anything.
3. **The active-slot repair ran after the one `udevadm trigger --settle`**, so its `by-label` link stayed stale until reboot while a comment claimed one settle covered both; and **`_relabel_slot_filesystem`'s verification result was discarded at both call sites**, so a label that provably did not stick produced one stderr line and an apply that still reported success. It now names the consequence and the one-line manual fix.
4. **The `#999` md-gate's justification described a hazard that no longer exists and whose direction has inverted** — on a mirror only the live raid *members* carry a GPT name, so without that gate the mkfs would land on a disk the array is still using.
5. **`_layout_is_reusable`'s header still asserted the premise this issue disproves** — and that mattered more than prose usually does: `test_the_layout_check_goes_by_label_not_partition_number` asserted `"LABEL" in fn`, and the only uppercase `LABEL` left in the function was in that comment. The guard was passing on the explanation while the code it describes had changed underneath it. Rewritten to assert on the calls.

## Testing

- **33 new appliance tests** in `appliance/tests/test_slot_filesystem_labels.py`, plus the rewritten guard. Every one run against the unpatched scripts first: **all 33 fail on `main`**, and the rewritten guard fails there while its 19 neighbours still pass.
- The installer half is **executed**, not grepped — `lsblk` is stubbed and the real functions are extracted and run against three fixtures: a pristine disk, the duplicated post-upgrade disk #1042 reported, and a `#999` mirror.
- Full appliance suite: **88 failures before and after**, identical sets — the known macOS-environmental baseline, no regressions.
- `lint_workflow_shell.py` and `lint_versions.py` both clean.

No migration, no API change, no new endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)