### PR TITLE
fix(dns-agent): a deferred daemon start is a wait, not a death (#1056)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1279,6 +1279,26 @@ the formatter handles the rest.
 
 ### Fixed
 
+- **A DNS agent whose first config had not arrived yet exited 2 one
+  second after logging `named_conf_missing_startup_deferred`, so every
+  freshly joined cluster member's bind pod crash-looped until its
+  bundle landed (#1056).** `Bind9Driver.start_daemon()` (and
+  PowerDNS's) legitimately returns without a daemon when nothing is
+  rendered yet — the sync loop starts it after the first bundle — but
+  the supervisor read "not running" as "died" from its first tick. A
+  deferred start is now a wait: the liveness exit needs a daemon that
+  was actually launched (`DriverBase.daemon_launched()`), the wait is
+  re-logged on a backoff and carried in the heartbeat as
+  `daemon.status=degraded`, and a requested stop (SIGTERM from a
+  rollout or a scale-down, wherever it lands in the loop) exits 0
+  instead of reporting the threads it just stopped as
+  `dns_agent_thread_died`. Observed on nested 3-node QA clusters: a
+  member's bind pod restart count of +2 on a healthy join is now 0,
+  and a DaemonSet rollout ends the old container 0, not 2. The
+  umbrella chart's DNS agents gain the liveness probe the appliance
+  chart already had (tcp :53, 30 s / 30 s), so a bundle that never
+  comes is still a bounded restart on both charts.
+
 
 - **Both OS slots ended up labelled `root_a` after an A/B upgrade, and
   the #995 "Keep /var" reinstall silently stopped being offered

--- a/agent/dns/spatium_dns_agent/drivers/base.py
+++ b/agent/dns/spatium_dns_agent/drivers/base.py
@@ -26,6 +26,13 @@ RRSET_OP_KINDS = frozenset({"create", "update", "delete"})
 
 
 class DriverBase(ABC):
+    #: PID of the daemon this driver spawned or adopted; ``None`` until then.
+    #: Every driver sets it at its spawn / adopt points (``start_daemon`` and
+    #: the system-wide look-up in ``daemon_running``) and never clears it, so
+    #: it is also the "has the daemon been launched at all" fact that
+    #: :meth:`daemon_launched` reports.
+    daemon_pid: int | None = None
+
     def __init__(self, state_dir: Path):
         self.state_dir = state_dir
 
@@ -62,6 +69,21 @@ class DriverBase(ABC):
     @abstractmethod
     def daemon_running(self) -> bool:
         ...
+
+    def daemon_launched(self) -> bool:
+        """True once this driver has spawned or adopted its daemon.
+
+        ``start_daemon`` does not always start one: the BIND9 and PowerDNS
+        drivers return WITHOUT a daemon when no config has been rendered yet
+        (``named_conf_missing_startup_deferred`` /
+        ``pdns_conf_missing_startup_deferred``) and leave the launch to
+        ``swap_and_reload``, which the sync loop reaches once the control
+        plane hands over the first bundle. A daemon that was never launched
+        cannot have died, so the supervisor consults this before it reads
+        ``daemon_running() == False`` as "exit and let the orchestrator
+        restart us" (#1056).
+        """
+        return self.daemon_pid is not None
 
     def daemon_version(self) -> str | None:
         """Version of the DNS daemon binary, e.g. ``"5.0.5"`` / ``"9.20.26"``.

--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -710,7 +710,6 @@ def _render_dnssec_policies(policies: list[dict[str, Any]]) -> str:
 
 class Bind9Driver(DriverBase):
     rendered_dir_name = "rendered"
-    daemon_pid: int | None = None
 
     # ── Render / validate / swap ────────────────────────────────────────────
 

--- a/agent/dns/spatium_dns_agent/drivers/powerdns.py
+++ b/agent/dns/spatium_dns_agent/drivers/powerdns.py
@@ -287,7 +287,6 @@ def render_dnsdist_conf(opts: dict[str, Any], has_cert: bool = False) -> str:
 class PowerDNSDriver(DriverBase):
     """PowerDNS agent driver — Phase 1."""
 
-    daemon_pid: int | None = None
 
     # ── Render / validate / swap ────────────────────────────────────────────
 

--- a/agent/dns/spatium_dns_agent/drivers/technitium.py
+++ b/agent/dns/spatium_dns_agent/drivers/technitium.py
@@ -615,7 +615,6 @@ def _record_params(rtype: str, value: str, rec: dict[str, Any]) -> dict[str, Any
 class TechnitiumDriver(DriverBase):
     """Technitium agent driver — v1."""
 
-    daemon_pid: int | None = None
 
     # ── Render / validate / swap ────────────────────────────────────────────
 

--- a/agent/dns/spatium_dns_agent/supervisor.py
+++ b/agent/dns/spatium_dns_agent/supervisor.py
@@ -28,6 +28,32 @@ from .sync import SyncLoop
 
 log = structlog.get_logger(__name__)
 
+#: What the heartbeat's ``daemon`` field carries while the daemon start is
+#: deferred (no bundle rendered yet, #1056). ``sync.py`` sets its own
+#: degraded verdicts on a failed apply and clears them after the next good
+#: poll; this one is set when the wait begins and cleared by the supervisor
+#: the moment the daemon is up — and only if it is still the supervisor's
+#: own, so a sync verdict set meanwhile is left alone.
+DEFERRED_DAEMON_STATUS: dict[str, str] = {
+    "status": "degraded",
+    "reason": "start deferred, no bundle yet",
+}
+
+
+def wait_log_due(ticks_waiting: int) -> bool:
+    """Whether the waiting state is logged on this tick (1 s each): the first
+    tick, then doubling to 32 s, then every minute. With the crash loop gone
+    this line is nearly the only signal a stuck agent produces, so it has to
+    be in a ``kubectl logs --tail`` an hour in — without a line a second."""
+    return ticks_waiting in (1, 2, 4, 8, 16, 32) or (
+        ticks_waiting >= 60 and ticks_waiting % 60 == 0
+    )
+
+
+def _clear_deferred_status(heartbeat) -> None:
+    if heartbeat.daemon_status.get("reason") == DEFERRED_DAEMON_STATUS["reason"]:
+        heartbeat.daemon_status = {"status": "ok"}
+
 
 def _select_driver(cfg: AgentConfig) -> DriverBase:
     if cfg.driver == "bind9":
@@ -146,6 +172,7 @@ def run(cfg: AgentConfig) -> int:
     # liveness probe (tcp :53) still bounds the wait if no bundle ever comes.
     daemon_managed_drivers = {"bind9", "powerdns", "technitium"}
     waiting_since: float | None = None
+    waiting_ticks = 0
     while not stopping.is_set():
         time.sleep(1.0)
         # A stop requested during the tick (SIGTERM / SIGINT: a DaemonSet
@@ -167,6 +194,8 @@ def run(cfg: AgentConfig) -> int:
                         waited_s=round(time.monotonic() - waiting_since, 1),
                     )
                     waiting_since = None
+                    waiting_ticks = 0
+                    _clear_deferred_status(heartbeat)
             elif driver.daemon_launched():
                 # The stop check above closes the 1 s sleep, not the checks
                 # themselves: ``_sig`` runs between bytecodes, so a SIGTERM
@@ -176,14 +205,19 @@ def run(cfg: AgentConfig) -> int:
                 if not stopping.is_set():
                     log.error("dns_daemon_exited", driver=cfg.driver)
                     return 2
-            elif waiting_since is None:
-                waiting_since = time.monotonic()
-                log.info(
-                    "dns_daemon_start_deferred_waiting",
-                    driver=cfg.driver,
-                    note="start_daemon spawned nothing (no rendered config yet); "
-                    "the sync loop launches the daemon after the first bundle",
-                )
+            else:
+                if waiting_since is None:
+                    waiting_since = time.monotonic()
+                    heartbeat.daemon_status = dict(DEFERRED_DAEMON_STATUS)
+                waiting_ticks += 1
+                if wait_log_due(waiting_ticks):
+                    log.info(
+                        "dns_daemon_start_deferred_waiting",
+                        driver=cfg.driver,
+                        waited_s=round(time.monotonic() - waiting_since, 1),
+                        note="start_daemon spawned nothing (no rendered config yet); "
+                        "the sync loop launches the daemon after the first bundle",
+                    )
         # If any critical thread died (e.g. the sync loop dropped its
         # token after a 401/404 and self-stopped), exit so the container
         # orchestrator restarts us — bootstrap then re-registers from

--- a/agent/dns/spatium_dns_agent/supervisor.py
+++ b/agent/dns/spatium_dns_agent/supervisor.py
@@ -172,7 +172,12 @@ def run(cfg: AgentConfig) -> int:
     # liveness probes (tcp :53 — the appliance chart's, and the umbrella
     # chart's since #1056) still bound the wait if no bundle ever comes.
     daemon_managed_drivers = {"bind9", "powerdns", "technitium"}
-    waiting_since: float | None = None
+    # The deferred wait can only ever begin here — ``daemon_launched()`` never
+    # goes back to False — so it is measured from the loop's start (a breath
+    # after ``start_daemon`` deferred), not from the tick that first noticed
+    # it: the re-log then reads 1, 2, 4, 8 … s, the schedule's own numbers.
+    loop_started = time.monotonic()
+    waiting = False
     waiting_ticks = 0
     while not stopping.is_set():
         time.sleep(1.0)
@@ -188,13 +193,13 @@ def run(cfg: AgentConfig) -> int:
             break
         if cfg.driver in daemon_managed_drivers:
             if driver.daemon_running():
-                if waiting_since is not None:
+                if waiting:
                     log.info(
                         "dns_daemon_launched_after_deferred_start",
                         driver=cfg.driver,
-                        waited_s=round(time.monotonic() - waiting_since, 1),
+                        waited_s=round(time.monotonic() - loop_started, 1),
                     )
-                    waiting_since = None
+                    waiting = False
                     waiting_ticks = 0
                     _clear_deferred_status(heartbeat)
             elif driver.daemon_launched():
@@ -207,15 +212,15 @@ def run(cfg: AgentConfig) -> int:
                     log.error("dns_daemon_exited", driver=cfg.driver)
                     return 2
             else:
-                if waiting_since is None:
-                    waiting_since = time.monotonic()
+                if not waiting:
+                    waiting = True
                     heartbeat.daemon_status = dict(DEFERRED_DAEMON_STATUS)
                 waiting_ticks += 1
                 if wait_log_due(waiting_ticks):
                     log.info(
                         "dns_daemon_start_deferred_waiting",
                         driver=cfg.driver,
-                        waited_s=round(time.monotonic() - waiting_since, 1),
+                        waited_s=round(time.monotonic() - loop_started, 1),
                         note="start_daemon spawned nothing (no rendered config yet); "
                         "the sync loop launches the daemon after the first bundle",
                     )

--- a/agent/dns/spatium_dns_agent/supervisor.py
+++ b/agent/dns/spatium_dns_agent/supervisor.py
@@ -168,8 +168,14 @@ def run(cfg: AgentConfig) -> int:
                     )
                     waiting_since = None
             elif driver.daemon_launched():
-                log.error("dns_daemon_exited", driver=cfg.driver)
-                return 2
+                # The stop check above closes the 1 s sleep, not the checks
+                # themselves: ``_sig`` runs between bytecodes, so a SIGTERM
+                # that lands inside ``daemon_running()`` (a rollout that took
+                # named first) arrives here with the daemon gone and the stop
+                # already requested. A stop is a stop, whenever it lands.
+                if not stopping.is_set():
+                    log.error("dns_daemon_exited", driver=cfg.driver)
+                    return 2
             elif waiting_since is None:
                 waiting_since = time.monotonic()
                 log.info(
@@ -183,7 +189,7 @@ def run(cfg: AgentConfig) -> int:
         # orchestrator restarts us — bootstrap then re-registers from
         # PSK with a fresh empty token cache.
         dead = [t.name for t in threads if not t.is_alive()]
-        if dead:
+        if dead and not stopping.is_set():
             log.error("dns_agent_thread_died", threads=dead)
             return 2
 

--- a/agent/dns/spatium_dns_agent/supervisor.py
+++ b/agent/dns/spatium_dns_agent/supervisor.py
@@ -168,8 +168,9 @@ def run(cfg: AgentConfig) -> int:
     # container until the bundle happened to arrive inside the 1 s window
     # (#1056: ``dns_daemon_exited`` 1.0 s after the deferral, Last State
     # exit 2, restart count +2 on a member). So: wait while nothing has
-    # been launched, exit only when a launched daemon is gone. The chart's
-    # liveness probe (tcp :53) still bounds the wait if no bundle ever comes.
+    # been launched, exit only when a launched daemon is gone. The charts'
+    # liveness probes (tcp :53 — the appliance chart's, and the umbrella
+    # chart's since #1056) still bound the wait if no bundle ever comes.
     daemon_managed_drivers = {"bind9", "powerdns", "technitium"}
     waiting_since: float | None = None
     waiting_ticks = 0

--- a/agent/dns/spatium_dns_agent/supervisor.py
+++ b/agent/dns/spatium_dns_agent/supervisor.py
@@ -129,12 +129,45 @@ def run(cfg: AgentConfig) -> int:
     # process (BIND9, PowerDNS, Technitium). If the daemon dies, we exit
     # non-zero so the orchestrator restarts the container — agent + daemon
     # are bound lifecycle-wise.
+    #
+    # "Dies" presumes it was launched. ``start_daemon()`` above returns
+    # WITHOUT a daemon when no config has been rendered yet (BIND9
+    # ``named_conf_missing_startup_deferred``, PowerDNS
+    # ``pdns_conf_missing_startup_deferred``) and the sync loop launches it
+    # from ``swap_and_reload`` once the first bundle lands. The first bind
+    # pod on a freshly joined cluster member always boots that way — its
+    # state dir is empty and the control plane has not built its bundle
+    # yet — and reading that deferred start as a death made this loop
+    # return 2 one tick after boot: kubelet then back-off-restarted the
+    # container until the bundle happened to arrive inside the 1 s window
+    # (#1056: ``dns_daemon_exited`` 1.0 s after the deferral, Last State
+    # exit 2, restart count +2 on a member). So: wait while nothing has
+    # been launched, exit only when a launched daemon is gone. The chart's
+    # liveness probe (tcp :53) still bounds the wait if no bundle ever comes.
     daemon_managed_drivers = {"bind9", "powerdns", "technitium"}
+    waiting_since: float | None = None
     while not stopping.is_set():
         time.sleep(1.0)
-        if cfg.driver in daemon_managed_drivers and not driver.daemon_running():
-            log.error("dns_daemon_exited", driver=cfg.driver)
-            return 2
+        if cfg.driver in daemon_managed_drivers:
+            if driver.daemon_running():
+                if waiting_since is not None:
+                    log.info(
+                        "dns_daemon_launched_after_deferred_start",
+                        driver=cfg.driver,
+                        waited_s=round(time.monotonic() - waiting_since, 1),
+                    )
+                    waiting_since = None
+            elif driver.daemon_launched():
+                log.error("dns_daemon_exited", driver=cfg.driver)
+                return 2
+            elif waiting_since is None:
+                waiting_since = time.monotonic()
+                log.info(
+                    "dns_daemon_start_deferred_waiting",
+                    driver=cfg.driver,
+                    note="start_daemon spawned nothing (no rendered config yet); "
+                    "the sync loop launches the daemon after the first bundle",
+                )
         # If any critical thread died (e.g. the sync loop dropped its
         # token after a 401/404 and self-stopped), exit so the container
         # orchestrator restarts us — bootstrap then re-registers from

--- a/agent/dns/spatium_dns_agent/supervisor.py
+++ b/agent/dns/spatium_dns_agent/supervisor.py
@@ -148,6 +148,16 @@ def run(cfg: AgentConfig) -> int:
     waiting_since: float | None = None
     while not stopping.is_set():
         time.sleep(1.0)
+        # A stop requested during the tick (SIGTERM / SIGINT: a DaemonSet
+        # rollout, a scale-down, an operator) has already stopped every
+        # worker thread through ``_sig`` and may have taken the daemon with
+        # it. Whatever the checks below would find dead now died because we
+        # were told to stop — take the designed exit, not the crash exits,
+        # so the container's last state reads 0 rather than "thread died"
+        # / "daemon exited" (#1056: every rollout ended the old container
+        # with exit 2 and a dns_agent_thread_died in its log).
+        if stopping.is_set():
+            break
         if cfg.driver in daemon_managed_drivers:
             if driver.daemon_running():
                 if waiting_since is not None:

--- a/agent/dns/tests/test_supervisor_deferred_start.py
+++ b/agent/dns/tests/test_supervisor_deferred_start.py
@@ -291,7 +291,7 @@ def test_deferred_start_is_waited_out_then_a_real_death_exits_2(supervised) -> N
     assert rc == 2
     assert ticks[-1] == 6
     events = spy.events
-    assert events.count("dns_daemon_start_deferred_waiting") == 1
+    assert events.count("dns_daemon_start_deferred_waiting") == 2  # wait ticks 1 and 2
     assert (
         events.index("dns_daemon_start_deferred_waiting")
         < events.index("dns_daemon_launched_after_deferred_start")
@@ -316,7 +316,8 @@ def test_a_deferred_start_that_never_launches_is_not_an_exit(supervised) -> None
     assert sv.ticks[-1] == 5
     assert "dns_daemon_exited" not in sv.spy.events
     assert "dns_agent_thread_died" not in sv.spy.events
-    assert sv.spy.events.count("dns_daemon_start_deferred_waiting") == 1
+    # logged at ticks 1, 2 and 4 of the wait (the backoff schedule below)
+    assert sv.spy.events.count("dns_daemon_start_deferred_waiting") == 3
     assert "dns_agent_signal_received" in sv.spy.events
     assert sv.spy.events[-1] == "dns_agent_exiting"
 
@@ -419,3 +420,59 @@ def test_a_driver_that_does_not_manage_a_daemon_is_never_checked(supervised, age
     assert rc == 0
     assert "dns_daemon_start_deferred_waiting" not in sv.spy.events
     assert "dns_daemon_exited" not in sv.spy.events
+
+
+# ── the wait stays visible: re-logged on a backoff, degraded in the heartbeat ──
+
+
+def test_wait_log_schedule() -> None:
+    """The first tick, doubling to 32 s, then every minute — a ``--tail`` an
+    hour into the wait still shows the state, without a line a second."""
+    assert [n for n in range(1, 200) if supervisor.wait_log_due(n)] == [
+        1, 2, 4, 8, 16, 32, 60, 120, 180,
+    ]
+
+
+def test_the_waiting_state_is_relogged_on_the_backoff(supervised) -> None:
+    sv = supervised
+
+    rc = sv.run({130: sv.sigterm})
+
+    assert rc == 0
+    waits = [kw for _, e, kw in sv.spy.calls if e == "dns_daemon_start_deferred_waiting"]
+    assert len(waits) == 8  # ticks 1, 2, 4, 8, 16, 32, 60, 120
+    assert all(isinstance(kw["waited_s"], float) and kw["driver"] == "bind9" for kw in waits)
+
+
+def test_waiting_sets_the_heartbeat_daemon_status_and_the_launch_clears_it(supervised) -> None:
+    """The heartbeat carries ``daemon: {status: degraded, reason: start
+    deferred, no bundle yet}`` for as long as the wait lasts and ``ok`` once
+    the daemon is up. Sampled from inside ``daemon_running`` each tick."""
+    sv = supervised
+    seen: list[dict[str, Any]] = []
+    # sv.idles[0] is HeartbeatClient's stand-in; it exists once run() has
+    # constructed it, hence the late lookup.
+    sv.drv.hook_running = lambda: seen.append(dict(sv.idles[0].daemon_status))
+
+    rc = sv.run({5: sv.drv.launch, 7: sv.drv.die})
+
+    assert rc == 2
+    # tick 1 samples before the wait is marked; 2-5 during it; 6-7 after the
+    # launch cleared it.
+    assert seen[0] == {}
+    assert seen[1:5] == [supervisor.DEFERRED_DAEMON_STATUS] * 4
+    assert seen[5:] == [{"status": "ok"}, {"status": "ok"}]
+    assert sv.idles[0].daemon_status == {"status": "ok"}
+
+
+def test_a_sync_verdict_set_while_waiting_is_left_alone_on_launch(supervised) -> None:
+    """``sync.py`` owns its own degraded verdicts (a failed apply); the
+    supervisor clears only the one it set."""
+    sv = supervised
+    theirs = {"status": "degraded", "reason": "config_apply_reverted: bad acl"}
+
+    rc = sv.run({3: lambda: setattr(sv.idles[0], "daemon_status", dict(theirs)),
+                 5: sv.drv.launch, 7: sv.drv.die})
+
+    assert rc == 2
+    assert sv.idles[0].daemon_status == theirs

--- a/agent/dns/tests/test_supervisor_deferred_start.py
+++ b/agent/dns/tests/test_supervisor_deferred_start.py
@@ -38,6 +38,7 @@ import signal
 import threading
 import time
 import types
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -155,6 +156,9 @@ class _ScriptedDriver(DriverBase):
         super().__init__(state_dir)
         self.running = False
         self.start_calls = 0
+        #: Runs inside ``daemon_running`` — the place a signal can land
+        #: between the tick's stop check and the loop's crash exits.
+        self.hook_running: Callable[[], None] | None = None
 
     def render(self, bundle: dict[str, Any]) -> None:
         return None
@@ -172,6 +176,8 @@ class _ScriptedDriver(DriverBase):
         self.start_calls += 1  # deferred: nothing spawned, daemon_pid stays None
 
     def daemon_running(self) -> bool:
+        if self.hook_running is not None:
+            self.hook_running()
         return self.running
 
     def launch(self) -> None:
@@ -189,6 +195,7 @@ class _Idle:
         self._stop = threading.Event()
         self.config_apply: Any = None
         self.pending_acks: list[Any] = []
+        self.daemon_status: dict[str, Any] = {}
 
     def run(self) -> None:
         self._stop.wait()
@@ -257,7 +264,7 @@ def supervised(agent_cfg: AgentConfig, monkeypatch):
             action = script.get(ticks[-1])
             if action is not None:
                 action()
-            assert len(ticks) < 50, "the supervisor never exited"
+            assert len(ticks) < 1000, "the supervisor never exited"
 
         monkeypatch.setattr(supervisor.time, "sleep", fake_sleep)
         saved = {s: signal.getsignal(s) for s in (signal.SIGTERM, signal.SIGINT)}
@@ -348,6 +355,45 @@ def test_a_thread_that_dies_while_not_stopping_still_exits_2(supervised) -> None
     assert sv.ticks[-1] == 3
     assert ("error", "dns_agent_thread_died", {"threads": ["sync"]}) in sv.spy.calls
     assert "dns_agent_exiting" not in sv.spy.events
+
+
+def test_a_stop_that_lands_inside_the_daemon_check_is_still_a_stop(supervised) -> None:
+    """``_sig`` runs between bytecodes, so the tick's stop check closes the
+    1 s sleep but not the checks themselves: a SIGTERM that lands while the
+    loop is inside ``daemon_running()`` — a rollout that took named first —
+    used to reach ``dns_daemon_exited`` and exit 2."""
+    sv = supervised
+
+    def stop_inside_the_check() -> None:
+        sv.drv.hook_running = None
+        sv.drv.die()
+        sv.sigterm()
+
+    rc = sv.run({1: sv.drv.launch, 3: lambda: setattr(sv.drv, "hook_running", stop_inside_the_check)})
+
+    assert rc == 0
+    assert sv.ticks[-1] == 3
+    assert "dns_daemon_exited" not in sv.spy.events
+    assert "dns_agent_thread_died" not in sv.spy.events
+    assert sv.spy.events[-2:] == ["dns_agent_signal_received", "dns_agent_exiting"]
+
+
+def test_a_stop_that_lands_inside_the_thread_check_is_still_a_stop(supervised) -> None:
+    """The same window on the other check: the daemon is fine, the stop lands
+    after the daemon check has passed, and the threads it stopped are dead by
+    the time the thread check runs — ``dns_agent_thread_died``, exit 2."""
+    sv = supervised
+
+    def stop_after_the_daemon_check() -> None:
+        sv.drv.hook_running = None
+        sv.sigterm()
+
+    rc = sv.run({1: sv.drv.launch, 3: lambda: setattr(sv.drv, "hook_running", stop_after_the_daemon_check)})
+
+    assert rc == 0
+    assert sv.ticks[-1] == 3
+    assert "dns_agent_thread_died" not in sv.spy.events
+    assert sv.spy.events[-2:] == ["dns_agent_signal_received", "dns_agent_exiting"]
 
 
 def test_a_daemon_that_was_running_at_boot_still_exits_on_death(supervised) -> None:

--- a/agent/dns/tests/test_supervisor_deferred_start.py
+++ b/agent/dns/tests/test_supervisor_deferred_start.py
@@ -1,0 +1,304 @@
+"""A deferred daemon start is a wait, not a death (#1056).
+
+``supervisor.run`` calls ``driver.start_daemon()`` once at boot, then polls
+``driver.daemon_running()`` every second and exits 2 — "the daemon died, let
+the orchestrator restart us" — the first time it answers False. But
+``start_daemon`` does not always start a daemon: the BIND9 and PowerDNS
+drivers return WITHOUT one when no config has been rendered yet
+(``named_conf_missing_startup_deferred`` / ``pdns_conf_missing_startup_deferred``)
+and leave the launch to ``swap_and_reload``, which the sync loop reaches once
+the control plane hands over the first bundle.
+
+The first bind pod on a freshly joined cluster member always boots that way —
+its state dir is empty and its bundle is not built yet — so the supervisor
+read "never started" as "died" one tick after boot, exited 2, and kubelet
+back-off-restarted the container until the bundle happened to land inside the
+1 s window. Observed on a nested 3-node QA cluster (2026-09-11): the previous
+container's whole log was ``named_conf_missing_startup_deferred`` at
+15:24:32.232 → shipper + ingest starting → heartbeat 200 → ``dns_daemon_exited``
+at 15:24:33.244; Last State exit 2; Restart Count 2; ``Back-off restarting
+failed container`` on every bind pod the two new members created.
+
+These tests pin the fixed contract: the liveness check is armed by the launch
+(a spawned or adopted pid), not by the boot.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import signal
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from spatium_dns_agent import supervisor
+from spatium_dns_agent.config import AgentConfig
+from spatium_dns_agent.drivers import bind9, powerdns
+from spatium_dns_agent.drivers.base import DriverBase
+from spatium_dns_agent.drivers.bind9 import Bind9Driver
+from spatium_dns_agent.drivers.powerdns import PowerDNSDriver
+
+
+class _LogSpy:
+    """Records ``(level, event, kwargs)`` — independent of structlog's global
+    configuration, which another test may have cached."""
+
+    LEVELS = ("debug", "info", "warning", "error", "exception", "critical")
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def __getattr__(self, name: str):
+        if name not in self.LEVELS:
+            raise AttributeError(name)
+
+        def _log(event: str, **kw: Any) -> None:
+            self.calls.append((name, event, kw))
+
+        return _log
+
+    @property
+    def events(self) -> list[str]:
+        return [e for _, e, _ in self.calls]
+
+
+# ── the drivers: what start_daemon leaves behind ──────────────────────────
+
+
+def test_bind9_deferred_start_launches_nothing(tmp_path: Path, monkeypatch) -> None:
+    """An empty state dir at boot: no named.conf, no spawn, no pid."""
+    monkeypatch.setattr(bind9, "find_running_daemon", lambda comm: None)
+    spy = _LogSpy()
+    monkeypatch.setattr(bind9, "log", spy)
+    drv = Bind9Driver(state_dir=tmp_path)
+
+    drv.start_daemon()
+
+    assert spy.events == ["named_conf_missing_startup_deferred"]
+    assert drv.daemon_launched() is False
+    assert drv.daemon_running() is False
+
+
+def test_powerdns_deferred_start_launches_nothing(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(powerdns, "find_running_daemon", lambda comm: None)
+    spy = _LogSpy()
+    monkeypatch.setattr(powerdns, "log", spy)
+    drv = PowerDNSDriver(state_dir=tmp_path)
+
+    drv.start_daemon()
+
+    assert spy.events == ["pdns_conf_missing_startup_deferred"]
+    assert drv.daemon_launched() is False
+    assert drv.daemon_running() is False
+
+
+def test_bind9_spawn_arms_the_liveness_check(tmp_path: Path, monkeypatch) -> None:
+    """Once named.conf exists the spawn records the pid — the tell the
+    supervisor arms on."""
+    conf = tmp_path / "rendered" / "named.conf"
+    conf.parent.mkdir()
+    conf.write_text("options {};\n")
+    monkeypatch.setattr(bind9, "find_running_daemon", lambda comm: None)
+    monkeypatch.setattr(bind9, "wait_for_daemon", lambda comm, pid, timeout_s=5.0: None)
+    spy = _LogSpy()
+    monkeypatch.setattr(bind9, "log", spy)
+    spawned: list[list[str]] = []
+
+    class _Popen:
+        pid = 4242
+
+        def __init__(self, cmd: list[str], *a: Any, **kw: Any) -> None:
+            spawned.append(list(cmd))
+
+    monkeypatch.setattr(bind9.subprocess, "Popen", _Popen)
+    drv = Bind9Driver(state_dir=tmp_path)
+
+    drv.start_daemon()
+
+    assert spawned == [["named", "-f", "-c", str(conf)]]
+    assert spy.events == ["named_started"]
+    assert drv.daemon_launched() is True
+    assert drv.daemon_pid == 4242
+
+
+def test_adopting_a_running_daemon_counts_as_launched(tmp_path: Path, monkeypatch) -> None:
+    """``daemon_running``'s system-wide look-up adopts a live daemon (#704);
+    that arms the check the same way a spawn does."""
+    monkeypatch.setattr(bind9, "find_running_daemon", lambda comm: 77)
+    drv = Bind9Driver(state_dir=tmp_path)
+
+    assert drv.daemon_launched() is False
+    assert drv.daemon_running() is True
+    assert drv.daemon_launched() is True
+    assert drv.daemon_pid == 77
+
+
+# ── the supervisor: armed by the launch, not the boot ─────────────────────
+
+
+class _ScriptedDriver(DriverBase):
+    """``start_daemon`` defers (no pid); the test flips the daemon up and down."""
+
+    def __init__(self, state_dir: Path) -> None:
+        super().__init__(state_dir)
+        self.running = False
+        self.start_calls = 0
+
+    def render(self, bundle: dict[str, Any]) -> None:
+        return None
+
+    def validate(self) -> None:
+        return None
+
+    def swap_and_reload(self) -> None:
+        return None
+
+    def apply_record_op(self, op: dict[str, Any]) -> dict[str, Any] | None:
+        return None
+
+    def start_daemon(self) -> None:
+        self.start_calls += 1  # deferred: nothing spawned, daemon_pid stays None
+
+    def daemon_running(self) -> bool:
+        return self.running
+
+    def launch(self) -> None:
+        self.daemon_pid = 4242
+        self.running = True
+
+    def die(self) -> None:
+        self.running = False
+
+
+class _Idle:
+    """Stands in for every thread-bearing component: blocks until stopped."""
+
+    def __init__(self, *a: Any, **kw: Any) -> None:
+        self._stop = threading.Event()
+        self.config_apply: Any = None
+        self.pending_acks: list[Any] = []
+
+    def run(self) -> None:
+        self._stop.wait()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+
+@pytest.fixture
+def supervised(agent_cfg: AgentConfig, monkeypatch):
+    """``supervisor.run`` with the network-facing parts stubbed and the 1 s
+    tick scripted.
+
+    Yields ``(driver, ticks, spy, run)``: ``run(script)`` executes the
+    supervisor, firing ``script[n]`` at tick ``n``, and returns the exit code.
+    """
+    drv = _ScriptedDriver(agent_cfg.state_dir)
+    idles: list[_Idle] = []
+
+    def _idle(*a: Any, **kw: Any) -> _Idle:
+        o = _Idle(*a, **kw)
+        idles.append(o)
+        return o
+
+    monkeypatch.setattr(supervisor, "ensure_token", lambda cfg: ("agent-id", "token"))
+    monkeypatch.setattr(supervisor, "_select_driver", lambda cfg: drv)
+    for name in (
+        "HeartbeatClient",
+        "SyncLoop",
+        "MetricsPoller",
+        "QueryLogShipper",
+        "RndcStatusPoller",
+        "IngestWorker",
+    ):
+        monkeypatch.setattr(supervisor, name, _idle)
+    spy = _LogSpy()
+    monkeypatch.setattr(supervisor, "log", spy)
+    ticks: list[int] = []
+
+    def run(script: dict[int, Any], cfg: AgentConfig | None = None) -> int:
+        def fake_sleep(seconds: float) -> None:
+            assert seconds == 1.0
+            ticks.append(len(ticks) + 1)
+            action = script.get(ticks[-1])
+            if action is not None:
+                action()
+            assert len(ticks) < 50, "the supervisor never exited"
+
+        monkeypatch.setattr(supervisor.time, "sleep", fake_sleep)
+        saved = {s: signal.getsignal(s) for s in (signal.SIGTERM, signal.SIGINT)}
+        try:
+            return supervisor.run(cfg if cfg is not None else agent_cfg)
+        finally:
+            for s, h in saved.items():
+                signal.signal(s, h)
+            for o in idles:
+                o.stop()
+
+    yield drv, ticks, spy, run
+
+
+def test_deferred_start_is_waited_out_then_a_real_death_exits_2(supervised) -> None:
+    """Three ticks with nothing launched must not exit; the death at tick 6 must."""
+    drv, ticks, spy, run = supervised
+
+    rc = run({4: drv.launch, 6: drv.die})
+
+    assert drv.start_calls == 1
+    assert rc == 2
+    assert ticks[-1] == 6
+    events = spy.events
+    assert events.count("dns_daemon_start_deferred_waiting") == 1
+    assert (
+        events.index("dns_daemon_start_deferred_waiting")
+        < events.index("dns_daemon_launched_after_deferred_start")
+        < events.index("dns_daemon_exited")
+    )
+    launched = next(
+        kw for _, e, kw in spy.calls if e == "dns_daemon_launched_after_deferred_start"
+    )
+    assert launched["driver"] == "bind9"
+    assert launched["waited_s"] >= 0
+    assert ("error", "dns_daemon_exited", {"driver": "bind9"}) in spy.calls
+
+
+def test_a_deferred_start_that_never_launches_is_not_an_exit(supervised) -> None:
+    """Nothing launched, ever: the loop waits until told to stop, and exits 0.
+    (In the pod, the chart's liveness probe on :53 bounds this wait.)"""
+    _drv, ticks, spy, run = supervised
+
+    rc = run({5: lambda: signal.raise_signal(signal.SIGTERM)})
+
+    assert rc == 0
+    assert ticks[-1] == 5
+    assert "dns_daemon_exited" not in spy.events
+    assert spy.events.count("dns_daemon_start_deferred_waiting") == 1
+    assert "dns_agent_signal_received" in spy.events
+    assert spy.events[-1] == "dns_agent_exiting"
+
+
+def test_a_daemon_that_was_running_at_boot_still_exits_on_death(supervised) -> None:
+    """The pre-#1056 contract is intact when ``start_daemon`` did spawn."""
+    drv, ticks, spy, run = supervised
+    drv.launch()  # what a real start_daemon leaves behind when named.conf exists
+
+    rc = run({2: drv.die})
+
+    assert rc == 2
+    assert ticks[-1] == 2
+    assert "dns_daemon_start_deferred_waiting" not in spy.events
+    assert spy.events[-1] == "dns_daemon_exited"
+
+
+def test_a_driver_that_does_not_manage_a_daemon_is_never_checked(supervised, agent_cfg) -> None:
+    """Only the daemon-managing drivers take the liveness exit at all."""
+    _drv, _ticks, spy, run = supervised
+    cfg = dataclasses.replace(agent_cfg, driver="something-else")
+
+    rc = run({3: lambda: signal.raise_signal(signal.SIGTERM)}, cfg=cfg)
+
+    assert rc == 0
+    assert "dns_daemon_start_deferred_waiting" not in spy.events
+    assert "dns_daemon_exited" not in spy.events

--- a/agent/dns/tests/test_supervisor_deferred_start.py
+++ b/agent/dns/tests/test_supervisor_deferred_start.py
@@ -21,6 +21,14 @@ failed container`` on every bind pod the two new members created.
 
 These tests pin the fixed contract: the liveness check is armed by the launch
 (a spawned or adopted pid), not by the boot.
+
+The same loop had a second misreading: on SIGTERM the handler stops every
+worker thread (and a rollout may take the daemon too), and the next tick's
+checks then found the threads it had just stopped dead and returned 2 —
+``dns_agent_thread_died`` on every DaemonSet rollout (containerd on the seed:
+``dns-bind9`` exit_status 2 at 21:20:53Z during the roles rollout, the
+``dhcp-kea`` container exit 0 the same second). A stop that was requested is
+the designed exit 0, whatever the stop killed.
 """
 
 from __future__ import annotations
@@ -28,6 +36,8 @@ from __future__ import annotations
 import dataclasses
 import signal
 import threading
+import time
+import types
 from pathlib import Path
 from typing import Any
 
@@ -187,16 +197,38 @@ class _Idle:
         self._stop.set()
 
 
+#: The names ``supervisor.run`` gives its worker threads, in construction
+#: order of the stubs that back them (heartbeat=idles[0], sync=idles[1], …).
+THREAD_NAMES = ("sync", "heartbeat", "metrics", "query-log", "rndc-status", "ingest")
+
+
 @pytest.fixture
 def supervised(agent_cfg: AgentConfig, monkeypatch):
     """``supervisor.run`` with the network-facing parts stubbed and the 1 s
     tick scripted.
 
-    Yields ``(driver, ticks, spy, run)``: ``run(script)`` executes the
-    supervisor, firing ``script[n]`` at tick ``n``, and returns the exit code.
+    Yields a namespace: ``run(script, cfg=None)`` executes the supervisor,
+    firing ``script[n]`` at tick ``n``, and returns the exit code; ``sigterm()``
+    raises SIGTERM and then waits for the stopped worker threads to actually
+    die — the order the live agent sees, since its 1 s sleep outlasts them;
+    ``settle(names)`` waits for just those threads; ``idles`` are the stubs.
     """
     drv = _ScriptedDriver(agent_cfg.state_dir)
     idles: list[_Idle] = []
+    real_sleep = time.sleep
+
+    def settle(names: tuple[str, ...] = THREAD_NAMES, timeout_s: float = 2.0) -> None:
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            alive = [t for t in threading.enumerate() if t.name in names and t.is_alive()]
+            if not alive:
+                return
+            real_sleep(0.005)
+        raise AssertionError(f"threads still alive: {[t.name for t in alive]}")
+
+    def sigterm() -> None:
+        signal.raise_signal(signal.SIGTERM)  # the handler runs before we return
+        settle()
 
     def _idle(*a: Any, **kw: Any) -> _Idle:
         o = _Idle(*a, **kw)
@@ -237,14 +269,16 @@ def supervised(agent_cfg: AgentConfig, monkeypatch):
             for o in idles:
                 o.stop()
 
-    yield drv, ticks, spy, run
+    yield types.SimpleNamespace(drv=drv, ticks=ticks, spy=spy, run=run,
+                                sigterm=sigterm, settle=settle, idles=idles)
 
 
 def test_deferred_start_is_waited_out_then_a_real_death_exits_2(supervised) -> None:
     """Three ticks with nothing launched must not exit; the death at tick 6 must."""
-    drv, ticks, spy, run = supervised
+    sv = supervised
+    drv, ticks, spy = sv.drv, sv.ticks, sv.spy
 
-    rc = run({4: drv.launch, 6: drv.die})
+    rc = sv.run({4: drv.launch, 6: drv.die})
 
     assert drv.start_calls == 1
     assert rc == 2
@@ -267,38 +301,75 @@ def test_deferred_start_is_waited_out_then_a_real_death_exits_2(supervised) -> N
 def test_a_deferred_start_that_never_launches_is_not_an_exit(supervised) -> None:
     """Nothing launched, ever: the loop waits until told to stop, and exits 0.
     (In the pod, the chart's liveness probe on :53 bounds this wait.)"""
-    _drv, ticks, spy, run = supervised
+    sv = supervised
 
-    rc = run({5: lambda: signal.raise_signal(signal.SIGTERM)})
+    rc = sv.run({5: sv.sigterm})
 
     assert rc == 0
-    assert ticks[-1] == 5
-    assert "dns_daemon_exited" not in spy.events
-    assert spy.events.count("dns_daemon_start_deferred_waiting") == 1
-    assert "dns_agent_signal_received" in spy.events
-    assert spy.events[-1] == "dns_agent_exiting"
+    assert sv.ticks[-1] == 5
+    assert "dns_daemon_exited" not in sv.spy.events
+    assert "dns_agent_thread_died" not in sv.spy.events
+    assert sv.spy.events.count("dns_daemon_start_deferred_waiting") == 1
+    assert "dns_agent_signal_received" in sv.spy.events
+    assert sv.spy.events[-1] == "dns_agent_exiting"
+
+
+def test_a_stop_is_exit_0_even_when_it_takes_the_daemon_and_the_threads(supervised) -> None:
+    """A rollout's SIGTERM stops the threads and may kill the daemon in the
+    same instant; neither is a death the loop should report (the seed's bind
+    container exited 2 on every DaemonSet rollout before this)."""
+    sv = supervised
+
+    def stop_everything() -> None:
+        sv.drv.die()
+        sv.sigterm()
+
+    rc = sv.run({2: sv.drv.launch, 4: stop_everything})
+
+    assert rc == 0
+    assert sv.ticks[-1] == 4
+    assert "dns_daemon_exited" not in sv.spy.events
+    assert "dns_agent_thread_died" not in sv.spy.events
+    assert sv.spy.events[-2:] == ["dns_agent_signal_received", "dns_agent_exiting"]
+
+
+def test_a_thread_that_dies_while_not_stopping_still_exits_2(supervised) -> None:
+    """The self-restart path for a dead worker (a sync loop that dropped its
+    token, say) is intact: only a *requested* stop is exempt."""
+    sv = supervised
+
+    def kill_sync_thread() -> None:
+        sv.idles[1].stop()  # SyncLoop's stub backs the "sync" thread
+        sv.settle(("sync",))
+
+    rc = sv.run({1: sv.drv.launch, 3: kill_sync_thread})
+
+    assert rc == 2
+    assert sv.ticks[-1] == 3
+    assert ("error", "dns_agent_thread_died", {"threads": ["sync"]}) in sv.spy.calls
+    assert "dns_agent_exiting" not in sv.spy.events
 
 
 def test_a_daemon_that_was_running_at_boot_still_exits_on_death(supervised) -> None:
     """The pre-#1056 contract is intact when ``start_daemon`` did spawn."""
-    drv, ticks, spy, run = supervised
-    drv.launch()  # what a real start_daemon leaves behind when named.conf exists
+    sv = supervised
+    sv.drv.launch()  # what a real start_daemon leaves behind when named.conf exists
 
-    rc = run({2: drv.die})
+    rc = sv.run({2: sv.drv.die})
 
     assert rc == 2
-    assert ticks[-1] == 2
-    assert "dns_daemon_start_deferred_waiting" not in spy.events
-    assert spy.events[-1] == "dns_daemon_exited"
+    assert sv.ticks[-1] == 2
+    assert "dns_daemon_start_deferred_waiting" not in sv.spy.events
+    assert sv.spy.events[-1] == "dns_daemon_exited"
 
 
 def test_a_driver_that_does_not_manage_a_daemon_is_never_checked(supervised, agent_cfg) -> None:
     """Only the daemon-managing drivers take the liveness exit at all."""
-    _drv, _ticks, spy, run = supervised
+    sv = supervised
     cfg = dataclasses.replace(agent_cfg, driver="something-else")
 
-    rc = run({3: lambda: signal.raise_signal(signal.SIGTERM)}, cfg=cfg)
+    rc = sv.run({3: sv.sigterm}, cfg=cfg)
 
     assert rc == 0
-    assert "dns_daemon_start_deferred_waiting" not in spy.events
-    assert "dns_daemon_exited" not in spy.events
+    assert "dns_daemon_start_deferred_waiting" not in sv.spy.events
+    assert "dns_daemon_exited" not in sv.spy.events

--- a/charts/spatiumddi/templates/dns-agent.yaml
+++ b/charts/spatiumddi/templates/dns-agent.yaml
@@ -138,6 +138,19 @@ spec:
             tcpSocket: { port: 53 }
             initialDelaySeconds: 5
             periodSeconds: 10
+          {{- /* #1056 — the agent now WAITS for its first bundle instead of
+                 exiting 2 one second after "startup deferred". A readiness
+                 probe never restarts a pod, so without a liveness probe a
+                 server whose bundle never arrives (wrong group, revoked key,
+                 a control plane that heartbeats but renders nothing) would
+                 sit NotReady for ever. Same shape as the appliance chart's
+                 dns-bind9 / dns-powerdns / dns-technitium: 30 s initial
+                 delay covers a slow first bundle, 3 × 30 s to a restart
+                 with the reason in the agent's log. */}}
+          livenessProbe:
+            tcpSocket: { port: 53 }
+            initialDelaySeconds: 30
+            periodSeconds: 30
           resources:
             {{- toYaml ($server.resources | default (dict "requests" (dict "cpu" "100m" "memory" "128Mi") "limits" (dict "cpu" "500m" "memory" "512Mi"))) | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Fixes #1056 — the `dns-bind9` pod on a freshly joined cluster member exited 2 one second after logging `named_conf_missing_startup_deferred`, and kubelet back-off-restarted it until its first config happened to land inside the 1 s window. The same supervisor loop also reported every DaemonSet rollout as a crash (exit 2 on a requested stop); that is the second commit. The review round added the race guards on both crash exits, kept the wait visible (re-logged on a backoff, `degraded` in the heartbeat), gave the umbrella chart's DNS agents the liveness probe the appliance chart already had, declared `daemon_pid` once, added the CHANGELOG entry, and measures the wait from the loop's start.

Root-caused live on nested 3-node QA clusters (three formations with the same signature: +1, +1, +2 restarts), fixed, and proven three times on the same base: the trigger fired by hand on a formed cluster, a full formation graded by the QA harness with the trigger inside its window, and — after the review — the amended stack on a third formation plus a stuck-agent drill for the bounded wait.

## 1. A never-launched daemon was read as a dead one

`supervisor.run()` calls `driver.start_daemon()` once at boot, then every second treats `driver.daemon_running() == False` as "the daemon died, exit 2 so the orchestrator restarts us". But `start_daemon()` is allowed to return *without* a daemon: `Bind9Driver.start_daemon` defers when no `named.conf` has been rendered yet and leaves the launch to `swap_and_reload`, which the sync loop reaches once the control plane hands over the first bundle (`PowerDNSDriver` defers the same way). The first bind pod on a freshly joined member always boots deferred — its hostPath state dir is empty and its bundle is not built yet — so the process exited at +1.0 s whenever the first bundle took longer than that.

The previous container's whole log on the member that counted +2 (2026-09-11, `nightly-2026.09.10` + #1053):

```
15:24:32.232Z {"event": "named_conf_missing_startup_deferred", "service": "spatium-dns-agent", "level": "warning"}
15:24:32.241Z {"event": "dns_query_log_shipper_starting", "path": "/var/log/named/queries.log", "level": "info"}
15:24:32.244Z {"event": "dns_ingest_worker_starting", "interval": 180.0, "level": "info"}
15:24:33.205Z HTTP Request: POST https://<seed>/api/v1/dns/agents/heartbeat "HTTP/1.1 200 OK"
15:24:33.245Z {"driver": "bind9", "event": "dns_daemon_exited", "service": "spatium-dns-agent", "level": "error"}
```

`kubectl describe`: `Last State: Terminated, Reason: Error, Exit Code: 2, Started 15:24:31, Finished 15:24:33`, `Restart Count: 2`, `Back-off restarting failed container dns-bind9`. The `GET /api/v1/dns/agents/config` never completed inside the container's life. Pods that read 0 on the same formation were the ones whose predecessor had already cached a bundle on the hostPath: `SyncLoop.__init__` applies it — and launches `named` — before the supervisor's own `start_daemon()` runs, so nothing defers there.

**The fix.** The liveness check is armed by the launch, not by the boot:

- `DriverBase.daemon_launched()` — true once the driver has spawned or adopted its daemon. `daemon_pid` is set at exactly those points (the spawn and the adopt in `start_daemon`, the system-wide look-up in `daemon_running`) and never cleared, so it is the tell. It is declared once, on `DriverBase`; the three subclass declarations are gone (review point 4 — the first version had added a fourth copy while calling it a move).
- `supervisor.run()` exits 2 only when `daemon_launched()` and not `daemon_running()`. While nothing has been launched it waits. `daemon_running()` is still evaluated first, so the #704 adopt path is unchanged.

Why the pid rather than "the config exists": `swap_and_reload` promotes `rendered.new → rendered` *before* it spawns, so a config-on-disk predicate has a window in which the main thread sees config and no daemon — a rarer version of the same bug. A pid exists only once a process does.

**What bounds the wait.** The liveness probes — on both charts now. The appliance chart's `dns-bind9` / `dns-powerdns` / `dns-technitium` already had `tcpSocket :53`, 30 s initial delay, 30 s period; the umbrella chart's `dns-agent` StatefulSet had a readiness probe only, and a readiness probe never restarts a pod (review point 1 — the first version claimed the bound for "the chart" and it held for one of the two). The umbrella chart's DNS agents get the same probe in this PR, so a bundle that never arrives (wrong group, revoked key, a control plane that answers `/heartbeat` but renders nothing) is a restart every ~2 min with the reason in the agent's log, on either chart, instead of a silent NotReady. A Compose deployment without a probe waits, heartbeating — and says so (next section).

## 2. A requested stop was reported as a death — wherever it lands

On SIGTERM the handler sets `stopping` and stops every worker thread, and a DaemonSet rollout may take the daemon in the same instant. The loop's next tick ran its two liveness checks first, found the threads it had just stopped (or the daemon the rollout killed) dead, logged `dns_agent_thread_died` / `dns_daemon_exited` and returned 2 — every rollout ended the old container with exit 2. Seen live on the seed when the serving roles were mirrored onto the members: kubelet `StopContainer … with signal terminated` at 21:20:52.96Z, the `dns-bind9` container's exit event 0.7 s later with `exit_status:2`; the `dhcp-kea` container replaced in the same second exited 0. The rollout that triggers it on every fresh cluster is the chart's own: once the serving roles land, the DaemonSet template is re-rendered with the external control-plane URL and every agent pod on every node is replaced.

**The fix.** A stop requested during the tick takes the designed exit before either check runs; and because Python runs signal handlers between bytecodes, both crash exits also require that no stop has been requested (review point 2 — a stop landing *inside* `daemon_running()` or between the two checks still reached them; reproduced with the fixture, rc 2 on both paths). The residual window is the few bytecodes between that test and the `return`. A worker thread that dies while the agent is *not* stopping still exits 2.

**What this does and does not cover.** Every container a rollout stops *once the agent is running* exits 0. A container stopped in its first few hundred milliseconds — before the entrypoint has handed off to the agent and the agent has installed its handlers, which happens after registration, driver construction and thread start — dies by the signal, as any process without a handler does: 143. Seen once in the review round, when a revision-2 pod's container creation raced the revision-3 rollout (the pod was already Terminating when kubelet started the container; 282 ms of life, no log line). That pre-handler window — the entrypoint shell, interpreter start-up, registration — is outside the loop's reach; closing it would need a bootstrap-time handler that turns SIGTERM into a clean exit, and it can never cover the shell. Not in this PR.

## 3. The wait is visible

With the crash loop gone, the waiting state was the only signal a stuck agent produced, and it was logged once, at t=1 s (review point 3). Now: `dns_daemon_start_deferred_waiting` is re-logged on a backoff — the first tick, then doubling to 32 s, then every minute — each line carrying `waited_s`, so a `kubectl logs --tail` an hour into the wait still shows the state without a line a second; and the heartbeat carries `daemon: {"status": "degraded", "reason": "start deferred, no bundle yet"}` for as long as the wait lasts, cleared to `ok` the moment the daemon is up — only if it is still the supervisor's own, so a degraded verdict `sync.py` set meanwhile (a failed apply) is left alone. The control plane discards the heartbeat's `daemon` field today (`agents.py` declares it, nothing reads it — the #882 class); the signal is there for when it does.

## Validation on real hardware

Nested 3-node clusters (seed + two members) on the QA Proxmox fleet; the formation gate counts every pod's `restartCount` growth across the window (threshold 0). The trigger is a member's *first* bind pod with an empty state dir.

**A. Trigger fired by hand on a formed cluster (commit 1)** — the seed's serving roles were mirrored onto both members with the same product API the gate uses:

| | Unfixed control (same base, member-2) | Fixed (member-2) | Fixed (member-1) |
|---|---|---|---|
| deferral → first bundle | `GET /config` never completed in the container's 1.0 s life | deferred 21:20:42.767 → `dns_daemon_start_deferred_waiting` :43.809 → `GET …/config 200` :43.864 → `named_started` :43.894 → `dns_daemon_launched_after_deferred_start waited_s 1.0` — **first bundle +1.10 s, past the old window** | deferred :43.062 → `GET 200` :43.746 → `named_started` :43.770 (+0.71 s) |
| `dns_daemon_exited` | at +1.012 s, twice | none | none |
| Restart Count / Last State | 2 / Terminated exit 2 | **0** / none | **0** / none |
| pod scheduled → Ready | two back-off rounds; serving container at +25 s | Ready at **+15 s** | Ready at +13 s |
| `version.bind CH TXT` from the node | (not measured) | `"9.20.27"` from all three node addresses | same |
| formation gate `pod_restarts` over the window | **fail** — `2 pod restart(s): dns-bind9-<member-2> +2` | **pass** — `0 pod restart(s) within the threshold of 0, 0 OOMKilled` | — |

**B. A full formation graded by the harness with the trigger inside its window (commits 1+2)** — the gate itself mirrored the roles during formation:

| check | result |
|---|---|
| `pod_restarts` | **pass** — `0 pod restart(s) within the threshold of 0, 0 OOMKilled` |
| `serving_roles_all_nodes` | pass — `roles ['dhcp', 'dns-bind9'] mirrored from the seed onto 2/2 member(s) …; dns agents 3/3, dhcp agents 3/3 registered` |
| `sites_serving_all_nodes` | pass — `3/3 nodes each answer the site's DHCP DISCOVER and DNS query` |
| `cluster_formation` / `_unrepaired` · `k3s_restarts` · `gate_predicate` | `2 members paired+approved+promoted (first try)` · `+0/+0/+0` · `3/3 ready, HA, CNPG=3` |
| members' first bind pods | member-2: deferred 22:30:04.99 → `named_started` :06.00 (+1.01 s); member-1: deferred :09.74 → `named_started` :10.61 (+0.87 s); no previous container anywhere |
| the rollout (commit 2) | six agent containers SIGTERMed on all three nodes at 22:30:15–49Z — **all exit 0**; member-1's log: `dns_agent_signal_received` 22:30:14.86 → `dns_agent_exiting` 22:30:15.76 (the same rollout ended the unfixed container with exit 2) |

**C. The amended stack on a third formation, graded by the harness with the serving roles on every node (review round)**:

| check | result |
|---|---|
| `pod_restarts` | **pass** — `0 pod restart(s) within the threshold of 0, 0 OOMKilled` |
| `serving_roles_all_nodes` / `sites_serving_all_nodes` | pass — `2/2 member(s) …; dns agents 3/3, dhcp agents 3/3 registered` / `3/3 nodes each answer the site's DHCP DISCOVER and DNS query` |
| `cluster_formation` / `_unrepaired` · `k3s_restarts` · `gate_predicate` | first try / no repair · `+0/+0/+0` · `3/3 ready, HA, CNPG=3` |
| rollout exit codes | five of five containers the rollout stopped with a running agent: **exit 0** (bind and kea, three nodes); one bind container SIGTERMed 282 ms after start, before its handlers existed: 143 (see §2); the revision-1 key-less pair: 2 (#1062) |

**D. Stuck-agent drill (appliance chart — the shape #1056 was observed on): the bounded wait, proven.** One member's DNS server row set `pending_approval`, its cached bundle wiped, its pod deleted: the agent registered, heartbeated every 30 s and never received a bundle, for 12 min 14 s.

| | observed |
|---|---|
| the wait in `kubectl logs --tail` | `dns_daemon_start_deferred_waiting` re-logged with `waited_s` on the backoff — 1, 2, 4, 8, 16, 32, 60 s within each container's life (the drill ran one commit before the from-loop-start measurement and read 0, 1, 3, 7, 15, 31, 59) — beside `sync_pending_approval_waiting` every 10 s and `heartbeat 200 OK` every 30 s |
| the bound | the liveness probe (tcp :53 — `named` never bound it) restarted the container every ~120 s: containers started 02:57:56, 02:59:56, 03:01:56, 03:03:55, 03:05:56 …; **six restarts in 12 min 14 s**; `Killing … failed liveness probe, will be restarted` |
| how each container ended | `dns_agent_signal_received` → `dns_agent_exiting` ~0.5 s later; `Last State: Terminated, Reason: Completed, Exit Code: 0`, every time (pre-fix: exit 2, `dns_agent_thread_died`) |
| restore (`pending_approval = false` at 03:10:05Z) | `GET …/config 200` 03:10:08.068 → `named_started` :08.091 → `structural_reload_applied` :08.092 → `dns_daemon_launched_after_deferred_start waited_s 10.2` :08.195; `version.bind` answered from 03:10:43; restarts frozen at 6 |
| the control plane's view, the whole 12 minutes | `last_seen_at` advancing every ~60 s, `config_apply_status ok`, `daemon_version 9.20.27`; the API log only `POST …/heartbeat 200 OK`. The heartbeat carried `daemon.status = degraded` throughout and nothing read it — reported separately. |

Physical floor for the wait: the first bundle needs register → `build_config_bundle` → the long-poll response (`DNS_AGENT_LONGPOLL_TIMEOUT` 30 s at most, immediate when the bundle is new); on four fixed members it took 0.71, 0.87, 1.01 and 1.10 s from the deferral — the old code lost that race whenever it exceeded 1.0 s, which is exactly the +1/+1/+2 variance the issue reports.

## Seen alongside, not fixed here: revision-1 pods without an agent key (#1062)

On every formation the DaemonSets go through three revisions. Revision 1 (rendered at the first HelmChart apply) carries **no** `DNS_AGENT_KEY` / `AGENT_GROUP` for bind and no `SPATIUM_AGENT_KEY` / `AGENT_GROUP` for kea; revision 2, 12–20 s later, carries both; revision 3 (once the serving roles land) re-points `CONTROL_PLANE_URL` from the in-cluster Service to the external https URL and adds `SPATIUM_INSECURE_SKIP_TLS_VERIFY=1`. Every revision-1 pod exits 2 within 0.2 s of starting — containerd `exit_status:2` for the bind and kea containers on both clusters — because the entrypoints refuse an empty key (`: "${DNS_AGENT_KEY:?…}"`, `: "${SPATIUM_AGENT_KEY:?…}"`) and busybox `sh` exits 2 on that expansion; the revision-2 rollout then deletes and replaces them. Those exit-2s are the chart's ordering, not the agents', and they are what a reader will find next to this fix's log lines on a fresh install. Filed as #1062.

## Other agents

- **PowerDNS** — same deferral (`pdns_conf_missing_startup_deferred`), same supervisor loop, covered by every change here and unit-tested.
- **Technitium** — never defers on config (starts `dotnet` unconditionally); the only change is that a missing binary now waits for the liveness probe instead of exiting at +1 s. Still loud in its log, and now in its heartbeat.
- **DHCP** — not this shape for the deferred start: `kea-dhcp4`/`kea-dhcp6` are started by the image entrypoint's supervise loops from the shipped idle configs, and the DHCP supervisor watches only its own threads (its pods read 0 restarts on every formation). Its loop has the same thread-death-after-stop order as cause 2, but the container's exit code is the entrypoint's (0 at every rollout observed), so nothing observable changes; left as is.

## Tests

`agent/dns/tests/test_supervisor_deferred_start.py` (16 tests) pins the drivers' deferred / spawned / adopted states and the supervisor loop with its tick scripted: it waits through a deferred start, exits 2 on a real death, exits 0 on a requested stop even when the stop takes the daemon and the threads — including a stop that lands *inside* the daemon check or between the two checks — keeps the boot-time-spawn contract, exits 2 on a thread that dies while not stopping, never checks a driver that manages no daemon, re-logs the wait on the schedule, carries `degraded` in the heartbeat while waiting and clears it on launch without touching a `sync.py` verdict. Each group fails on the commit under it: the loop test exits 2 at tick 1 on the unfixed code; the stop cases exit 2 on the first commit alone; the race cases exit 2 on the second; the visibility cases fail on the third.

- `agent/dns`: 292 passed, 8 skipped, 0 failed (was 276 / 8 / 0) — CI's shape on `python:3.12` (the images and `ci.yml` pin 3.12; the same counts on 3.14).
- Charts: `Charts — Lint & Template` mirrored (`charts-render-check.sh`: helm lint --strict, helm template with every toggle, kubeconform, helm v3.21.4 + kubeconform v0.8.0 in a container): all passed; the rendered `dns-agent` StatefulSet carries both probes.
- ruff on the touched files: clean but for a pre-existing `RUF100` (agent code is not under CI lint).
- gitleaks: no new findings against the base.
- CHANGELOG: `Unreleased` → `Fixed`.

## Tradeoffs and remaining work

- The agent bounds its own wait only through the log and the heartbeat; the probes do the restarting. If a deployment wants a hard cap inside the agent, that is a follow-up knob, not this fix.
- A stop that arrives while the daemon was *never* launched also exits 0 (the loop was waiting); that is the honest reading of a requested stop.
- The heartbeat's `daemon` field is discarded server-side today; reading it is the control plane's follow-up.

## Verification still to come

The QA side carries every open fix of ours, stacked on the next nightly's bytes, through a PostQA walk of both topologies (single node, then the three-node cluster). This fix rides that walk; the `cluster_gate/pod_restarts` result on the stacked build will be posted here, as was done on #1053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
