### PR TITLE
fix(appliance): reclaim the CNPG instance claim a dead-node replace strands on the deleted node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1280,6 +1280,30 @@ the formatter handles the rest.
 ### Fixed
 
 
+- **A replaced control-plane member's Postgres instance now comes
+  back (#1058).** After a dead-node replace — the dead member evicted,
+  a replacement paired and promoted under a new hostname — the
+  CloudNativePG instance that lived on the dead node never returned:
+  its claim stayed `Bound` to a local-path volume whose node affinity
+  named the deleted node, the operator re-created the pod against that
+  same claim, and it sat `Pending` ("0/3 nodes are available: 3
+  node(s) didn't match PersistentVolume's node affinity") for good.
+  Postgres ran 2 of 3, the replacement never hosted an instance, and
+  `cluster/health` still reported the control plane HA. Observed live
+  on a nested three-node cluster 77 minutes after the replacement had
+  joined. The seed's eviction path already reclaimed the dead node's
+  Redis claim for the same reason (#590) and left CNPG's alone on the
+  premise that the operator manages its own — it does not. The seed
+  now reclaims a CNPG instance claim whose volume is pinned to a
+  hostname no Node carries (the claim, then the Pending pod — the
+  chart README's manual repair, done by the appliance itself), and
+  CNPG joins a fresh replica from the primary on a live node. Only a
+  replica's claim is ever touched: an instance the Cluster still names
+  as its current or target primary is deferred to the next heartbeat,
+  by which time the operator has failed over. Runs on every seed
+  heartbeat, so a deferred primary and a supervisor restart both
+  converge; one Cluster read per tick while Postgres is whole.
+
 - **Both OS slots ended up labelled `root_a` after an A/B upgrade, and
   the #995 "Keep /var" reinstall silently stopped being offered
   (#1045).** `build-slot-image.sh` builds ONE image for both slots and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1297,12 +1297,21 @@ the formatter handles the rest.
   now reclaims a CNPG instance claim whose volume is pinned to a
   hostname no Node carries (the claim, then the Pending pod — the
   chart README's manual repair, done by the appliance itself), and
-  CNPG joins a fresh replica from the primary on a live node. Only a
+  CNPG joins a fresh replica from the primary on a live node. The
+  node's own volume affinity is what decides "pinned" — the
+  supervisor's ClusterRole gains the `persistentvolumes: get` that
+  read needs; a forbidden or failing read is surfaced, never guessed
+  around, and the journal line says which read decided. Only a
   replica's claim is ever touched: an instance the Cluster still names
-  as its current or target primary is deferred to the next heartbeat,
-  by which time the operator has failed over. Runs on every seed
-  heartbeat, so a deferred primary and a supervisor restart both
-  converge; one Cluster read per tick while Postgres is whole.
+  as its current or target primary — or any instance while the
+  Cluster names no primary at all — is deferred and retried on the
+  next heartbeat, by which time the operator has failed over. The
+  names the seed just evicted are authoritative, so a replica's claim
+  goes on the eviction tick itself; a refused pod delete is an error,
+  and a claim still Terminating from an earlier tick is reported as
+  pending, not reclaimed again. Runs on every seed heartbeat, so a
+  deferred primary and a supervisor restart both converge; one
+  Cluster read per tick while Postgres is whole.
 
 - **Both OS slots ended up labelled `root_a` after an A/B upgrade, and
   the #995 "Keep /var" reinstall silently stopped being offered

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -1128,11 +1128,15 @@ def heartbeat_once(
         # tick are handed in as authoritative (the Node DELETE is
         # milliseconds old and the name can still be listed), so a
         # replica's claim goes on the eviction tick itself.
-        global _stranded_pending
         pg = k8s_api.reclaim_stranded_postgres_storage(
             evicted_nodes=set(evicted_now) | _stranded_pending
         )
-        _stranded_pending = _carry_stranded(_stranded_pending, evicted_now, pg)
+        # Mutated in place rather than rebound: the module-level set is the
+        # state, and a ``global`` rebinding reads as a never-read assignment
+        # to a static analyser (it is read on the next tick).
+        owed = _carry_stranded(_stranded_pending, evicted_now, pg)
+        _stranded_pending.clear()
+        _stranded_pending.update(owed)
         pg_reclaimed, pg_deferred, pg_err = pg.reclaimed, pg.deferred, pg.error
         if pg_reclaimed:
             log.info(

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -1110,14 +1110,17 @@ def heartbeat_once(
         # has failed over. Every seed tick, not only the eviction one, so a
         # deferred primary and a supervisor restart both converge; one CR
         # read per tick while Postgres is whole.
-        pg_reclaimed, pg_deferred, pg_err = k8s_api.reclaim_stranded_postgres_storage(
-            evicted_nodes=evicted_now
-        )
+        pg = k8s_api.reclaim_stranded_postgres_storage(evicted_nodes=evicted_now)
+        pg_reclaimed, pg_deferred, pg_err = pg.reclaimed, pg.deferred, pg.error
         if pg_reclaimed:
             log.info(
                 "supervisor.heartbeat.postgres_storage_reclaimed",
                 pvcs=pg_reclaimed,
                 evicted=evicted_now,
+                # which read decided each claim was stranded: the PV's node
+                # affinity ("pv") or the scheduler's selected-node
+                # annotation ("annotation", only when the PV is gone)
+                affinity_source={name: pg.sources.get(name, "") for name in pg_reclaimed},
             )
         if pg_deferred:
             log.info(

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -322,6 +322,21 @@ _last_peer_drift_at: float = 0.0
 # request; pruned once the backend drops the name from its evict list.
 _evicted_pending: set[str] = set()
 
+# #1058 — hostnames whose stranded CNPG claims the reclaim still owes (a
+# deferral: the instance was the primary, or the Cluster named none). Handed
+# back to the sweep as evicted names next tick so it scans past its
+# "Postgres is whole" early-out; cleared by the tick that settles them.
+_stranded_pending: set[str] = set()
+
+
+def _carry_stranded(previous: set[str], evicted_now: list[str], outcome) -> set[str]:
+    """PURE — what the next tick must force: after a clean sweep, exactly
+    what it left owed; after a failed one (kubeapi error), everything that
+    was owed plus this tick's evictions, so an outage never drops a node."""
+    if outcome.error is not None:
+        return set(previous) | {str(n) for n in evicted_now}
+    return set(outcome.pending_nodes)
+
 
 def _watchdog_check_due() -> bool:
     """First call always returns True (forces a probe within the
@@ -1109,8 +1124,15 @@ def heartbeat_once(
         # primary is deferred to the next tick, by which time the operator
         # has failed over. Every seed tick, not only the eviction one, so a
         # deferred primary and a supervisor restart both converge; one CR
-        # read per tick while Postgres is whole.
-        pg = k8s_api.reclaim_stranded_postgres_storage(evicted_nodes=evicted_now)
+        # read per tick while Postgres is whole. The names evicted THIS
+        # tick are handed in as authoritative (the Node DELETE is
+        # milliseconds old and the name can still be listed), so a
+        # replica's claim goes on the eviction tick itself.
+        global _stranded_pending
+        pg = k8s_api.reclaim_stranded_postgres_storage(
+            evicted_nodes=set(evicted_now) | _stranded_pending
+        )
+        _stranded_pending = _carry_stranded(_stranded_pending, evicted_now, pg)
         pg_reclaimed, pg_deferred, pg_err = pg.reclaimed, pg.deferred, pg.error
         if pg_reclaimed:
             log.info(

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -1063,12 +1063,14 @@ def heartbeat_once(
         # backend clears the flag. Prune the stash to whatever the
         # backend still lists as pending (everything else is confirmed).
         evict_names = body_out.get("evict_node_names") or []
+        evicted_now: list[str] = []
         for name in evict_names:
             if name in _evicted_pending:
                 continue
             ok, evict_err = k8s_api.delete_node(str(name))
             if ok:
                 _evicted_pending.add(str(name))
+                evicted_now.append(str(name))
                 log.info("supervisor.heartbeat.node_evicted", node=name)
                 # #590 — the deleted node strands any local-path Redis PVC
                 # provisioned on it (node-affine PV): the replacement
@@ -1096,6 +1098,35 @@ def heartbeat_once(
                     "supervisor.heartbeat.node_evict_failed", node=name, error=evict_err
                 )
         _evicted_pending.intersection_update({str(n) for n in evict_names})
+
+        # #1058 — the deleted Node strands the CloudNativePG instance claim
+        # provisioned on it exactly as it strands Redis's, and the operator
+        # does NOT reclaim it: the re-created pod sits Pending on the dead
+        # node's PV affinity, Postgres runs 2 of 3 for good, and the
+        # replacement member never hosts an instance. Reclaim it the way
+        # the chart README says a human would — the claim, then the pod,
+        # and ONLY a replica's: an instance the Cluster still names as its
+        # primary is deferred to the next tick, by which time the operator
+        # has failed over. Every seed tick, not only the eviction one, so a
+        # deferred primary and a supervisor restart both converge; one CR
+        # read per tick while Postgres is whole.
+        pg_reclaimed, pg_deferred, pg_err = k8s_api.reclaim_stranded_postgres_storage(
+            evicted_nodes=evicted_now
+        )
+        if pg_reclaimed:
+            log.info(
+                "supervisor.heartbeat.postgres_storage_reclaimed",
+                pvcs=pg_reclaimed,
+                evicted=evicted_now,
+            )
+        if pg_deferred:
+            log.info(
+                "supervisor.heartbeat.postgres_storage_reclaim_deferred",
+                instances=pg_deferred,
+                reason="instance is the current or target primary; retrying next tick",
+            )
+        if pg_err:
+            log.warning("supervisor.heartbeat.postgres_storage_reclaim_failed", error=pg_err)
 
         # #590 — cluster DNS must survive a node loss. k3s's bundled
         # CoreDNS is a single replica that deterministically sits on the

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -1150,6 +1150,12 @@ def heartbeat_once(
                 instances=pg_deferred,
                 reason=pg.deferred_reason,
             )
+        if pg.terminating:
+            log.info(
+                "supervisor.heartbeat.postgres_storage_reclaim_pending",
+                pvcs=pg.terminating,
+                reason="deleted on an earlier tick; pvc-protection is waiting for the pod",
+            )
         if pg_err:
             log.warning("supervisor.heartbeat.postgres_storage_reclaim_failed", error=pg_err)
 

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -1126,7 +1126,7 @@ def heartbeat_once(
             log.info(
                 "supervisor.heartbeat.postgres_storage_reclaim_deferred",
                 instances=pg_deferred,
-                reason="instance is the current or target primary; retrying next tick",
+                reason=pg.deferred_reason,
             )
         if pg_err:
             log.warning("supervisor.heartbeat.postgres_storage_reclaim_failed", error=pg_err)

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -667,6 +667,10 @@ class PostgresReclaim:
     # hands them back as ``evicted_nodes`` next tick so the scan runs again
     # even while the Cluster reads whole
     pending_nodes: set[str] = field(default_factory=set)
+    # claims an earlier tick already deleted that are still Terminating
+    # (pvc-protection waits for the consumer pod) — reported as pending,
+    # never counted as reclaimed again
+    terminating: list[str] = field(default_factory=list)
 
     def __iter__(self):
         # ``reclaimed, deferred, err = ...`` keeps working for callers that
@@ -791,11 +795,13 @@ def reclaim_stranded_postgres_storage(
     stranded: dict[str, list[str]] = {}
     sources: dict[str, str] = {}
     pinned_to: dict[str, set[str]] = {}
+    already_terminating: set[str] = set()
     for pvc in items:
         instance = _cnpg_instance_of(pvc, cluster_name)
         if instance is None:
             continue
-        name = str((pvc.get("metadata") or {}).get("name") or "")
+        meta = pvc.get("metadata") or {}
+        name = str(meta.get("name") or "")
         pinned, source, pin_err = _pvc_pinned_hostnames(pvc)
         if pin_err:
             return PostgresReclaim(error=f"{name}: {pin_err}")
@@ -804,9 +810,12 @@ def reclaim_stranded_postgres_storage(
         stranded.setdefault(instance, []).append(name)
         sources[name] = source
         pinned_to.setdefault(instance, set()).update(pinned)
+        if meta.get("deletionTimestamp"):
+            already_terminating.add(name)
 
     reclaimed: list[str] = []
     deferred: list[str] = []
+    terminating: list[str] = []
     deferred_reason = ""
     for instance, claims in sorted(stranded.items()):
         if primary_unknown:
@@ -818,27 +827,48 @@ def reclaim_stranded_postgres_storage(
             deferred_reason = "instance is the current or target primary; retrying next tick"
             continue
         for name in sorted(claims):
+            if name in already_terminating:
+                # Deleted on an earlier tick; pvc-protection is holding it
+                # until its pod is gone. Not ours to count again — the first
+                # cut re-reported it as "reclaimed" every tick for ever
+                # (review, point 4). The pod delete below is what it waits on.
+                terminating.append(name)
+                continue
             try:
                 status, resp = _request(
                     "DELETE", f"{base}/persistentvolumeclaims/{quote(name)}"
                 )
             except RuntimeError as exc:
-                return PostgresReclaim(reclaimed, deferred, str(exc), sources, deferred_reason)
+                return PostgresReclaim(reclaimed, deferred, str(exc), sources,
+                                       deferred_reason, terminating=terminating)
             if status not in (200, 202, 404):
-                return PostgresReclaim(reclaimed, deferred, f"kubeapi status {status}: {resp[:200]!r}", sources, deferred_reason)
-            reclaimed.append(name)
+                return PostgresReclaim(reclaimed, deferred,
+                                       f"kubeapi status {status}: {resp[:200]!r}",
+                                       sources, deferred_reason, terminating=terminating)
+            if status != 404:  # 404: vanished between the list and the delete — not ours
+                reclaimed.append(name)
         # The pod the operator re-created against the stranded claim is
         # unscheduled, so a plain DELETE removes it at once and releases
         # pvc-protection; CNPG then sees a missing instance and joins a
-        # fresh one (pg_basebackup from the primary) on a live node.
+        # fresh one (pg_basebackup from the primary) on a live node. A
+        # refused delete leaves the claim Terminating under pvc-protection
+        # and CNPG unable to re-create a claim of that name, so it is an
+        # error, not a shrug (review, point 4).
+        pod_path = f"{base}/pods/{quote(instance)}"
         try:
-            _request("DELETE", f"{base}/pods/{quote(instance)}")
-        except RuntimeError:
-            pass  # the pod may already be gone; the claim reclaim is what matters
+            status, resp = _request("DELETE", pod_path)
+        except RuntimeError as exc:
+            return PostgresReclaim(reclaimed, deferred, f"pod {instance}: {exc}", sources,
+                                   deferred_reason, terminating=terminating)
+        if status not in (200, 202, 404):
+            return PostgresReclaim(reclaimed, deferred,
+                                   f"pod {instance}: kubeapi status {status}: {resp[:200]!r}",
+                                   sources, deferred_reason, terminating=terminating)
     pending = set()
     for instance in deferred:
         pending |= pinned_to.get(instance, set())
-    return PostgresReclaim(reclaimed, deferred, None, sources, deferred_reason, pending)
+    return PostgresReclaim(reclaimed, deferred, None, sources, deferred_reason, pending,
+                           terminating)
 
 
 # #272 — durable control-plane state via k3s HelmChartConfig.

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -660,6 +660,9 @@ class PostgresReclaim:
     deferred: list[str] = field(default_factory=list)
     error: str | None = None
     sources: dict[str, str] = field(default_factory=dict)
+    # why ``deferred`` is non-empty: the instance is the current or target
+    # primary, or the Cluster names no primary at all
+    deferred_reason: str = ""
 
     def __iter__(self):
         # ``reclaimed, deferred, err = ...`` keeps working for callers that
@@ -701,7 +704,8 @@ def reclaim_stranded_postgres_storage(
     as ``currentPrimary`` or ``targetPrimary`` is deferred — the caller
     retries on its next tick, by which time the operator has failed over
     (the primary's pod is gone with the node) and the same instance is a
-    stranded replica.
+    stranded replica. A Cluster that names no primary at all defers
+    everything: an unknown primary is not "no primary".
 
     Bounded and idempotent: one GET of the Cluster CR when Postgres is
     whole (``readyInstances >= instances``) and nothing was evicted this
@@ -736,6 +740,13 @@ def reclaim_stranded_postgres_storage(
     primaries = {
         str(cr_status.get(key) or "") for key in ("currentPrimary", "targetPrimary")
     } - {""}
+    # A Cluster that names NO primary (no status yet, a status wiped by an
+    # operator restart, a bootstrap in progress) is not one where every
+    # instance is a replica — it is one where the primary is unknown.
+    # Deleting anything on that reading could be the primary's PGDATA
+    # (review of the first cut, point 2), so nothing is; the next tick,
+    # with a status, decides. The deferral costs one tick.
+    primary_unknown = not primaries
 
     try:
         status, resp = _request("GET", "/api/v1/nodes")
@@ -780,9 +791,15 @@ def reclaim_stranded_postgres_storage(
 
     reclaimed: list[str] = []
     deferred: list[str] = []
+    deferred_reason = ""
     for instance, claims in sorted(stranded.items()):
+        if primary_unknown:
+            deferred.append(instance)
+            deferred_reason = "the Cluster names no current or target primary; retrying next tick"
+            continue
         if instance in primaries:
             deferred.append(instance)
+            deferred_reason = "instance is the current or target primary; retrying next tick"
             continue
         for name in sorted(claims):
             try:
@@ -790,9 +807,9 @@ def reclaim_stranded_postgres_storage(
                     "DELETE", f"{base}/persistentvolumeclaims/{quote(name)}"
                 )
             except RuntimeError as exc:
-                return PostgresReclaim(reclaimed, deferred, str(exc), sources)
+                return PostgresReclaim(reclaimed, deferred, str(exc), sources, deferred_reason)
             if status not in (200, 202, 404):
-                return PostgresReclaim(reclaimed, deferred, f"kubeapi status {status}: {resp[:200]!r}", sources)
+                return PostgresReclaim(reclaimed, deferred, f"kubeapi status {status}: {resp[:200]!r}", sources, deferred_reason)
             reclaimed.append(name)
         # The pod the operator re-created against the stranded claim is
         # unscheduled, so a plain DELETE removes it at once and releases
@@ -802,7 +819,7 @@ def reclaim_stranded_postgres_storage(
             _request("DELETE", f"{base}/pods/{quote(instance)}")
         except RuntimeError:
             pass  # the pod may already be gone; the claim reclaim is what matters
-    return PostgresReclaim(reclaimed, deferred, None, sources)
+    return PostgresReclaim(reclaimed, deferred, None, sources, deferred_reason)
 
 
 # #272 — durable control-plane state via k3s HelmChartConfig.

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -1781,7 +1781,7 @@ def patch_cnpg_instances(
     instances: int,
     *,
     pod_anti_affinity_type: str = "required",
-    cluster_name: str = "spatium-control-spatiumddi-postgresql",
+    cluster_name: str = _CNPG_DEFAULT_CLUSTER,
     namespace: str = "spatium",
 ) -> tuple[bool, str | None]:
     """Directly reconcile the CNPG ``Cluster`` CR's ``spec.instances`` and

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -615,26 +615,58 @@ def _cnpg_instance_of(pvc: dict, cluster_name: str) -> str | None:
     return f"{cluster_name}-{ordinal}"
 
 
-def _pvc_pinned_hostnames(pvc: dict) -> set[str]:
-    """The hostnames a claim's storage lives on. The bound PV's required
-    node affinity is authoritative (it is what the scheduler enforces);
-    the scheduler's ``selected-node`` annotation — what the Redis reclaim
-    keys on — is the fallback when the PV cannot be read. A readable PV
-    with no hostname affinity is network storage: nothing pins it."""
+def _pvc_pinned_hostnames(pvc: dict) -> tuple[set[str], str, str | None]:
+    """``(hostnames, source, error)`` — where a claim's storage lives.
+
+    The bound PV's required node affinity is authoritative (it is what the
+    scheduler enforces): ``source == "pv"``. A readable PV with no hostname
+    affinity is network storage — nothing pins it, the set is empty. The
+    scheduler's ``selected-node`` annotation — what the Redis reclaim keys
+    on — stands in only when there is no PV to read (an unbound claim, or a
+    PV object already gone: 404): ``source == "annotation"``. Anything else
+    — 403, 5xx, a transport failure — is an ``error`` the caller surfaces
+    instead of guessing from the annotation: the review of the first cut
+    found the supervisor's ClusterRole had no ``persistentvolumes`` grant,
+    so every production read was a 403 that silently decided on the
+    annotation, and the network-storage guard above could never hold.
+    """
     volume = str((pvc.get("spec") or {}).get("volumeName") or "")
     if volume:
+        path = f"/api/v1/persistentvolumes/{quote(volume)}"
         try:
-            status, resp = _request("GET", f"/api/v1/persistentvolumes/{quote(volume)}")
-        except RuntimeError:
-            status, resp = 0, b""
+            status, resp = _request("GET", path)
+        except RuntimeError as exc:
+            return set(), "", str(exc)
         if status == 200:
             try:
-                return _pv_affinity_hostnames(json.loads(resp))
+                return _pv_affinity_hostnames(json.loads(resp)), "pv", None
             except ValueError:
-                return set()
+                return set(), "", f"unparseable PV {volume}"
+        if status != 404:
+            return set(), "", f"kubeapi GET {path}: status {status}: {resp[:200]!r}"
     anns = (pvc.get("metadata") or {}).get("annotations") or {}
     selected = anns.get(_SELECTED_NODE_ANNOTATION)
-    return {str(selected)} if selected else set()
+    return ({str(selected)} if selected else set()), "annotation", None
+
+
+@dataclass
+class PostgresReclaim:
+    """What one sweep did. ``sources`` says, per reclaimed claim, whether
+    the bound PV's node affinity (``pv``) or the scheduler's selected-node
+    annotation (``annotation``) decided it was stranded — the journal
+    carries it so a live run can tell the two apart."""
+
+    reclaimed: list[str] = field(default_factory=list)
+    deferred: list[str] = field(default_factory=list)
+    error: str | None = None
+    sources: dict[str, str] = field(default_factory=dict)
+
+    def __iter__(self):
+        # ``reclaimed, deferred, err = ...`` keeps working for callers that
+        # only need the verdict.
+        yield self.reclaimed
+        yield self.deferred
+        yield self.error
 
 
 def reclaim_stranded_postgres_storage(
@@ -642,11 +674,12 @@ def reclaim_stranded_postgres_storage(
     evicted_nodes: Iterable[str] = (),
     namespace: str = "spatium",
     cluster_name: str = _CNPG_DEFAULT_CLUSTER,
-) -> tuple[list[str], list[str], str | None]:
+) -> PostgresReclaim:
     """Delete the CloudNativePG instance claims (and their Pending pods)
     pinned to a node that no longer exists, so the operator re-creates the
-    instance on a live node — returns ``(reclaimed_pvc_names,
-    deferred_instance_names, error)``.
+    instance on a live node — returns a :class:`PostgresReclaim`
+    (``reclaimed`` claim names, ``deferred`` instance names, ``error``,
+    and the affinity ``sources``).
 
     #1058 — the Redis reclaim above rested on "CNPG manages (deletes +
     recreates) its own instance PVCs". It does not. After a dead-node
@@ -685,11 +718,11 @@ def reclaim_stranded_postgres_storage(
     try:
         status, resp = _request("GET", cr_path)
     except RuntimeError as exc:
-        return [], [], str(exc)
+        return PostgresReclaim(error=str(exc))
     if status == 404:
-        return [], [], None  # not a cnpg deployment / Cluster not up yet
+        return PostgresReclaim()  # not a cnpg deployment / Cluster not up yet
     if status != 200:
-        return [], [], f"kubeapi status {status}: {resp[:200]!r}"
+        return PostgresReclaim(error=f"kubeapi status {status}: {resp[:200]!r}")
     try:
         cr = json.loads(resp)
         spec = cr.get("spec") or {}
@@ -697,9 +730,9 @@ def reclaim_stranded_postgres_storage(
         want = int(spec.get("instances") or 0)
         ready = int(cr_status.get("readyInstances") or 0)
     except (ValueError, TypeError, AttributeError):
-        return [], [], "unparseable Cluster CR"
+        return PostgresReclaim(error="unparseable Cluster CR")
     if ready >= want and not forced:
-        return [], [], None
+        return PostgresReclaim()
     primaries = {
         str(cr_status.get(key) or "") for key in ("currentPrimary", "targetPrimary")
     } - {""}
@@ -707,39 +740,43 @@ def reclaim_stranded_postgres_storage(
     try:
         status, resp = _request("GET", "/api/v1/nodes")
     except RuntimeError as exc:
-        return [], [], str(exc)
+        return PostgresReclaim(error=str(exc))
     if status != 200:
-        return [], [], f"kubeapi status {status}: {resp[:200]!r}"
+        return PostgresReclaim(error=f"kubeapi status {status}: {resp[:200]!r}")
     try:
         live = {
             str(((n.get("metadata") or {}).get("name")) or "")
             for n in json.loads(resp).get("items", [])
         } - {""}
     except (ValueError, AttributeError):
-        return [], [], "unparseable node list"
+        return PostgresReclaim(error="unparseable node list")
 
     base = f"/api/v1/namespaces/{quote(namespace)}"
     try:
         status, resp = _request("GET", f"{base}/persistentvolumeclaims")
     except RuntimeError as exc:
-        return [], [], str(exc)
+        return PostgresReclaim(error=str(exc))
     if status != 200:
-        return [], [], f"kubeapi status {status}: {resp[:200]!r}"
+        return PostgresReclaim(error=f"kubeapi status {status}: {resp[:200]!r}")
     try:
         items = json.loads(resp).get("items", [])
     except (ValueError, AttributeError):
-        return [], [], "unparseable PVC list"
+        return PostgresReclaim(error="unparseable PVC list")
 
     stranded: dict[str, list[str]] = {}
+    sources: dict[str, str] = {}
     for pvc in items:
         instance = _cnpg_instance_of(pvc, cluster_name)
         if instance is None:
             continue
-        pinned = _pvc_pinned_hostnames(pvc)
+        name = str((pvc.get("metadata") or {}).get("name") or "")
+        pinned, source, pin_err = _pvc_pinned_hostnames(pvc)
+        if pin_err:
+            return PostgresReclaim(error=f"{name}: {pin_err}")
         if not pinned or pinned & live:
             continue
-        name = str((pvc.get("metadata") or {}).get("name") or "")
         stranded.setdefault(instance, []).append(name)
+        sources[name] = source
 
     reclaimed: list[str] = []
     deferred: list[str] = []
@@ -753,9 +790,9 @@ def reclaim_stranded_postgres_storage(
                     "DELETE", f"{base}/persistentvolumeclaims/{quote(name)}"
                 )
             except RuntimeError as exc:
-                return reclaimed, deferred, str(exc)
+                return PostgresReclaim(reclaimed, deferred, str(exc), sources)
             if status not in (200, 202, 404):
-                return reclaimed, deferred, f"kubeapi status {status}: {resp[:200]!r}"
+                return PostgresReclaim(reclaimed, deferred, f"kubeapi status {status}: {resp[:200]!r}", sources)
             reclaimed.append(name)
         # The pod the operator re-created against the stranded claim is
         # unscheduled, so a plain DELETE removes it at once and releases
@@ -765,7 +802,7 @@ def reclaim_stranded_postgres_storage(
             _request("DELETE", f"{base}/pods/{quote(instance)}")
         except RuntimeError:
             pass  # the pod may already be gone; the claim reclaim is what matters
-    return reclaimed, deferred, None
+    return PostgresReclaim(reclaimed, deferred, None, sources)
 
 
 # #272 — durable control-plane state via k3s HelmChartConfig.

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -26,6 +26,7 @@ import json
 import os
 import socket
 import ssl
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -518,11 +519,14 @@ def reclaim_stranded_redis_storage(
 
     Redis here is cache + Celery broker; Postgres is the store of record,
     so the data is expendable and the replica resyncs from the master.
-    Deliberately restricted to claims with ``-redis-`` in the name: CNPG
-    manages (deletes + recreates) its own instance PVCs, and anything
-    else is not ours to reap. The PVC goes first (pvc-protection holds it
-    until its pod is gone), then the pod — the StatefulSet then recreates
-    both and the provisioner lands the new PV on a live node."""
+    Deliberately restricted to claims with ``-redis-`` in the name:
+    anything else is not ours to reap here. CloudNativePG's instance
+    claims have the same hazard but a stricter rule (a primary's claim
+    is never expendable), so they get their own reclaim —
+    :func:`reclaim_stranded_postgres_storage` (#1058). The PVC goes first
+    (pvc-protection holds it until its pod is gone), then the pod — the
+    StatefulSet then recreates both and the provisioner lands the new PV
+    on a live node."""
     base = f"/api/v1/namespaces/{quote(namespace)}"
     try:
         status, resp = _request("GET", f"{base}/persistentvolumeclaims")
@@ -562,6 +566,206 @@ def reclaim_stranded_redis_storage(
                 pass  # pod may not exist; the PVC reclaim is what matters
         reclaimed.append(name)
     return reclaimed, None
+
+
+# #1058 — CloudNativePG instance storage stranded on an evicted node.
+#
+# CNPG's own labels on the claims and pods it creates (docs: "Labels and
+# annotations"). The name fallback below follows the naming CNPG documents:
+# ``<cluster>-<ordinal>`` for the PGDATA claim, with ``-wal`` / ``-tbs-<name>``
+# suffixes for WAL and tablespace claims.
+_CNPG_CLUSTER_LABEL = "cnpg.io/cluster"
+_CNPG_INSTANCE_LABEL = "cnpg.io/instanceName"
+_CNPG_DEFAULT_CLUSTER = "spatium-control-spatiumddi-postgresql"
+_SELECTED_NODE_ANNOTATION = "volume.kubernetes.io/selected-node"
+
+
+def _pv_affinity_hostnames(pv: dict) -> set[str]:
+    """Every ``kubernetes.io/hostname`` a PV's *required* node affinity pins
+    it to. The local-path provisioner writes exactly one; a network volume
+    writes none, and an empty set means "not node-local" to the caller."""
+    out: set[str] = set()
+    required = ((pv.get("spec") or {}).get("nodeAffinity") or {}).get("required") or {}
+    for term in required.get("nodeSelectorTerms") or []:
+        for expr in (term or {}).get("matchExpressions") or []:
+            if expr.get("key") == "kubernetes.io/hostname" and expr.get("operator") == "In":
+                out.update(str(v) for v in expr.get("values") or [])
+    return out
+
+
+def _cnpg_instance_of(pvc: dict, cluster_name: str) -> str | None:
+    """The CNPG instance a claim belongs to, or None when the claim is not
+    this Cluster's (Redis, the slot-image mirror, agent state, …)."""
+    meta = pvc.get("metadata") or {}
+    labels = meta.get("labels") or {}
+    name = str(meta.get("name") or "")
+    owner = labels.get(_CNPG_CLUSTER_LABEL)
+    if owner:
+        if owner != cluster_name:
+            return None
+        instance = labels.get(_CNPG_INSTANCE_LABEL)
+        if instance:
+            return str(instance)
+    prefix = f"{cluster_name}-"
+    if not name.startswith(prefix):
+        return None
+    ordinal = name[len(prefix) :].split("-", 1)[0]
+    if not ordinal.isdigit():
+        return None
+    return f"{cluster_name}-{ordinal}"
+
+
+def _pvc_pinned_hostnames(pvc: dict) -> set[str]:
+    """The hostnames a claim's storage lives on. The bound PV's required
+    node affinity is authoritative (it is what the scheduler enforces);
+    the scheduler's ``selected-node`` annotation — what the Redis reclaim
+    keys on — is the fallback when the PV cannot be read. A readable PV
+    with no hostname affinity is network storage: nothing pins it."""
+    volume = str((pvc.get("spec") or {}).get("volumeName") or "")
+    if volume:
+        try:
+            status, resp = _request("GET", f"/api/v1/persistentvolumes/{quote(volume)}")
+        except RuntimeError:
+            status, resp = 0, b""
+        if status == 200:
+            try:
+                return _pv_affinity_hostnames(json.loads(resp))
+            except ValueError:
+                return set()
+    anns = (pvc.get("metadata") or {}).get("annotations") or {}
+    selected = anns.get(_SELECTED_NODE_ANNOTATION)
+    return {str(selected)} if selected else set()
+
+
+def reclaim_stranded_postgres_storage(
+    *,
+    evicted_nodes: Iterable[str] = (),
+    namespace: str = "spatium",
+    cluster_name: str = _CNPG_DEFAULT_CLUSTER,
+) -> tuple[list[str], list[str], str | None]:
+    """Delete the CloudNativePG instance claims (and their Pending pods)
+    pinned to a node that no longer exists, so the operator re-creates the
+    instance on a live node — returns ``(reclaimed_pvc_names,
+    deferred_instance_names, error)``.
+
+    #1058 — the Redis reclaim above rested on "CNPG manages (deletes +
+    recreates) its own instance PVCs". It does not. After a dead-node
+    replace (Node deleted here, replacement promoted under a new hostname)
+    the evicted member's instance claim stays ``Bound`` to a local-path PV
+    whose ``nodeAffinity`` names the deleted node; the operator re-creates
+    the pod against that same claim and it sits ``Pending`` with "0/3 nodes
+    are available: 3 node(s) didn't match PersistentVolume's node
+    affinity". Observed live on a nested 3-node cluster: ``readyInstances
+    2`` of ``instances 3`` for 77+ min after the replacement had joined,
+    ``healthyPVC`` still listing the stranded claim, the operator log only
+    reconciling, and ``cluster/health`` reporting the control plane HA
+    with two of three Postgres instances. The chart README documents the
+    manual repair (delete the claim, then the pod; CNPG re-clones the
+    replica from the primary); an appliance has to do it itself.
+
+    The rule that README states is enforced here, not assumed: **only a
+    replica's claim is ever deleted**. An instance the Cluster still names
+    as ``currentPrimary`` or ``targetPrimary`` is deferred — the caller
+    retries on its next tick, by which time the operator has failed over
+    (the primary's pod is gone with the node) and the same instance is a
+    stranded replica.
+
+    Bounded and idempotent: one GET of the Cluster CR when Postgres is
+    whole (``readyInstances >= instances``) and nothing was evicted this
+    tick; the node/claim/PV scan only runs while an instance is missing.
+    "Stranded" means every hostname the claim's PV is pinned to is absent
+    from the Node list — a claim whose node is merely NotReady is left
+    alone, because that node can come back and its data with it.
+    """
+    forced = {str(n) for n in evicted_nodes if n}
+    cr_path = (
+        f"/apis/postgresql.cnpg.io/v1/namespaces/{quote(namespace)}"
+        f"/clusters/{quote(cluster_name)}"
+    )
+    try:
+        status, resp = _request("GET", cr_path)
+    except RuntimeError as exc:
+        return [], [], str(exc)
+    if status == 404:
+        return [], [], None  # not a cnpg deployment / Cluster not up yet
+    if status != 200:
+        return [], [], f"kubeapi status {status}: {resp[:200]!r}"
+    try:
+        cr = json.loads(resp)
+        spec = cr.get("spec") or {}
+        cr_status = cr.get("status") or {}
+        want = int(spec.get("instances") or 0)
+        ready = int(cr_status.get("readyInstances") or 0)
+    except (ValueError, TypeError, AttributeError):
+        return [], [], "unparseable Cluster CR"
+    if ready >= want and not forced:
+        return [], [], None
+    primaries = {
+        str(cr_status.get(key) or "") for key in ("currentPrimary", "targetPrimary")
+    } - {""}
+
+    try:
+        status, resp = _request("GET", "/api/v1/nodes")
+    except RuntimeError as exc:
+        return [], [], str(exc)
+    if status != 200:
+        return [], [], f"kubeapi status {status}: {resp[:200]!r}"
+    try:
+        live = {
+            str(((n.get("metadata") or {}).get("name")) or "")
+            for n in json.loads(resp).get("items", [])
+        } - {""}
+    except (ValueError, AttributeError):
+        return [], [], "unparseable node list"
+
+    base = f"/api/v1/namespaces/{quote(namespace)}"
+    try:
+        status, resp = _request("GET", f"{base}/persistentvolumeclaims")
+    except RuntimeError as exc:
+        return [], [], str(exc)
+    if status != 200:
+        return [], [], f"kubeapi status {status}: {resp[:200]!r}"
+    try:
+        items = json.loads(resp).get("items", [])
+    except (ValueError, AttributeError):
+        return [], [], "unparseable PVC list"
+
+    stranded: dict[str, list[str]] = {}
+    for pvc in items:
+        instance = _cnpg_instance_of(pvc, cluster_name)
+        if instance is None:
+            continue
+        pinned = _pvc_pinned_hostnames(pvc)
+        if not pinned or pinned & live:
+            continue
+        name = str((pvc.get("metadata") or {}).get("name") or "")
+        stranded.setdefault(instance, []).append(name)
+
+    reclaimed: list[str] = []
+    deferred: list[str] = []
+    for instance, claims in sorted(stranded.items()):
+        if instance in primaries:
+            deferred.append(instance)
+            continue
+        for name in sorted(claims):
+            try:
+                status, resp = _request(
+                    "DELETE", f"{base}/persistentvolumeclaims/{quote(name)}"
+                )
+            except RuntimeError as exc:
+                return reclaimed, deferred, str(exc)
+            if status not in (200, 202, 404):
+                return reclaimed, deferred, f"kubeapi status {status}: {resp[:200]!r}"
+            reclaimed.append(name)
+        # The pod the operator re-created against the stranded claim is
+        # unscheduled, so a plain DELETE removes it at once and releases
+        # pvc-protection; CNPG then sees a missing instance and joins a
+        # fresh one (pg_basebackup from the primary) on a live node.
+        try:
+            _request("DELETE", f"{base}/pods/{quote(instance)}")
+        except RuntimeError:
+            pass  # the pod may already be gone; the claim reclaim is what matters
+    return reclaimed, deferred, None
 
 
 # #272 — durable control-plane state via k3s HelmChartConfig.

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -663,6 +663,10 @@ class PostgresReclaim:
     # why ``deferred`` is non-empty: the instance is the current or target
     # primary, or the Cluster names no primary at all
     deferred_reason: str = ""
+    # hostnames whose stranded claims are still owed (deferred): the caller
+    # hands them back as ``evicted_nodes`` next tick so the scan runs again
+    # even while the Cluster reads whole
+    pending_nodes: set[str] = field(default_factory=set)
 
     def __iter__(self):
         # ``reclaimed, deferred, err = ...`` keeps working for callers that
@@ -709,7 +713,10 @@ def reclaim_stranded_postgres_storage(
 
     Bounded and idempotent: one GET of the Cluster CR when Postgres is
     whole (``readyInstances >= instances``) and nothing was evicted this
-    tick; the node/claim/PV scan only runs while an instance is missing.
+    tick; the node/claim/PV scan only runs while an instance is missing,
+    or for the nodes in ``evicted_nodes`` — the names the caller evicted
+    this tick (authoritative: a just-deleted Node can still be listed) and
+    the ones a deferral left owed (``pending_nodes``).
     "Stranded" means every hostname the claim's PV is pinned to is absent
     from the Node list — a claim whose node is merely NotReady is left
     alone, because that node can come back and its data with it.
@@ -761,6 +768,13 @@ def reclaim_stranded_postgres_storage(
         } - {""}
     except (ValueError, AttributeError):
         return PostgresReclaim(error="unparseable node list")
+    # A node the caller just evicted is gone whatever the list says: on the
+    # eviction tick the Node DELETE is milliseconds old and the name can
+    # still be listed, which made the first cut's eviction tick a silent
+    # no-op (review, point 3) — the reclaim then waited for a later tick
+    # that the scaled-down spec kept early-outing until the replacement
+    # had joined. delete_node's success is the authority here.
+    live -= forced
 
     base = f"/api/v1/namespaces/{quote(namespace)}"
     try:
@@ -776,6 +790,7 @@ def reclaim_stranded_postgres_storage(
 
     stranded: dict[str, list[str]] = {}
     sources: dict[str, str] = {}
+    pinned_to: dict[str, set[str]] = {}
     for pvc in items:
         instance = _cnpg_instance_of(pvc, cluster_name)
         if instance is None:
@@ -788,6 +803,7 @@ def reclaim_stranded_postgres_storage(
             continue
         stranded.setdefault(instance, []).append(name)
         sources[name] = source
+        pinned_to.setdefault(instance, set()).update(pinned)
 
     reclaimed: list[str] = []
     deferred: list[str] = []
@@ -819,7 +835,10 @@ def reclaim_stranded_postgres_storage(
             _request("DELETE", f"{base}/pods/{quote(instance)}")
         except RuntimeError:
             pass  # the pod may already be gone; the claim reclaim is what matters
-    return PostgresReclaim(reclaimed, deferred, None, sources, deferred_reason)
+    pending = set()
+    for instance in deferred:
+        pending |= pinned_to.get(instance, set())
+    return PostgresReclaim(reclaimed, deferred, None, sources, deferred_reason, pending)
 
 
 # #272 — durable control-plane state via k3s HelmChartConfig.

--- a/agent/supervisor/tests/test_postgres_storage_reclaim.py
+++ b/agent/supervisor/tests/test_postgres_storage_reclaim.py
@@ -1,0 +1,326 @@
+"""#1058 — reclaim_stranded_postgres_storage frees a CNPG claim pinned to a
+node that no longer exists.
+
+After a dead-node replace the evicted member's CloudNativePG instance claim
+stays Bound to a local-path PV whose nodeAffinity names the deleted node; the
+operator re-creates the pod against that claim and it sits Pending forever
+("didn't match PersistentVolume's node affinity"), Postgres runs 2 of 3 and
+the replacement member never hosts an instance. These tests pin the contract:
+reclaim exactly the CNPG claims whose PV is pinned to a hostname no Node
+carries (the claim first, then the Pending pod, so the operator joins a fresh
+instance elsewhere); NEVER the current or target primary's (deferred instead);
+never a claim on a live or merely NotReady node; never Redis's or any other
+component's; a cheap no-op while Postgres is whole unless a node was evicted
+this tick; and kubeapi errors are surfaced, never guessed around.
+"""
+
+from __future__ import annotations
+
+import json
+
+from spatium_supervisor import k8s_api
+
+CLUSTER = "spatium-control-spatiumddi-postgresql"
+CR_PATH = f"/apis/postgresql.cnpg.io/v1/namespaces/spatium/clusters/{CLUSTER}"
+PVC_PATH = "/api/v1/namespaces/spatium/persistentvolumeclaims"
+POD_PATH = "/api/v1/namespaces/spatium/pods"
+
+
+class _Recorder:
+    """Stand-in for k8s_api._request keyed by path: scripts every GET and
+    records every DELETE, in order."""
+
+    def __init__(self, gets: dict[str, tuple[int, object]], delete_status: int = 200):
+        self._gets = gets
+        self._delete_status = delete_status
+        self.calls: list[tuple[str, str]] = []
+
+    def __call__(self, method, path, body=None, content_type=None, timeout=None):
+        self.calls.append((method, path))
+        if method == "GET":
+            status, payload = self._gets.get(path, (404, {}))
+            raw = payload if isinstance(payload, (bytes, str)) else json.dumps(payload)
+            return status, raw.encode() if isinstance(raw, str) else raw
+        return self._delete_status, b"{}"
+
+    @property
+    def deleted(self) -> list[str]:
+        return [p for m, p in self.calls if m == "DELETE"]
+
+    @property
+    def gets(self) -> list[str]:
+        return [p for m, p in self.calls if m == "GET"]
+
+
+def _cr(ready: int, want: int = 3, current: str = f"{CLUSTER}-1", target: str | None = None):
+    return {
+        "spec": {"instances": want},
+        "status": {
+            "readyInstances": ready,
+            "currentPrimary": current,
+            "targetPrimary": target or current,
+        },
+    }
+
+
+def _nodes(*names: str):
+    return {"items": [{"metadata": {"name": n}} for n in names]}
+
+
+def _pvc(name: str, volume: str, *, labels: dict | None = None, selected: str | None = None):
+    meta: dict = {"name": name}
+    if labels is not None:
+        meta["labels"] = labels
+    if selected:
+        meta["annotations"] = {"volume.kubernetes.io/selected-node": selected}
+    return {"metadata": meta, "spec": {"volumeName": volume}}
+
+
+def _pv(host: str | None):
+    if host is None:
+        return {"spec": {}}
+    return {
+        "spec": {
+            "nodeAffinity": {
+                "required": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {"key": "kubernetes.io/hostname", "operator": "In", "values": [host]}
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+
+def _cnpg_labels(instance: str, role: str = "PG_DATA") -> dict:
+    return {"cnpg.io/cluster": CLUSTER, "cnpg.io/instanceName": instance, "cnpg.io/pvcRole": role}
+
+
+def _world(
+    *,
+    ready: int = 2,
+    nodes=("ddipg-seed", "ddipg-member-1", "ddipg-member-3"),
+    current: str = f"{CLUSTER}-1",
+    target: str | None = None,
+    pvcs=(),
+    pvs=None,
+) -> dict:
+    gets: dict[str, tuple[int, object]] = {
+        CR_PATH: (200, _cr(ready, current=current, target=target)),
+        "/api/v1/nodes": (200, _nodes(*nodes)),
+        PVC_PATH: (200, {"items": list(pvcs)}),
+    }
+    for vol, host in (pvs or {}).items():
+        gets[f"/api/v1/persistentvolumes/{vol}"] = (200, _pv(host))
+    return gets
+
+
+# The shape the live evidence had (spatiumddi#1058): instance 3's claim on the
+# evicted ddipg-member-2, the primary on the seed, the replacement member-3
+# hosting nothing.
+_LIVE_PVCS = (
+    _pvc(f"{CLUSTER}-1", "pv-1", labels=_cnpg_labels(f"{CLUSTER}-1"), selected="ddipg-seed"),
+    _pvc(f"{CLUSTER}-2", "pv-2", labels=_cnpg_labels(f"{CLUSTER}-2"), selected="ddipg-member-1"),
+    _pvc(f"{CLUSTER}-3", "pv-3", labels=_cnpg_labels(f"{CLUSTER}-3"), selected="ddipg-member-2"),
+    _pvc("data-spatium-control-spatiumddi-redis-2", "pv-r2", selected="ddipg-member-2"),
+    _pvc("spatium-control-spatiumddi-slot-image-mirror-data", "pv-m", selected="ddipg-member-2"),
+)
+_LIVE_PVS = {
+    "pv-1": "ddipg-seed",
+    "pv-2": "ddipg-member-1",
+    "pv-3": "ddipg-member-2",
+    "pv-r2": "ddipg-member-2",
+    "pv-m": "ddipg-member-2",
+}
+
+
+def test_reclaims_the_replica_claim_pinned_to_a_missing_node_then_its_pod(monkeypatch) -> None:
+    rec = _Recorder(_world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    reclaimed, deferred, err = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert (reclaimed, deferred, err) == ([f"{CLUSTER}-3"], [], None)
+    # The claim first (pvc-protection holds it until its pod is gone), then
+    # the Pending pod — and nothing that is not CNPG's, whatever node it is on.
+    assert rec.deleted == [f"{PVC_PATH}/{CLUSTER}-3", f"{POD_PATH}/{CLUSTER}-3"]
+
+
+def test_the_primary_is_deferred_never_deleted(monkeypatch) -> None:
+    # The dead node hosted the primary and the operator has not failed over
+    # yet: leave the claim alone and say so; the next tick tries again.
+    rec = _Recorder(_world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS, current=f"{CLUSTER}-3"))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    reclaimed, deferred, err = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert (reclaimed, deferred, err) == ([], [f"{CLUSTER}-3"], None)
+    assert rec.deleted == []
+
+
+def test_a_target_primary_counts_as_the_primary(monkeypatch) -> None:
+    # Mid-failover the operator has already chosen the stranded instance as
+    # the next primary (targetPrimary) while currentPrimary still says the old
+    # one: touching it now would race the promotion.
+    rec = _Recorder(
+        _world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS, current=f"{CLUSTER}-1", target=f"{CLUSTER}-3")
+    )
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    reclaimed, deferred, err = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert (reclaimed, deferred, err) == ([], [f"{CLUSTER}-3"], None)
+    assert rec.deleted == []
+
+
+def test_a_whole_postgres_is_one_cheap_read(monkeypatch) -> None:
+    rec = _Recorder(_world(ready=3, pvcs=_LIVE_PVCS, pvs=_LIVE_PVS))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    assert k8s_api.reclaim_stranded_postgres_storage() == ([], [], None)
+    assert rec.gets == [CR_PATH]
+    assert rec.deleted == []
+
+
+def test_an_eviction_this_tick_forces_the_scan_past_a_stale_status(monkeypatch) -> None:
+    # Right after the Node deletion the Cluster status may still count the
+    # dead instance ready (its pod is not garbage-collected yet); the tick
+    # that evicted the node scans anyway.
+    rec = _Recorder(_world(ready=3, pvcs=_LIVE_PVCS, pvs=_LIVE_PVS))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    reclaimed, deferred, err = k8s_api.reclaim_stranded_postgres_storage(
+        evicted_nodes=["ddipg-member-2"]
+    )
+
+    assert (reclaimed, deferred, err) == ([f"{CLUSTER}-3"], [], None)
+
+
+def test_a_claim_on_a_node_that_still_exists_is_left_alone(monkeypatch) -> None:
+    # NotReady is not gone: the Node object is still registered, so the node
+    # (and the data on it) can come back. Only a hostname absent from the
+    # Node list counts as stranded.
+    rec = _Recorder(
+        _world(
+            nodes=("ddipg-seed", "ddipg-member-1", "ddipg-member-2"),
+            pvcs=_LIVE_PVCS,
+            pvs=_LIVE_PVS,
+        )
+    )
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    assert k8s_api.reclaim_stranded_postgres_storage() == ([], [], None)
+    assert rec.deleted == []
+
+
+def test_the_instances_wal_claim_goes_with_its_data_claim(monkeypatch) -> None:
+    pvcs = (
+        *_LIVE_PVCS,
+        _pvc(f"{CLUSTER}-3-wal", "pv-3w", labels=_cnpg_labels(f"{CLUSTER}-3", "PG_WAL")),
+    )
+    rec = _Recorder(_world(pvcs=pvcs, pvs={**_LIVE_PVS, "pv-3w": "ddipg-member-2"}))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    reclaimed, deferred, err = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert (deferred, err) == ([], None)
+    assert sorted(reclaimed) == [f"{CLUSTER}-3", f"{CLUSTER}-3-wal"]
+    assert rec.deleted[-1] == f"{POD_PATH}/{CLUSTER}-3"
+
+
+def test_unlabelled_claims_are_recognised_by_cnpg_naming(monkeypatch) -> None:
+    # Older CNPG releases label less; the documented <cluster>-<ordinal>
+    # naming (with -wal / -tbs-<name> suffixes) still identifies the instance.
+    pvcs = (
+        _pvc(f"{CLUSTER}-1", "pv-1"),
+        _pvc(f"{CLUSTER}-3", "pv-3"),
+        _pvc(f"{CLUSTER}-3-wal", "pv-3w"),
+        _pvc(f"{CLUSTER}-3-tbs-fast", "pv-3t"),
+        _pvc("data-spatium-control-spatiumddi-redis-2", "pv-r2"),
+    )
+    pvs = {
+        "pv-1": "ddipg-seed",
+        "pv-3": "ddipg-member-2",
+        "pv-3w": "ddipg-member-2",
+        "pv-3t": "ddipg-member-2",
+        "pv-r2": "ddipg-member-2",
+    }
+    rec = _Recorder(_world(pvcs=pvcs, pvs=pvs))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    reclaimed, deferred, err = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert (deferred, err) == ([], None)
+    assert sorted(reclaimed) == [f"{CLUSTER}-3", f"{CLUSTER}-3-tbs-fast", f"{CLUSTER}-3-wal"]
+    assert f"{PVC_PATH}/data-spatium-control-spatiumddi-redis-2" not in rec.deleted
+
+
+def test_another_clusters_claims_are_not_ours(monkeypatch) -> None:
+    pvcs = (
+        _pvc("other-postgres-3", "pv-o3", labels={"cnpg.io/cluster": "other-postgres"}),
+    )
+    rec = _Recorder(_world(pvcs=pvcs, pvs={"pv-o3": "ddipg-member-2"}))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    assert k8s_api.reclaim_stranded_postgres_storage() == ([], [], None)
+    assert rec.deleted == []
+
+
+def test_network_storage_is_never_stranded(monkeypatch) -> None:
+    # A readable PV with no hostname affinity is not node-local; the
+    # scheduler's selected-node annotation must not make it look stranded.
+    pvcs = (_pvc(f"{CLUSTER}-3", "pv-3", selected="ddipg-member-2"),)
+    rec = _Recorder(_world(pvcs=pvcs, pvs={"pv-3": None}))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    assert k8s_api.reclaim_stranded_postgres_storage() == ([], [], None)
+    assert rec.deleted == []
+
+
+def test_an_unreadable_pv_falls_back_to_the_selected_node_annotation(monkeypatch) -> None:
+    pvcs = (
+        _pvc(f"{CLUSTER}-3", "pv-3", labels=_cnpg_labels(f"{CLUSTER}-3"), selected="ddipg-member-2"),
+    )
+    rec = _Recorder(_world(pvcs=pvcs, pvs={}))  # no PV scripted → 404
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    reclaimed, deferred, err = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert (reclaimed, deferred, err) == ([f"{CLUSTER}-3"], [], None)
+
+
+def test_no_cnpg_cluster_is_a_quiet_no_op(monkeypatch) -> None:
+    rec = _Recorder({CR_PATH: (404, {})})
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    assert k8s_api.reclaim_stranded_postgres_storage(evicted_nodes=["x"]) == ([], [], None)
+    assert rec.deleted == []
+
+
+def test_kubeapi_failures_are_reported_not_guessed_around(monkeypatch) -> None:
+    gets = _world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS)
+    gets[PVC_PATH] = (500, "boom")
+    rec = _Recorder(gets)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    reclaimed, deferred, err = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert (reclaimed, deferred) == ([], [])
+    assert err is not None and "500" in err
+    assert rec.deleted == []
+
+
+def test_a_refused_delete_stops_and_reports(monkeypatch) -> None:
+    rec = _Recorder(_world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS), delete_status=403)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    reclaimed, _deferred, err = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert reclaimed == []
+    assert err is not None and "403" in err
+    # No pod delete after a refused claim delete — the order is the contract.
+    assert rec.deleted == [f"{PVC_PATH}/{CLUSTER}-3"]

--- a/agent/supervisor/tests/test_postgres_storage_reclaim.py
+++ b/agent/supervisor/tests/test_postgres_storage_reclaim.py
@@ -32,9 +32,11 @@ class _Recorder:
     """Stand-in for k8s_api._request keyed by path: scripts every GET and
     records every DELETE, in order."""
 
-    def __init__(self, gets: dict[str, tuple[int, object]], delete_status: int = 200):
+    def __init__(self, gets: dict[str, tuple[int, object]], delete_status: int = 200,
+                 deletes: dict[str, int] | None = None):
         self._gets = gets
         self._delete_status = delete_status
+        self._deletes = deletes or {}  # per-path DELETE status overrides
         self.calls: list[tuple[str, str]] = []
 
     def __call__(self, method, path, body=None, content_type=None, timeout=None):
@@ -43,7 +45,7 @@ class _Recorder:
             status, payload = self._gets.get(path, (404, {}))
             raw = payload if isinstance(payload, (bytes, str)) else json.dumps(payload)
             return status, raw.encode() if isinstance(raw, str) else raw
-        return self._delete_status, b"{}"
+        return self._deletes.get(path, self._delete_status), b"{}"
 
     @property
     def deleted(self) -> list[str]:
@@ -69,12 +71,15 @@ def _nodes(*names: str):
     return {"items": [{"metadata": {"name": n}} for n in names]}
 
 
-def _pvc(name: str, volume: str, *, labels: dict | None = None, selected: str | None = None):
+def _pvc(name: str, volume: str, *, labels: dict | None = None, selected: str | None = None,
+         terminating: bool = False):
     meta: dict = {"name": name}
     if labels is not None:
         meta["labels"] = labels
     if selected:
         meta["annotations"] = {"volume.kubernetes.io/selected-node": selected}
+    if terminating:
+        meta["deletionTimestamp"] = "2026-09-11T21:21:55Z"
     return {"metadata": meta, "spec": {"volumeName": volume}}
 
 
@@ -460,6 +465,48 @@ def test_no_cnpg_cluster_is_a_quiet_no_op(monkeypatch) -> None:
 
     assert tuple(k8s_api.reclaim_stranded_postgres_storage(evicted_nodes=["x"])) == ([], [], None)
     assert rec.deleted == []
+
+
+def test_a_refused_pod_delete_is_an_error_with_the_claim_still_counted(monkeypatch) -> None:
+    # The first cut discarded the pod DELETE's status: a 500 read as a clean
+    # reclaim, the claim sat Terminating under pvc-protection, CNPG could not
+    # re-create a claim of that name, and every next tick logged
+    # "reclaimed" again with no error ever set (review, point 4).
+    rec = _Recorder(_world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS),
+                    deletes={f"{POD_PATH}/{CLUSTER}-3": 500})
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    out = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert out.reclaimed == [f"{CLUSTER}-3"]  # the claim delete did land
+    assert out.error is not None and "500" in out.error and f"pod {CLUSTER}-3" in out.error
+
+
+def test_a_terminating_claim_is_pending_not_reclaimed_again(monkeypatch) -> None:
+    # Deleted last tick, still held by pvc-protection: no second DELETE on
+    # the claim, no "reclaimed" line, the pod delete retried.
+    pvcs = (
+        _LIVE_PVCS[0], _LIVE_PVCS[1],
+        _pvc(f"{CLUSTER}-3", "pv-3", labels=_cnpg_labels(f"{CLUSTER}-3"), terminating=True),
+    )
+    rec = _Recorder(_world(pvcs=pvcs, pvs=_LIVE_PVS))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    out = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert out.reclaimed == [] and out.error is None
+    assert out.terminating == [f"{CLUSTER}-3"]
+    assert rec.deleted == [f"{POD_PATH}/{CLUSTER}-3"]
+
+
+def test_a_claim_that_vanished_before_the_delete_is_not_counted(monkeypatch) -> None:
+    rec = _Recorder(_world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS),
+                    deletes={f"{PVC_PATH}/{CLUSTER}-3": 404})
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    out = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert (out.reclaimed, out.error) == ([], None)
 
 
 def test_kubeapi_failures_are_reported_not_guessed_around(monkeypatch) -> None:

--- a/agent/supervisor/tests/test_postgres_storage_reclaim.py
+++ b/agent/supervisor/tests/test_postgres_storage_reclaim.py
@@ -11,7 +11,9 @@ carries (the claim first, then the Pending pod, so the operator joins a fresh
 instance elsewhere); NEVER the current or target primary's (deferred instead);
 never a claim on a live or merely NotReady node; never Redis's or any other
 component's; a cheap no-op while Postgres is whole unless a node was evicted
-this tick; and kubeapi errors are surfaced, never guessed around.
+this tick; and kubeapi errors are surfaced, never guessed around — a PV read that is
+forbidden or failing is an error, only a PV that does not exist falls back to the
+scheduler's selected-node annotation, and the journal records which one decided.
 """
 
 from __future__ import annotations
@@ -181,7 +183,7 @@ def test_a_whole_postgres_is_one_cheap_read(monkeypatch) -> None:
     rec = _Recorder(_world(ready=3, pvcs=_LIVE_PVCS, pvs=_LIVE_PVS))
     monkeypatch.setattr(k8s_api, "_request", rec)
 
-    assert k8s_api.reclaim_stranded_postgres_storage() == ([], [], None)
+    assert tuple(k8s_api.reclaim_stranded_postgres_storage()) == ([], [], None)
     assert rec.gets == [CR_PATH]
     assert rec.deleted == []
 
@@ -213,7 +215,7 @@ def test_a_claim_on_a_node_that_still_exists_is_left_alone(monkeypatch) -> None:
     )
     monkeypatch.setattr(k8s_api, "_request", rec)
 
-    assert k8s_api.reclaim_stranded_postgres_storage() == ([], [], None)
+    assert tuple(k8s_api.reclaim_stranded_postgres_storage()) == ([], [], None)
     assert rec.deleted == []
 
 
@@ -266,7 +268,7 @@ def test_another_clusters_claims_are_not_ours(monkeypatch) -> None:
     rec = _Recorder(_world(pvcs=pvcs, pvs={"pv-o3": "ddipg-member-2"}))
     monkeypatch.setattr(k8s_api, "_request", rec)
 
-    assert k8s_api.reclaim_stranded_postgres_storage() == ([], [], None)
+    assert tuple(k8s_api.reclaim_stranded_postgres_storage()) == ([], [], None)
     assert rec.deleted == []
 
 
@@ -277,27 +279,88 @@ def test_network_storage_is_never_stranded(monkeypatch) -> None:
     rec = _Recorder(_world(pvcs=pvcs, pvs={"pv-3": None}))
     monkeypatch.setattr(k8s_api, "_request", rec)
 
-    assert k8s_api.reclaim_stranded_postgres_storage() == ([], [], None)
+    assert tuple(k8s_api.reclaim_stranded_postgres_storage()) == ([], [], None)
     assert rec.deleted == []
 
 
-def test_an_unreadable_pv_falls_back_to_the_selected_node_annotation(monkeypatch) -> None:
+def test_a_missing_pv_falls_back_to_the_selected_node_annotation(monkeypatch) -> None:
+    # 404 = there is no PV object to read (unbound, or already released and
+    # gone): the scheduler's annotation is the only anchor left, and the
+    # journal says so.
     pvcs = (
         _pvc(f"{CLUSTER}-3", "pv-3", labels=_cnpg_labels(f"{CLUSTER}-3"), selected="ddipg-member-2"),
     )
     rec = _Recorder(_world(pvcs=pvcs, pvs={}))  # no PV scripted → 404
     monkeypatch.setattr(k8s_api, "_request", rec)
 
-    reclaimed, deferred, err = k8s_api.reclaim_stranded_postgres_storage()
+    out = k8s_api.reclaim_stranded_postgres_storage()
 
-    assert (reclaimed, deferred, err) == ([f"{CLUSTER}-3"], [], None)
+    assert tuple(out) == ([f"{CLUSTER}-3"], [], None)
+    assert out.sources == {f"{CLUSTER}-3": "annotation"}
+
+
+def test_the_live_shape_records_the_pv_as_the_source(monkeypatch) -> None:
+    rec = _Recorder(_world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    out = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert out.reclaimed == [f"{CLUSTER}-3"]
+    assert out.sources == {f"{CLUSTER}-3": "pv"}
+
+
+def test_a_forbidden_pv_read_is_an_error_not_a_guess(monkeypatch) -> None:
+    # The first cut fell back to the annotation on ANY non-200 — and the
+    # supervisor's ClusterRole had no persistentvolumes grant, so every
+    # production read was a 403 that silently decided on the annotation
+    # (review of the first cut). A 403 is a misconfiguration to surface.
+    gets = _world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS)
+    gets["/api/v1/persistentvolumes/pv-1"] = (403, "forbidden")
+    rec = _Recorder(gets)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    out = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert out.reclaimed == [] and out.deferred == []
+    assert out.error is not None and "403" in out.error and "persistentvolumes/pv-1" in out.error
+    assert rec.deleted == []
+
+
+def test_a_pv_server_error_is_an_error_not_a_guess(monkeypatch) -> None:
+    gets = _world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS)
+    gets["/api/v1/persistentvolumes/pv-3"] = (500, "boom")
+    rec = _Recorder(gets)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    out = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert out.reclaimed == []
+    assert out.error is not None and "500" in out.error
+    assert rec.deleted == []
+
+
+def test_a_pv_transport_failure_is_an_error_not_a_guess(monkeypatch) -> None:
+    inner = _Recorder(_world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS))
+
+    def flaky(method, path, **kw):
+        if path == "/api/v1/persistentvolumes/pv-3":
+            raise RuntimeError("kubeapi GET /api/v1/persistentvolumes/pv-3: timed out")
+        return inner(method, path, **kw)
+
+    monkeypatch.setattr(k8s_api, "_request", flaky)
+
+    out = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert out.reclaimed == []
+    assert out.error is not None and "timed out" in out.error
+    assert inner.deleted == []
 
 
 def test_no_cnpg_cluster_is_a_quiet_no_op(monkeypatch) -> None:
     rec = _Recorder({CR_PATH: (404, {})})
     monkeypatch.setattr(k8s_api, "_request", rec)
 
-    assert k8s_api.reclaim_stranded_postgres_storage(evicted_nodes=["x"]) == ([], [], None)
+    assert tuple(k8s_api.reclaim_stranded_postgres_storage(evicted_nodes=["x"])) == ([], [], None)
     assert rec.deleted == []
 
 

--- a/agent/supervisor/tests/test_postgres_storage_reclaim.py
+++ b/agent/supervisor/tests/test_postgres_storage_reclaim.py
@@ -241,6 +241,65 @@ def test_an_eviction_this_tick_forces_the_scan_past_a_stale_status(monkeypatch) 
     assert (reclaimed, deferred, err) == ([f"{CLUSTER}-3"], [], None)
 
 
+def test_the_eviction_tick_reclaims_with_the_node_still_listed(monkeypatch) -> None:
+    # On the eviction tick delete_node has just returned and the Node list
+    # can still carry the name (the first cut's eviction tick was a silent
+    # no-op for exactly that reason — review, point 3). The names the
+    # caller evicted are authoritative.
+    rec = _Recorder(
+        _world(
+            ready=3,  # the dead node's pod still reads Ready for the node-monitor grace
+            nodes=("ddipg-seed", "ddipg-member-1", "ddipg-member-2"),
+            pvcs=_LIVE_PVCS,
+            pvs=_LIVE_PVS,
+        )
+    )
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    out = k8s_api.reclaim_stranded_postgres_storage(evicted_nodes=["ddipg-member-2"])
+
+    assert (out.reclaimed, out.deferred, out.error) == ([f"{CLUSTER}-3"], [], None)
+    assert rec.deleted == [f"{PVC_PATH}/{CLUSTER}-3", f"{POD_PATH}/{CLUSTER}-3"]
+
+
+def test_a_deferral_names_its_node_for_the_next_tick(monkeypatch) -> None:
+    # The primary on the evicted node is deferred; the caller must be told
+    # which node to force next tick, or the scaled-down spec's "Postgres is
+    # whole" early-out would sit on the deferral until the replacement joins.
+    rec = _Recorder(_world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS, current=f"{CLUSTER}-3"))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    out = k8s_api.reclaim_stranded_postgres_storage(evicted_nodes=["ddipg-member-2"])
+
+    assert out.deferred == [f"{CLUSTER}-3"]
+    assert out.pending_nodes == {"ddipg-member-2"}
+    assert rec.deleted == []
+
+
+def test_a_clean_reclaim_leaves_nothing_owed(monkeypatch) -> None:
+    rec = _Recorder(_world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    out = k8s_api.reclaim_stranded_postgres_storage(evicted_nodes=["ddipg-member-2"])
+
+    assert out.reclaimed == [f"{CLUSTER}-3"] and out.pending_nodes == set()
+
+
+def test_the_heartbeat_carries_what_a_sweep_left_owed() -> None:
+    from spatium_supervisor import heartbeat
+
+    owed = k8s_api.PostgresReclaim(deferred=[f"{CLUSTER}-3"], pending_nodes={"ddipg-member-2"})
+    assert heartbeat._carry_stranded(set(), ["ddipg-member-2"], owed) == {"ddipg-member-2"}
+    settled = k8s_api.PostgresReclaim(reclaimed=[f"{CLUSTER}-3"])
+    assert heartbeat._carry_stranded({"ddipg-member-2"}, [], settled) == set()
+    # a kubeapi outage drops nothing: everything owed plus this tick's evictions stays forced
+    failed = k8s_api.PostgresReclaim(error="kubeapi status 503")
+    assert heartbeat._carry_stranded({"ddipg-member-2"}, ["ddipg-member-4"], failed) == {
+        "ddipg-member-2",
+        "ddipg-member-4",
+    }
+
+
 def test_a_claim_on_a_node_that_still_exists_is_left_alone(monkeypatch) -> None:
     # NotReady is not gone: the Node object is still registered, so the node
     # (and the data on it) can come back. Only a hostname absent from the

--- a/agent/supervisor/tests/test_postgres_storage_reclaim.py
+++ b/agent/supervisor/tests/test_postgres_storage_reclaim.py
@@ -179,6 +179,45 @@ def test_a_target_primary_counts_as_the_primary(monkeypatch) -> None:
     assert rec.deleted == []
 
 
+def test_a_cluster_that_names_no_primary_defers_everything(monkeypatch) -> None:
+    # No currentPrimary/targetPrimary in the status (none yet, or wiped by an
+    # operator restart): the primary is UNKNOWN, not absent. The first cut
+    # read an empty primary set as "everything is a replica" and would have
+    # deleted a stranded primary's PGDATA (review, point 2).
+    gets = _world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS)
+    gets[CR_PATH] = (200, {"spec": {"instances": 3}, "status": {"readyInstances": 2}})
+    rec = _Recorder(gets)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    out = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert (out.reclaimed, out.deferred, out.error) == ([], [f"{CLUSTER}-3"], None)
+    assert "no current or target primary" in out.deferred_reason
+    assert rec.deleted == []
+
+
+def test_a_cluster_with_no_status_at_all_defers_everything(monkeypatch) -> None:
+    gets = _world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS)
+    gets[CR_PATH] = (200, {"spec": {"instances": 3}})
+    rec = _Recorder(gets)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    out = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert (out.reclaimed, out.deferred) == ([], [f"{CLUSTER}-3"])
+    assert rec.deleted == []
+
+
+def test_the_primary_deferral_says_why(monkeypatch) -> None:
+    rec = _Recorder(_world(pvcs=_LIVE_PVCS, pvs=_LIVE_PVS, current=f"{CLUSTER}-3"))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    out = k8s_api.reclaim_stranded_postgres_storage()
+
+    assert out.deferred == [f"{CLUSTER}-3"]
+    assert "current or target primary" in out.deferred_reason
+
+
 def test_a_whole_postgres_is_one_cheap_read(monkeypatch) -> None:
     rec = _Recorder(_world(ready=3, pvcs=_LIVE_PVCS, pvs=_LIVE_PVS))
     monkeypatch.setattr(k8s_api, "_request", rec)

--- a/charts/spatiumddi-appliance/templates/supervisor-rbac.yaml
+++ b/charts/spatiumddi-appliance/templates/supervisor-rbac.yaml
@@ -213,6 +213,18 @@ rules:
     resources: ["deployments"]
     resourceNames: ["coredns"]
     verbs: ["get", "patch"]
+    # #1058 — the dead-node evict reclaims the CloudNativePG instance claim
+    # the deleted node stranded (k8s_api.reclaim_stranded_postgres_storage,
+    # every seed heartbeat). "Stranded" is decided from the bound PV's
+    # required node affinity — the thing the scheduler enforces — and
+    # PersistentVolumes are cluster-scoped, so the read lives here. Without
+    # the verb the GET 403s and the reclaim refuses to act
+    # (``postgres_storage_reclaim_failed`` on every degraded tick) rather
+    # than guess from the scheduler's selected-node annotation; the first
+    # cut of the fix did guess, and the review caught it. ``get`` only.
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Fixes #1058 — after a dead-node replace, the Postgres instance that lived on the dead member never comes back; the seed now reclaims its node-affine claim so CloudNativePG re-creates the instance on a live node.

Root-caused and validated live on nested 3-node QA clusters (the same HA drill sequence that surfaced #1058: leader kill, operator restart storm, member partition, then `dead_node_replace`), on the day's nightly plus #1053 — one build-and-break iteration after the mechanism was pinned on the unfixed build, and a second live round after review (the five review findings below are all fixed and re-proven).

## 1. What happens today

`POST /api/v1/appliance/fleet/control-plane/{id}/replace` flags the dead row `evict_requested`; on its next heartbeat the seed deletes the k8s Node (`k8s_api.delete_node`) and reclaims the dead node's **Redis** claim (#590), on the premise recorded in that code that "CNPG manages (deletes + recreates) its own instance PVCs". It does not.

Live, 77 minutes after the replacement member had joined (`kubectl` on the seed):

```
NAME                                      READY   STATUS    RESTARTS   AGE   NODE
spatium-control-spatiumddi-postgresql-1   1/1     Running   0          86m   ddipg-seed
spatium-control-spatiumddi-postgresql-2   1/1     Running   1          128m  ddipg-member-1
spatium-control-spatiumddi-postgresql-3   0/1     Pending   0          77m   <none>

Warning  FailedScheduling  15m (x12 over 65m)  default-scheduler  0/3 nodes are available:
  3 node(s) didn't match PersistentVolume's node affinity. no new claims to deallocate, preemption: ...

persistentvolume/pvc-f1381dbc-…  claim: spatium-control-spatiumddi-postgresql-3
  affinity: {"required":{"nodeSelectorTerms":[{"matchExpressions":[
             {"key":"kubernetes.io/hostname","operator":"In","values":["ddipg-member-2"]}]}]}}

Cluster status: instances 3, readyInstances 2, phase "Waiting for the instances to become active",
  healthyPVC [postgresql-1, postgresql-2, postgresql-3], instancesStatus.failed [postgresql-3]
```

`ddipg-member-2` is the node the replace evicted; `ddipg-member-3` is the replacement, `Ready`, `control-plane,etcd`, hosting no Postgres instance. The operator log over the whole window is `"Defaulting for Cluster"` every two seconds — it reconciles and waits. `GET /api/v1/appliance/cluster/health` meanwhile says `is_ha: true, nodes_ready: 3` with the `postgresql` workload `degraded 2/3`.

The mechanism is the local-path provisioner's contract: the PV is pinned to the hostname it was provisioned on, the Node is gone, and CNPG's documented behaviour for a lost node is to keep re-using the claim ("Pods are restarted using PVCs if available"); the operator only ever destroys a claim itself inside a `nodeMaintenanceWindow` with `reusePVC: false`, i.e. a controlled drain of a node that still exists. The chart README already documents the manual repair for exactly this shape (delete the replica's claim, then the pod; CNPG re-clones it from the primary) — an appliance has to do it itself.

### Why it sometimes looked self-healing

`_committed_cp_count` stops counting the replaced row the moment `/replace` clears its `cluster_role`, so the seed's cp-size block patches CNPG `spec.instances` 3 → 2 on the same tick it deletes the Node, and back to 3 when the replacement settles `ready`. CloudNativePG only creates or removes instances while every instance pod reports Ready, and its scale-down sacrifices the highest-serial ready non-primary pod. So the outcome of a replace has been a race against the kubelet's ~40 s node-monitor grace: a tick that lands while the dead node's pod still reads Ready makes CNPG sacrifice precisely that instance (its claim goes with it, and the later scale-up joins a fresh instance on the replacement — the "CNPG manages its own PVCs" observation); a tick that lands after the pod went NotReady makes CNPG refuse to scale at all, the spec returns to 3 with three claims already present, and the stranded one is never reclaimed. Two consecutive nightly walks of the same drill produced one of each: the first converged ("CNPG=3 after 128.9s" at the next tier's gate), the second sat at 2 of 3 for 77 minutes. On the fixed build's own run the losing branch was observed live: the seed logged the scale request (`cnpg_instances_scaled size 2`) at the eviction tick and CNPG kept `instances 3` with the stranded pod Pending for the next nine minutes, until the reclaim below removed the claim. The transient scale-down is left as it is in this PR (see Tradeoffs).

## 2. The fix

`agent/supervisor/spatium_supervisor/k8s_api.reclaim_stranded_postgres_storage`, run from the seed's heartbeat right after the eviction block, on every control-plane tick:

* one `GET` of the Cluster CR while Postgres is whole (`readyInstances >= spec.instances`) and nothing was evicted this tick and nothing is owed from an earlier one — otherwise it lists Nodes and the namespace's claims and reads each CNPG claim's PV. The PV read is cluster-scoped, so the supervisor's `spatium-supervisor-nodes` ClusterRole gains `persistentvolumes: get`; a read that is forbidden or failing is an error the journal reports (`postgres_storage_reclaim_failed`), never a guess, and only a PV that does not exist (404) falls back to the scheduler's `selected-node` annotation — the reclaim line records which one decided (`affinity_source`);
* a claim is **stranded** only when every hostname its PV's required node affinity names is absent from the Node list, where the names the seed evicted on this very tick count as absent whatever the list says (the Node DELETE is milliseconds old and can still be listed). A NotReady node still exists and can bring its data back, so its claims are left alone; a readable PV with no hostname affinity is network storage and is never stranded;
* stranded claims are deleted first, then the instance's Pending pod — the order the operator's own instance deletion uses (the pod-first order is the `cnpg destroy` race in cloudnative-pg#10846); the pod delete's status counts (a refused one leaves the claim Terminating under pvc-protection and CNPG unable to re-create a claim of that name, so it is an error), and a claim still Terminating from an earlier tick is reported as pending, never as reclaimed again; CloudNativePG then joins a fresh replica from the primary on a live node;
* **only a replica's claim is ever deleted.** An instance the Cluster still names as `currentPrimary` or `targetPrimary` is deferred and logged (`supervisor.heartbeat.postgres_storage_reclaim_deferred`, with the reason) — and so is every instance while the Cluster names no primary at all: an unknown primary is not "no primary". The deferral names its node, the heartbeat carries it, and the next tick retries even while the Cluster reads whole; by then the operator has failed over (the primary's pod is gone with the node) and the same instance is a stranded replica. Because the sweep runs every tick rather than once at eviction, a deferred primary and a seed-supervisor restart both converge;
* claims are recognised by CNPG's own labels (`cnpg.io/cluster`, `cnpg.io/instanceName`) with the documented `<cluster>-<ordinal>[-wal|-tbs-<name>]` naming as the fallback; Redis's, the slot-image mirror's and any other component's claims are never touched here; kubeapi errors are surfaced, never guessed around.

Journal lines: `supervisor.heartbeat.postgres_storage_reclaimed` (the claims, the nodes evicted this tick, and `affinity_source` per claim), `…_reclaim_deferred` (with its reason), `…_reclaim_pending` (a claim still Terminating), `…_reclaim_failed`.

## Validation on real hardware

Two live rounds. The first ran the first cut of this branch and is kept below because it is the unfixed-versus-fixed comparison; review then showed two things about it that the numbers alone did not: the supervisor's ClusterRole had no `persistentvolumes` grant, so that run's reclaim decided on the scheduler's annotation (the PV read was a 403 the first cut fell back from), and the reclaim landed 10 min 31 s after the eviction not only because of the transient scale-down but because the eviction tick itself could not act on a Node still listed milliseconds after its deletion. The second round runs the amended branch and records which read decided.

### Round 2 — the amended branch (after review)

Same topology, same drill sequence, this time with the QA harness's full-lane knobs (serving roles on every node, formation graded before any repair) and the drill graded against the whole gate predicate rather than `nodes_ready`.

RBAC, on the seed of the amended build:

```
$ kubectl auth can-i get persistentvolumes --as=system:serviceaccount:spatium:spatium-supervisor
yes
$ curl -sk -H "Authorization: Bearer $(kubectl -n spatium create token spatium-supervisor)" \
    -o /dev/null -w '%{http_code}\n' https://127.0.0.1:6443/api/v1/persistentvolumes/<pv>
200
```

(On the unamended chart the `spatium-supervisor-nodes` ClusterRole grants nodes, etcdsnapshotfiles and the coredns deployment only — that request is a 403, which is what the first cut silently fell back from.)

The eviction tick, seed journal (structlog), verbatim:

```
02:49:17.170Z supervisor.heartbeat.cnpg_instances_scaled      size=2
02:49:17.350Z supervisor.heartbeat.node_evicted               node=ddipg-member-2
02:49:17.750Z supervisor.heartbeat.redis_storage_reclaimed    node=ddipg-member-2 pvcs=[data-spatium-control-spatiumddi-redis-2]
02:49:18.231Z supervisor.heartbeat.postgres_storage_reclaimed pvcs=[spatium-control-spatiumddi-postgresql-3]
                                                              evicted=[ddipg-member-2]
                                                              affinity_source={spatium-control-spatiumddi-postgresql-3: pv}
```

The stranded claim goes **0.88 s after the Node deletion, on the same tick** — decided by the volume's own node affinity, with the transient `spec.instances` 3→2 (#1059) requested 0.2 s earlier and no longer in the way. Round 1's first cut had needed 10 min 31 s for the same claim.

At t+30 s (02:49:26Z, 9 s after the deletion) `kubectl get nodes` no longer listed `ddipg-member-2`. The reclaim did not need the list: the name it had just evicted was authority enough.

After it, on the same cluster: CloudNativePG joined a fresh `postgresql-3` on the replacement node — at the end of the drill its claim's PV is pinned `kubernetes.io/hostname In [ddipg-member-3]`, and no claim or volume names `ddipg-member-2` any more — and the QA drill, now graded against the whole gate predicate rather than three Ready nodes, read:

```
ha/dead_node_replace  pass  recovered in 833.9s; serving 100.0% (replacement=<replacement-node>; 3/3 ready, HA, CNPG=3 after 182.0s)
```

i.e. the cluster was whole (nodes 3/3, control plane 3, every promoted row settled, CNPG 3/3) 182 s after the replacement's nodes came Ready — the join of a fresh replica, nothing else. The rolling-upgrade tier's pre-roll predicate, run afterwards against the API from the harness: `(True, '3/3 ready, HA, CNPG=3 after 1.2s', 1.2)` (at 2026-09-12T03:05:28Z). The rest of the HA sequence on the same run: leader kill recovered in 117.0 s with the survivors answering 29/29 DHCP exchanges (100 %, graded against the 99 % floor this time — the serving roles were placed on every node), operator restart storm 17.3 s, member partition 155.8 s; no k3s restarts, no OOM.

### Round 1 — the first cut (unfixed vs fixed)

Nested 3-node clusters (seed 8 GiB/4 vCPU, members 6 GiB/2 vCPU), the full HA drill sequence ending in `dead_node_replace` (the member VM destroyed, `/replace` posted, a fresh member installed, approved and promoted under a new hostname), then the rolling-upgrade tier's pre-roll gate, which requires nodes 3/3, control-plane 3, every promoted row `ready` (or a `left` tombstone once the counts are whole) and CNPG 3/3.

| | before (this nightly + #1053) | after (same + this PR) |
|---|---|---|
| CNPG `readyInstances` after the replacement joined | 2 of 3, still 2 of 3 after 77 min | 2 of 3 "Waiting for the instances to become active" until the reclaim, "Creating a new replica" 16 s after the replacement joined, **3 of 3 under four minutes after the join** ("Cluster in healthy state") |
| stranded claim / PV | `postgresql-3` Bound, PV pinned to the deleted node, for good | reclaimed 16 s after the replacement joined (10 min 31 s after the eviction); no claim or PV pinned to the deleted node afterwards |
| instance on the replacement node | none | a fresh claim pinned to the replacement, `postgresql-3-join` (pg_basebackup from the primary) on it within 90 s, `postgresql-3` ready |
| `cluster/health` `postgresql` workload | degraded 2/3 (`is_ha: true`) | healthy 3/3 |
| pre-roll gate (`cluster_present` predicate: nodes 3/3, control plane 3, promoted rows settled, CNPG 3) | fail after 900 s: `CNPG instances=2 (want 3)` | pass: `3/3 ready, HA, CNPG=3 after 9.2s` |
| seed journal | `node_evicted`, `redis_storage_reclaimed` only | `node_evicted` → `redis_storage_reclaimed` (same tick) → `postgres_storage_reclaimed pvcs=["spatium-control-spatiumddi-postgresql-3"]` once the replacement had joined and CNPG was one instance short |

Verbatim, from the fixed build's run (seed journal, structlog):

```
21:11:23.711Z supervisor.heartbeat.cnpg_instances_scaled   size=2
21:11:23.988Z supervisor.heartbeat.node_evicted            node=ddipg-member-2
21:11:24.414Z supervisor.heartbeat.redis_storage_reclaimed node=ddipg-member-2 pvcs=[data-spatium-control-spatiumddi-redis-2]
21:21:55.493Z supervisor.heartbeat.postgres_storage_reclaimed pvcs=[spatium-control-spatiumddi-postgresql-3] evicted=[]
```

Nine minutes before that last line, CNPG on the same cluster (the unfixed state the sweep then repaired):

```
spatium-control-spatiumddi-postgresql-3   0/1   Pending   0   8m58s   <none>   <none>
status: instances 3, readyInstances 2, phase "Waiting for the instances to become active"
```

Ninety seconds after it, with the replacement (`ddipg-member-3`) Ready for under two minutes:

```
persistentvolumeclaim/spatium-control-spatiumddi-postgresql-3   Bound   pvc-3f388f0d-…   8Gi   local-path   69s
persistentvolume/pvc-3f388f0d-…  affinity: kubernetes.io/hostname In [ddipg-member-3]
spatium-control-spatiumddi-postgresql-3-join-2xhhq   0/1   Init:0/1   0   67s   ddipg-member-3
status: instances 3, readyInstances 2, phase "Creating a new replica"
```

Under four minutes after the reclaim the Cluster reported `readyInstances 3`, phase "Cluster in healthy state"; the pre-roll gate's own predicate, run from the QA harness against the API: `(True, '3/3 ready, HA, CNPG=3 after 9.2s')`. The dead node's instance was a replica on this run (the primary had moved to another member during the earlier leader-kill drill), so the primary-deferral path is covered by the unit tests rather than by this drill.

Physical floors that shape the timings: the kubelet's node-monitor grace (40 s; 50 s on k8s ≥ 1.32) plus the 20 s `NoExecute` toleration before a dead node's pods leave the API; the pod GC's 20 s sweep of pods bound to a deleted Node; the seed's heartbeat interval; and the `pg_basebackup` join of a freshly-installed appliance database (under four minutes here), which is what "3 of 3" waits on once the claim is gone.

## Tests

`agent/supervisor/tests/test_postgres_storage_reclaim.py` pins the contract (28 cases — the first 14 plus one per review finding: a forbidden, failing or unreachable PV read is an error with nothing deleted and only a missing PV falls back to the annotation, with the source recorded; a Cluster that names no primary, or has no status, defers everything and says why; the eviction tick reclaims with the Node still listed and the dead pod still reading Ready, a deferral names its node and the heartbeat carries it; a refused pod delete is an error with the claim still counted, a Terminating claim is pending not reclaimed, a vanished claim is not counted; the original 14: the live shape reclaims exactly the replica's claim then its pod; the current and the target primary are deferred, never deleted; a whole Postgres is one read; an eviction this tick scans past a stale status; a claim on a node that still exists — NotReady included — is left alone; WAL/tablespace claims go with their instance; unlabelled claims by CNPG naming; another cluster's, Redis's and network-storage claims are never touched; kubeapi failures and a refused delete are reported). `python -m pytest tests -q` in `agent/supervisor`: 402 passed (374 pre-existing + 28). No pre-existing failures.

CI mirror: agent tests as CI runs them (`pip install -e ".[dev]" && python -m pytest tests -q`, Python 3.14) green; the charts gate (`helm lint` + template + kubeconform) green with the rendered `spatium-supervisor-nodes` ClusterRole carrying `persistentvolumes: get`; gitleaks unchanged against the base (the same 4 pre-existing findings, delta 0). No `backend/`, `frontend/`, `appliance/` or migration paths are touched.

## Tradeoffs and known remaining work

* **The transient `spec.instances` 3 → 2 during a replace is left alone.** It is what `_committed_cp_count` implies and it also scales api/worker/frontend/redis, so changing it is a control-plane accounting decision, not a storage fix. It is worth its own look: when the dead node's instance is the primary at that moment, CNPG's scale-down (if it fires) sacrifices the *healthy* replica instead. This PR's sweep still converges that case — once the operator has failed over, the stranded claim is reclaimed and CNPG re-creates what is missing — but a replace should not have to pass through a primary-only window.
* `cluster/health` keeps `is_ha = control_plane_nodes > 1`; the `postgresql` workload row already reports `degraded 2/3` and is what the QA gate reads. Whether `is_ha` should also require the database to be whole is a UI/API contract question, not changed here.
* The slot-image mirror's claim has the same node affinity. Its Deployment references a fixed claim name, so reclaiming it would need the claim re-created from the chart; not done here, noted for the upgrade path.
* The replaced appliance row stays `approved`/`left` with its role assignments (the documented terminal state); nothing here changes the row.
* The QA drill that surfaced this graded `dead_node_replace` green on `nodes_ready >= 3` while CNPG sat at 2/3; the harness will grade the full gate predicate there (tracked on the QA side).

## Verification still to come

The QA side carries every open fix of ours, stacked on the next nightly's bytes, through a PostQA walk of both topologies (single node, then the three-node cluster). This fix rides that walk; the `dead_node_replace` drill's result on the stacked build will be posted here, as was done on #1053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
