### PR TITLE
perf(orchestrator): count DNS answers by rcode, attribute DHCP ACKs to the exchange they answer, and read both ledgers in the report (#1057)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -745,7 +745,14 @@ jobs:
   # ran (#955 merged on 25 green checks that opened none of its files) while
   # the backend path filter, which did not know ``perf/`` either, spent all 8
   # backend shards on it. Hermetic: the tests use a fake socket, no network,
-  # no appliance, ~0.01 s.
+  # no appliance, well under a second.
+  #
+  # PyYAML, dnspython and hdrhistogram are the orchestrator's and report's
+  # own imports (perf/requirements.txt): the tests that drive the
+  # orchestrator FSM and the report against them (#1057) import-skip without
+  # the first two, and with pytest alone that skip let a reverted fix pass
+  # this job green (review of #1063). hdrhistogram ships a wheel for x86_64
+  # only, which this runner is.
   #
   # Tests only, like the agent + appliance jobs: ``perf/`` is outside the
   # Backend Lint scope and carries pre-existing ruff/black drift (25 findings,
@@ -762,7 +769,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install pytest
+        run: pip install pytest pyyaml dnspython hdrhistogram
 
       - name: Run tests
         run: python -m pytest perf -q

--- a/Makefile
+++ b/Makefile
@@ -473,11 +473,18 @@ workflow-shell-check:
 	@echo "→ Workflow shell-status linter (matches .github/workflows/ci.yml)"
 	@python3 scripts/lint_workflow_shell.py
 
-# Perf — Tests (#968): hermetic, stdlib-only tests under perf/.
+# Perf — Tests (#968): hermetic tests under perf/ (no network, no appliance).
+# PyYAML + dnspython are what the orchestrator and report tests import
+# (#1057); hdrhistogram has an x86_64 wheel only and builds a C extension
+# elsewhere, so it is taken as a wheel when one exists — the single assertion
+# that needs the HdrHistogram backend is gated on it in the test.
 perf-test:
 	@echo "→ Perf — Tests (matches .github/workflows/ci.yml)"
 	docker run --rm -v "$(PWD):/repo" -w /repo python:3.12-slim sh -c \
-	  'pip -q install pytest >/dev/null && python -m pytest perf -q'
+	  'pip -q install pytest pyyaml dnspython >/dev/null \
+	   && (pip -q install --only-binary=:all: hdrhistogram >/dev/null 2>&1 \
+	       || echo "hdrhistogram: no binary wheel for this arch; the .hdr assertion is gated") \
+	   && python -m pytest perf -q'
 
 # ── Screenshots ────────────────────────────────────────────────────────────────
 # Re-captures the README screenshots via headless chromium. The dev stack must

--- a/perf/generators/orchestrator/accounting.py
+++ b/perf/generators/orchestrator/accounting.py
@@ -1,0 +1,54 @@
+"""Per-rcode DNS accounting for the device-fleet orchestrator (#1057).
+
+``_dns_query`` counted ``dns_ok`` for NOERROR/NXDOMAIN and ``dns_timeout`` on
+an exception. Any other rcode was counted as nothing: a run whose 606k queries
+BIND answered REFUSED read "ok 0, timeouts 46" beside a 606k-sample latency
+histogram. ``DnsTally`` counts every answer under its rcode; ``dns_ok`` keeps
+its meaning (NOERROR + NXDOMAIN), ``dns_answered`` is every response received,
+and timeouts are separated from other exceptions.
+
+Pure and stdlib-only so it is unit-tested without dnspython or an appliance.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class DnsTally:
+    """Every DNS answer under its rcode; timeouts apart from other exceptions."""
+
+    def __init__(self) -> None:
+        self.rcodes: dict[str, int] = {}
+        self.errors: dict[str, int] = {}
+
+    def answered(self, rcode_name: str) -> None:
+        self.rcodes[rcode_name] = self.rcodes.get(rcode_name, 0) + 1
+
+    def error(self, exc_type_name: str) -> bool:
+        """Count an exception by type; True the first time a type is seen (so
+        the caller can log it once instead of once per query)."""
+        first = exc_type_name not in self.errors
+        self.errors[exc_type_name] = self.errors.get(exc_type_name, 0) + 1
+        return first
+
+    def counter_fields(self) -> dict[str, int]:
+        """``dns_rcode_<NAME>`` fields for the counter snapshot (sorted, so the
+        summary line is stable)."""
+        return {f"dns_rcode_{k}": v for k, v in sorted(self.rcodes.items())}
+
+
+def rcode_name(rc: Any, to_text: Any = None) -> str:
+    """A stable rcode label: dnspython's mnemonic when available (``to_text``),
+    else ``RCODE<n>``; never raises (an unknown code is still counted)."""
+    if to_text is not None:
+        try:
+            name = str(to_text(rc))
+            if name:
+                return name
+        except Exception:  # noqa: BLE001 — an unknown value must still be counted
+            pass
+    try:
+        return f"RCODE{int(rc)}"
+    except (TypeError, ValueError):
+        return "RCODE?"

--- a/perf/generators/orchestrator/accounting.py
+++ b/perf/generators/orchestrator/accounting.py
@@ -1,18 +1,198 @@
-"""Per-rcode DNS accounting for the device-fleet orchestrator (#1057).
+"""Exchange-correlated DHCP accounting + per-rcode DNS accounting for the
+device-fleet orchestrator (#1057).
 
-``_dns_query`` counted ``dns_ok`` for NOERROR/NXDOMAIN and ``dns_timeout`` on
-an exception. Any other rcode was counted as nothing: a run whose 606k queries
-BIND answered REFUSED read "ok 0, timeouts 46" beside a 606k-sample latency
-histogram. ``DnsTally`` counts every answer under its rcode; ``dns_ok`` keeps
-its meaning (NOERROR + NXDOMAIN), ``dns_answered`` is every response received,
-and timeouts are separated from other exceptions.
+Two holes made the orchestrator's counters — the evidence a load run's
+handshake and DNS verdicts are read from — disagree with the appliance's own
+counters on the same run:
 
-Pure and stdlib-only so it is unit-tested without dnspython or an appliance.
+1. ``_on_ack`` decided what an ACK meant from the DEVICE'S STATE at the moment
+   it arrived. After ``MAX_DORA_RETRIES`` the device is OFFLINE, so an ACK that
+   answers its last REQUEST a moment later matched no branch: the DORA had
+   already been counted as a timeout and the lease kea just allocated was
+   discarded. The per-packet ``dora_timeout`` timers (one per DISCOVER, one per
+   REQUEST) also fired on whichever exchange happened to be current, so a
+   DISCOVER's deadline could retransmit over a live REQUEST.
+
+   The ledger below keys every exchange on its xid instead. An ACK is
+   attributed to the exchange it answers, with that exchange's own send time
+   (so retried DORAs measure the leg the ACK actually closes) and a verdict:
+   ``duplicate`` (the exchange was already closed), ``over_budget`` (its own
+   timer had fired — the device retried past it but had not given up) or
+   ``late`` (the device had given up on the whole DORA / renewal and counted a
+   timeout or a lapse). Late ACKs are counted under their own name and the
+   lease they carry is taken (the appliance holds it; a model that ignores it
+   drifts from the server it is measuring).
+
+2. ``_dns_query`` counted ``dns_ok`` for NOERROR/NXDOMAIN and ``dns_timeout``
+   on an exception. Any other rcode was counted as nothing. ``DnsTally`` counts
+   every answer under its rcode; ``dns_ok`` keeps its meaning (NOERROR +
+   NXDOMAIN), ``dns_answered`` is every response received, and timeouts are
+   separated from other exceptions.
+
+Pure and stdlib-only so it is unit-tested without a socket, dnspython, or an
+appliance; the orchestrator owns the FSM and the counters, this module owns
+the correlation and the verdict.
 """
 
 from __future__ import annotations
 
+import heapq
+from dataclasses import dataclass, field
 from typing import Any
+
+KIND_DISCOVER = "discover"
+KIND_SELECT = "select"      # the REQUEST that answers an OFFER (the DORA 'R')
+KIND_RENEW = "renew"
+KIND_REBIND = "rebind"
+DORA_KINDS = frozenset({KIND_DISCOVER, KIND_SELECT})
+
+#: How long a closed / expired / abandoned exchange stays known, so a reply
+#: that arrives that much later is still attributed (as duplicate or late)
+#: rather than counted as unmatched. Bounds the ledger: at ~20 exchanges/s a
+#: 120 s grace keeps a few thousand entries.
+DEFAULT_GRACE_S = 120.0
+
+
+@dataclass
+class Exchange:
+    xid: int
+    index: int
+    kind: str
+    tx_at: float
+    episode: int = 0                 # the device's DORA / renewal round this belongs to
+    expired_at: float | None = None  # its own timer fired while it was still live
+    gave_up_at: float | None = None  # the device abandoned the round it belonged to
+    closed_at: float | None = None   # answered, superseded, or abandoned
+    closed_by: str = ""              # "ack" | "nak" | "offer" | "superseded" | "abandoned"
+    purge_at: float | None = None
+
+    @property
+    def open(self) -> bool:
+        return self.closed_at is None
+
+
+@dataclass
+class Closed:
+    """What an ACK/NAK/OFFER turned out to be, for the counters."""
+    exchange: Exchange
+    duplicate: bool = False    # the exchange had already been closed
+    over_budget: bool = False  # its own timer had fired (the device retried past it)
+    late: bool = False         # the device had given up on the round (timeout/lapse counted)
+
+
+@dataclass
+class ExchangeLedger:
+    grace_s: float = DEFAULT_GRACE_S
+    _by_xid: dict[int, Exchange] = field(default_factory=dict)
+    _by_index: dict[int, set[int]] = field(default_factory=dict)
+    _purge_heap: list[tuple[float, int]] = field(default_factory=list)
+
+    # ---- bookkeeping ----
+    def __len__(self) -> int:
+        return len(self._by_xid)
+
+    def get(self, xid: int | None) -> Exchange | None:
+        if xid is None:
+            return None
+        return self._by_xid.get(int(xid))
+
+    def open_for(self, index: int, kinds: frozenset[str] | None = None) -> list[Exchange]:
+        out = []
+        for xid in self._by_index.get(index, ()):
+            ex = self._by_xid.get(xid)
+            if ex is not None and ex.open and (kinds is None or ex.kind in kinds):
+                out.append(ex)
+        return out
+
+    def _schedule_purge(self, ex: Exchange, now: float) -> None:
+        ex.purge_at = now + self.grace_s
+        heapq.heappush(self._purge_heap, (ex.purge_at, ex.xid))
+
+    def purge(self, now: float) -> int:
+        """Forget exchanges whose grace has passed; returns how many."""
+        n = 0
+        while self._purge_heap and self._purge_heap[0][0] <= now:
+            _when, xid = heapq.heappop(self._purge_heap)
+            ex = self._by_xid.get(xid)
+            if ex is None or ex.purge_at is None or ex.purge_at > now:
+                continue  # re-scheduled later, or already gone
+            del self._by_xid[xid]
+            idx_set = self._by_index.get(ex.index)
+            if idx_set is not None:
+                idx_set.discard(xid)
+                if not idx_set:
+                    del self._by_index[ex.index]
+            n += 1
+        return n
+
+    # ---- lifecycle ----
+    def open(self, xid: int, index: int, kind: str, tx_at: float, episode: int = 0) -> Exchange:
+        """Register a sent request. A reused xid (the 8-bit nonce collided with
+        a still-known exchange of the same device) closes the old one as
+        superseded first, so the reply is attributed to the newer send."""
+        old = self._by_xid.get(xid)
+        if old is not None and old.open:
+            self._close(old, tx_at, "superseded")
+        ex = Exchange(xid=xid, index=index, kind=kind, tx_at=tx_at, episode=episode)
+        self._by_xid[xid] = ex
+        self._by_index.setdefault(index, set()).add(xid)
+        return ex
+
+    def expire(self, xid: int, now: float) -> Exchange | None:
+        """The exchange's own timer fired. Marks it; the caller decides whether
+        the device retries, escalates or gives up (see ``give_up``)."""
+        ex = self._by_xid.get(xid)
+        if ex is None:
+            return None
+        if ex.expired_at is None:
+            ex.expired_at = now
+        if ex.open:
+            self._schedule_purge(ex, now)
+        return ex
+
+    def give_up(self, index: int, now: float,
+                kinds: frozenset[str] | None = None) -> list[Exchange]:
+        """The device abandoned its current round (DORA timeout, lapse): every
+        open exchange of that round is marked so a later reply reads as late."""
+        marked = []
+        for ex in self.open_for(index, kinds):
+            if ex.gave_up_at is None:
+                ex.gave_up_at = now
+            if ex.expired_at is None:
+                ex.expired_at = now
+            self._schedule_purge(ex, now)
+            marked.append(ex)
+        return marked
+
+    def settle(self, index: int, now: float, keep: int | None = None,
+               kinds: frozenset[str] | None = None,
+               reason: str = "superseded") -> list[Exchange]:
+        """The device's round is over (an ACK took a lease, a NAK restarted it):
+        every other open exchange of that round is closed as ``reason``."""
+        out = []
+        for ex in self.open_for(index, kinds):
+            if keep is not None and ex.xid == keep:
+                continue
+            self._close(ex, now, reason)
+            out.append(ex)
+        return out
+
+    def _close(self, ex: Exchange, now: float, by: str) -> None:
+        ex.closed_at = now
+        ex.closed_by = by
+        self._schedule_purge(ex, now)
+
+    def close(self, xid: int, now: float, by: str = "ack") -> Closed | None:
+        """A reply for ``xid`` arrived. None when the xid is unknown (purged, or
+        never ours). Otherwise the verdict for the counters; the exchange is
+        closed so a second reply reads as ``duplicate``."""
+        ex = self._by_xid.get(xid)
+        if ex is None:
+            return None
+        if not ex.open:
+            return Closed(ex, duplicate=True)
+        self._close(ex, now, by)
+        return Closed(ex, over_budget=ex.expired_at is not None, late=ex.gave_up_at is not None)
 
 
 class DnsTally:

--- a/perf/generators/orchestrator/device_fleet.py
+++ b/perf/generators/orchestrator/device_fleet.py
@@ -66,8 +66,11 @@ import dhcp_packet as dp  # noqa: E402
 from lifecycle_log import LatencyAccumulator, LifecycleLog  # noqa: E402
 from relay_sockets import open_relay_sockets  # noqa: E402
 
-from accounting import DnsTally, rcode_name  # noqa: E402
-from spddi_perf.generator_tallies import dns_summary  # noqa: E402
+from accounting import (  # noqa: E402
+    DORA_KINDS, KIND_DISCOVER, KIND_REBIND, KIND_RENEW, KIND_SELECT, Closed, DnsTally,
+    Exchange, ExchangeLedger, rcode_name,
+)
+from spddi_perf.generator_tallies import dns_summary, handshake_summary  # noqa: E402
 
 # dnspython is an off-box runtime dep (perf/requirements.txt: dnspython>=2.6); resolve
 # it once at import so the per-query hot path doesn't re-run the import machinery. When
@@ -135,6 +138,14 @@ class Device:
     dora_retries: int = 0
     # propagation-probe membership
     probe: bool = False
+    # #1057 — exchange-correlated accounting: the DORA / renewal round this
+    # device is on (retransmits keep it, a fresh arrival or a NAK bumps it), the
+    # token of the live T1 timer (a re-ACKed lease invalidates the old one), and
+    # whether a LEFT device got there by lapsing (a late rebind ACK revives it)
+    # or by departing (it does not).
+    episode: int = 0
+    t1_token: int = 0
+    lapsed: bool = False
 
 
 @dataclass
@@ -170,8 +181,18 @@ class Counters:
     ddns_first_publish: int = 0
     ddns_renew_writes: int = 0   # MUST stay 0 (H3) — incremented only if a renewal IP-changes
     renew_ip_changed: int = 0    # named correctness FAIL signal
-    # #1057 — every DNS answer counted. The fields above keep their meaning
-    # (add, never rename: ddi-pg's load tier folds them by name).
+    # #1057 — exchange-correlated accounting. The fields above keep their
+    # meaning (add, never rename: ddi-pg's load tier folds them by name); these
+    # make the generator's tally reconcilable with kea's and BIND's own counters.
+    dora_offer: int = 0            # OFFERs received, whatever the device was doing
+    offer_ignored: int = 0         # OFFERs that found the device not DISCOVERING
+    request_sent: int = 0          # SELECTING REQUESTs sent (one per accepted OFFER)
+    dora_ack_over_budget: int = 0  # of dora_ack: its exchange's own timer had fired
+    dora_ack_late: int = 0         # DORA ACKs after the device gave up (a `timeout` that was slow)
+    renew_ack_late: int = 0        # renew ACKs after the renew timer escalated / the device left
+    rebind_ack_late: int = 0       # rebind ACKs after the device lapsed (a `lapses` that was slow)
+    ack_duplicate: int = 0         # a second ACK for an exchange already closed
+    ack_unmatched: int = 0         # an ACK whose xid matches no exchange the ledger knows
     dns_answered: int = 0          # every DNS response received, any rcode (+ dns_rcode_<NAME>)
     dns_error: int = 0             # DNS exceptions that were not timeouts (types in the log)
 
@@ -317,6 +338,9 @@ class Orchestrator:
 
         # Latency accumulators (DORA + renew SEPARATELY, DNS resolve, both prop legs).
         self.lat_dora = LatencyAccumulator("dhcp_dora_ack")
+        # Late DORA ACKs (after the device gave up) get their own histogram so
+        # the strict one keeps its meaning and the slow tail is still visible.
+        self.lat_dora_late = LatencyAccumulator("dhcp_dora_ack_late")
         self.lat_renew = LatencyAccumulator("dhcp_renew_ack")
         self.lat_dns = LatencyAccumulator("dns_resolve")
         self.lat_prop_ipam = LatencyAccumulator("propagation_lease_to_ipam")
@@ -325,8 +349,10 @@ class Orchestrator:
         self.counters = Counters()
         self.devices: dict[int, Device] = {}
         self.online_set: set[int] = set()
-        # pending DHCP exchanges keyed by xid -> device index (recv correlation)
-        self.pending: dict[int, int] = {}
+        # Every in-flight (and recently closed) DHCP exchange keyed by xid: the
+        # reply is attributed to the exchange it answers, not to whatever the
+        # device happens to be doing when it arrives (#1057).
+        self.ledger = ExchangeLedger()
         self.dns_tally = DnsTally()
         # timer wheel: due_time -> list[(index, action)]
         self._timers: list[tuple[float, int, str]] = []  # min-heap of (when, index, action)
@@ -408,8 +434,15 @@ class Orchestrator:
     def _new_xid(self, dev: Device) -> int:
         # xid encodes the device index in the low 24 bits + a per-attempt nonce in the
         # high byte → cheap recv correlation while staying unique across re-sends.
-        nonce = self.rng.randrange(256)
-        return ((nonce & 0xFF) << 24) | (dev.index & 0xFFFFFF)
+        # The nonce must not collide with an exchange of this device the ledger
+        # still knows, or the reply would be attributed to the older send.
+        xid = dev.index & 0xFFFFFF
+        for _ in range(8):
+            nonce = self.rng.randrange(256)
+            xid = ((nonce & 0xFF) << 24) | (dev.index & 0xFFFFFF)
+            if self.ledger.get(xid) is None:
+                break
+        return xid
 
     def _send(self, pkt: bytes, dev: Device) -> None:
         sock = self._sock_for(dev)
@@ -429,7 +462,10 @@ class Orchestrator:
             self.log.debug("send failed: %s", exc,
                            extra={"fields": {"event": "send_error", "index": dev.index}})
 
-    def _send_discover(self, dev: Device) -> None:
+    def _send_discover(self, dev: Device, *, new_round: bool) -> None:
+        """A DISCOVER. ``new_round`` opens a fresh DORA round (arrival, re-arrival,
+        NAK); a retransmit after ``dora_timeout`` keeps the round, so a reply to
+        any of its sends still belongs to it."""
         if dev.discover_tpl is None:
             dev.discover_tpl = dp.build_discover(
                 mac=dev.mac, client_id=dev.client_id_bytes,
@@ -439,12 +475,18 @@ class Orchestrator:
         dev.xid = self._new_xid(dev)
         giaddr = self.subnets[dev.subnet_idx].giaddr if self.relay else None
         dp.patch_send_fields(pkt, xid=dev.xid, giaddr=giaddr)
+        if new_round:
+            dev.episode += 1
+            dev.lapsed = False
         dev.state = DState.DISCOVERING
         dev.tx_at = time.monotonic()
-        self.pending[dev.xid] = dev.index
+        self.ledger.open(dev.xid, dev.index, KIND_DISCOVER, dev.tx_at, dev.episode)
         self._send(bytes(pkt), dev)
         self.counters.dora_sent += 1
-        self._schedule(DORA_TIMEOUT_S, dev.index, "dora_timeout")
+        # The timer belongs to THIS exchange (#1057): it retransmits only if this
+        # send is still the device's live one when it fires — a DISCOVER's
+        # deadline no longer fires over the REQUEST that answered its OFFER.
+        self._schedule(DORA_TIMEOUT_S, dev.index, f"dora_timeout:{dev.xid}")
 
     def _send_request_renew(self, dev: Device) -> None:
         assert dev.leased_ip
@@ -454,11 +496,12 @@ class Orchestrator:
         dev.xid = self._new_xid(dev)
         dp.patch_send_fields(pkt, xid=dev.xid)  # NO giaddr — renew is unicast direct
         dev.state = DState.RENEWING
+        dev.episode += 1
         dev.tx_at = time.monotonic()
-        self.pending[dev.xid] = dev.index
+        self.ledger.open(dev.xid, dev.index, KIND_RENEW, dev.tx_at, dev.episode)
         self._send(bytes(pkt), dev)
         self.counters.renew_sent += 1
-        self._schedule(RENEW_TIMEOUT_S, dev.index, "renew_timeout")
+        self._schedule(RENEW_TIMEOUT_S, dev.index, f"renew_timeout:{dev.xid}")
 
     def _send_request_rebind(self, dev: Device) -> None:
         assert dev.leased_ip
@@ -470,10 +513,10 @@ class Orchestrator:
         dp.patch_send_fields(pkt, xid=dev.xid, giaddr=giaddr)
         dev.state = DState.REBINDING
         dev.tx_at = time.monotonic()
-        self.pending[dev.xid] = dev.index
+        self.ledger.open(dev.xid, dev.index, KIND_REBIND, dev.tx_at, dev.episode)
         self._send(bytes(pkt), dev)
         self.counters.rebind_sent += 1
-        self._schedule(RENEW_TIMEOUT_S, dev.index, "rebind_timeout")
+        self._schedule(RENEW_TIMEOUT_S, dev.index, f"rebind_timeout:{dev.xid}")
 
     def _send_request_selecting(self, dev: Device, offered_ip: str, server_id: str) -> None:
         pkt = bytearray(dp.build_request_selecting(
@@ -482,10 +525,18 @@ class Orchestrator:
         dev.xid = self._new_xid(dev)
         giaddr = self.subnets[dev.subnet_idx].giaddr if self.relay else None
         dp.patch_send_fields(pkt, xid=dev.xid, giaddr=giaddr)
-        dev.tx_at = time.monotonic()  # keep DORA clock running through SELECTING
-        self.pending[dev.xid] = dev.index
+        dev.tx_at = time.monotonic()  # the DORA latency is the REQUEST->ACK leg (unchanged)
+        self.ledger.open(dev.xid, dev.index, KIND_SELECT, dev.tx_at, dev.episode)
         self._send(bytes(pkt), dev)
-        self._schedule(DORA_TIMEOUT_S, dev.index, "dora_timeout")
+        self.counters.request_sent += 1
+        self._schedule(DORA_TIMEOUT_S, dev.index, f"dora_timeout:{dev.xid}")
+
+    def _schedule_t1(self, dev: Device) -> None:
+        """(Re)arm the T1 renewal for the lease the device holds now. The token
+        retires any earlier T1 timer, so a lease re-ACKed twice (a late renew
+        ACK and then the rebind's) renews once, not twice."""
+        dev.t1_token += 1
+        self._schedule(T1_RENEW_S, dev.index, f"t1_renew:{dev.t1_token}")
 
     def _send_release(self, dev: Device) -> None:
         if not (dev.leased_ip and dev.server_id):
@@ -499,12 +550,24 @@ class Orchestrator:
         self.counters.releases += 1
 
     # ---------------- FSM event handlers ----------------
-    def _on_offer(self, dev: Device, reply: dict) -> None:
+    def _on_offer(self, dev: Device, reply: dict, ex: Exchange | None, now: float) -> None:
+        self.counters.dora_offer += 1
+        if dev.state is not DState.DISCOVERING:
+            # A late or duplicate OFFER: the device already took a lease or gave
+            # up, so nobody is selecting. Counted so kea's OFFER tally reconciles
+            # with ours; the FSM does not move.
+            self.counters.offer_ignored += 1
+            if ex is not None and ex.open:
+                self.ledger.close(ex.xid, now, "offer")
+            return
         # SELECTING: accept the OFFER with a REQUEST(opt-50/opt-54).
         offered = reply.get("yiaddr")
         sid = reply.get("server_id") or offered
         if not offered or offered == "0.0.0.0":
             return
+        if ex is not None and ex.open:
+            # The DISCOVER is answered: its own timer must not retransmit it.
+            self.ledger.close(ex.xid, now, "offer")
         self._send_request_selecting(dev, offered, sid)
 
     def _ip_in_seeded_subnet(self, ip: str) -> bool:
@@ -516,84 +579,182 @@ class Orchestrator:
             return False
         return any(addr in net for net in self._seeded_nets)
 
-    def _on_ack(self, dev: Device, reply: dict, now: float) -> None:
-        prev_state = dev.state
+    def _on_ack(self, dev: Device, reply: dict, now: float, ex: Exchange | None) -> None:
+        """Attribute an ACK to the exchange it answers (#1057). Before, the
+        device's state at arrival decided what the ACK meant — and after
+        MAX_DORA_RETRIES the device was OFFLINE, so the ACK that answered its
+        last REQUEST matched no branch: counted as a timeout already, then
+        dropped with the lease kea had just allocated."""
+        if ex is None:
+            self.counters.ack_unmatched += 1
+            self.log.debug("ACK for an xid the ledger does not know",
+                           extra={"fields": {"event": "ack_unmatched", "index": dev.index,
+                                             "xid": reply.get("xid")}})
+            return
+        closed = self.ledger.close(ex.xid, now, "ack")
+        if closed is None or closed.duplicate:
+            self.counters.ack_duplicate += 1
+            return
+        latency_ms = (now - ex.tx_at) * 1000.0  # the leg this ACK actually closes
+        if ex.kind in DORA_KINDS:
+            self._on_dora_ack(dev, reply, ex, closed, latency_ms, now)
+        else:
+            self._on_renewal_ack(dev, reply, ex, closed, latency_ms, now)
+
+    def _on_dora_ack(self, dev: Device, reply: dict, ex: Exchange, closed: Closed,
+                     latency_ms: float, now: float) -> None:
         new_ip = reply.get("yiaddr")
-        latency_ms = (now - dev.tx_at) * 1000.0
-        if prev_state in (DState.DISCOVERING,):
-            # perf #454 — foreign-responder guard. If the leased IP is outside
-            # every seeded subnet, a DIFFERENT DHCP server answered (e.g. the
-            # site router on a shared LAN) — we're not testing the appliance's
-            # Kea. Count it and warn loudly (once) so the run isn't silently
-            # measuring the wrong server. Use an isolated VLAN or relay topology.
-            if new_ip and self._seeded_nets and not self._ip_in_seeded_subnet(new_ip):
-                self.counters.foreign_ack += 1
-                if not self._foreign_warned:
-                    self._foreign_warned = True
-                    self.log.error(
-                        "DHCP ACK from a FOREIGN server — leased IP %s is outside "
-                        "every seeded subnet. A non-appliance DHCP server is winning "
-                        "the broadcast race; use an isolated test VLAN or relay "
-                        "topology (perf #454).", new_ip,
-                        extra={"fields": {"event": "foreign_dhcp_responder",
-                                          "leased_ip": new_ip, "server_id": reply.get("server_id")}})
-            # DORA ACK — first lease (or re-lease after re-arrival).
-            dev.leased_ip = new_ip
-            dev.server_id = reply.get("server_id") or dev.server_id
-            dev.lease_time = int(reply.get("lease_time", self.m.scale.lease_time_s))
-            dev.state = DState.ONLINE
-            self.online_set.add(dev.index)
-            self.counters.dora_ack += 1
-            self.lat_dora.record_ms(latency_ms)
-            dev.dora_retries = 0
-            # DDNS coupling happens ONLY on first DORA (hostname-bearing devices).
+        # perf #454 — foreign-responder guard. If the leased IP is outside
+        # every seeded subnet, a DIFFERENT DHCP server answered (e.g. the
+        # site router on a shared LAN) — we're not testing the appliance's
+        # Kea. Count it and warn loudly (once) so the run isn't silently
+        # measuring the wrong server. Use an isolated VLAN or relay topology.
+        if new_ip and self._seeded_nets and not self._ip_in_seeded_subnet(new_ip):
+            self.counters.foreign_ack += 1
+            if not self._foreign_warned:
+                self._foreign_warned = True
+                self.log.error(
+                    "DHCP ACK from a FOREIGN server — leased IP %s is outside "
+                    "every seeded subnet. A non-appliance DHCP server is winning "
+                    "the broadcast race; use an isolated test VLAN or relay "
+                    "topology (perf #454).", new_ip,
+                    extra={"fields": {"event": "foreign_dhcp_responder",
+                                      "leased_ip": new_ip, "server_id": reply.get("server_id")}})
+        if closed.late:
+            # The device had given up (its `timeout` is already counted). Kea's
+            # ACK still allocated the lease: count it under its own name, keep
+            # its latency apart from the strict histogram, and take the lease
+            # unless a newer round already holds one — the server holds it, and
+            # a model that ignores it drifts from the server it measures.
+            self.counters.dora_ack_late += 1
+            self.lat_dora_late.record_ms(latency_ms)
+            self.lifecycle.emit(mac=dev.mac, index=dev.index, event="dora_ack_late",
+                                ip=new_ip, ack_ms=round(latency_ms, 2),
+                                late_by_s=round(now - (ex.gave_up_at or now), 2),
+                                ddns=bool(dev.hostname))
+            if dev.leased_ip is not None:
+                return
             if dev.hostname:
                 self.counters.ddns_first_publish += 1
-            self.lifecycle.emit(mac=dev.mac, index=dev.index, event="dora_ack",
-                                ip=new_ip, ack_ms=round(latency_ms, 2),
-                                ddns=bool(dev.hostname))
-            # Self-schedule the next renewal at T1=900s (renewals self-track online).
-            self._schedule(T1_RENEW_S, dev.index, "t1_renew")
-            # Propagation probe membership (1-in-1000 arrivals).
-            if dev.probe:
-                self._schedule(0.0, dev.index, "probe_start")
-        elif prev_state in (DState.RENEWING, DState.REBINDING):
-            # RENEW/REBIND ACK — HARD CONTRACT: same IP. A changed IP is a FAIL.
-            if new_ip and dev.leased_ip and new_ip != dev.leased_ip:
-                self.counters.renew_ip_changed += 1
-                self.counters.ddns_renew_writes += 1  # would trigger the 6-write cascade
-                self.log.error(
-                    "RENEWAL LANDED ON A DIFFERENT IP — correctness FAIL (H3)",
-                    extra={"fields": {"event": "renew_ip_changed", "index": dev.index,
-                                      "old_ip": dev.leased_ip, "new_ip": new_ip}})
-                self.lifecycle.emit(mac=dev.mac, index=dev.index, event="renew_ip_changed",
-                                    old_ip=dev.leased_ip, new_ip=new_ip)
-                dev.leased_ip = new_ip
-            dev.state = DState.ONLINE
-            if prev_state is DState.RENEWING:
+            self._take_lease(dev, reply, now)
+            return
+        # DORA ACK — first lease (or re-lease after re-arrival), before the
+        # device gave up: the pre-#1057 meaning of dora_ack, retries included.
+        self.counters.dora_ack += 1
+        if closed.over_budget:
+            self.counters.dora_ack_over_budget += 1
+        self.lat_dora.record_ms(latency_ms)
+        # DDNS coupling happens ONLY on first DORA (hostname-bearing devices).
+        if dev.hostname:
+            self.counters.ddns_first_publish += 1
+        self.lifecycle.emit(mac=dev.mac, index=dev.index, event="dora_ack",
+                            ip=new_ip, ack_ms=round(latency_ms, 2),
+                            ddns=bool(dev.hostname), over_budget=closed.over_budget)
+        self._take_lease(dev, reply, now)
+        # Propagation probe membership (1-in-1000 arrivals).
+        if dev.probe:
+            self._schedule(0.0, dev.index, "probe_start")
+
+    def _take_lease(self, dev: Device, reply: dict, now: float) -> None:
+        """The ACK's lease becomes the device's: ONLINE, T1 armed, every other
+        exchange of the DORA round (a retransmit still in flight) settled."""
+        dev.leased_ip = reply.get("yiaddr")
+        dev.server_id = reply.get("server_id") or dev.server_id
+        dev.lease_time = int(reply.get("lease_time", self.m.scale.lease_time_s))
+        dev.state = DState.ONLINE
+        dev.lapsed = False
+        dev.dora_retries = 0
+        self.online_set.add(dev.index)
+        self.ledger.settle(dev.index, now, kinds=DORA_KINDS)
+        # Self-schedule the next renewal at T1=900s (renewals self-track online).
+        self._schedule_t1(dev)
+
+    def _on_renewal_ack(self, dev: Device, reply: dict, ex: Exchange, closed: Closed,
+                        latency_ms: float, now: float) -> None:
+        new_ip = reply.get("yiaddr")
+        # RENEW/REBIND ACK — HARD CONTRACT: same IP. A changed IP is a FAIL.
+        if new_ip and dev.leased_ip and new_ip != dev.leased_ip:
+            self.counters.renew_ip_changed += 1
+            self.counters.ddns_renew_writes += 1  # would trigger the 6-write cascade
+            self.log.error(
+                "RENEWAL LANDED ON A DIFFERENT IP — correctness FAIL (H3)",
+                extra={"fields": {"event": "renew_ip_changed", "index": dev.index,
+                                  "old_ip": dev.leased_ip, "new_ip": new_ip}})
+            self.lifecycle.emit(mac=dev.mac, index=dev.index, event="renew_ip_changed",
+                                old_ip=dev.leased_ip, new_ip=new_ip)
+            dev.leased_ip = new_ip
+        renew = ex.kind == KIND_RENEW
+        if closed.late:
+            # After RENEW_TIMEOUT_S escalated the device (renew), after it lapsed
+            # (rebind), or after it departed with the request in flight. Kea
+            # answered; the count says so under its own name, whatever state
+            # the reply found. Its latency stays out of the strict histogram.
+            if renew:
+                self.counters.renew_ack_late += 1
+            else:
+                self.counters.rebind_ack_late += 1
+            event = "renew_ack_late"
+        else:
+            if renew:
                 self.counters.renew_ack += 1
             else:
                 self.counters.rebind_ack += 1
             self.lat_renew.record_ms(latency_ms)
-            self.lifecycle.emit(mac=dev.mac, index=dev.index, event="renew_ack",
-                                ip=dev.leased_ip, ack_ms=round(latency_ms, 2))
-            self._schedule(T1_RENEW_S, dev.index, "t1_renew")
-        self.pending.pop(dev.xid, None)
+            event = "renew_ack"
+        self.lifecycle.emit(mac=dev.mac, index=dev.index, event=event,
+                            ip=dev.leased_ip or new_ip, ack_ms=round(latency_ms, 2),
+                            kind=ex.kind)
+        if dev.state in (DState.RENEWING, DState.REBINDING):
+            # The lease is renewed. A late renew ACK arriving while the rebind
+            # is in flight leaves that exchange open: kea will ACK it too, and
+            # that ACK counts on its own (two ACKs from kea, two here).
+            dev.state = DState.ONLINE
+            if dev.leased_ip is None:
+                dev.leased_ip = new_ip
+            self._schedule_t1(dev)
+        elif dev.state is DState.LEFT and dev.lapsed and new_ip:
+            # Lapsed (rebind timed out), then kea's rebind ACK arrived: the
+            # server extended the lease, so the device is back ONLINE with it.
+            # A device that DEPARTED is left alone — its lease expires
+            # server-side exactly as a silent departure should (§3.2).
+            self.lifecycle.emit(mac=dev.mac, index=dev.index, event="lapse_revived", ip=new_ip)
+            dev.leased_ip = new_ip
+            dev.state = DState.ONLINE
+            dev.lapsed = False
+            self.online_set.add(dev.index)
+            self._schedule_t1(dev)
 
-    def _on_nak(self, dev: Device) -> None:
+    def _on_nak(self, dev: Device, ex: Exchange | None, now: float) -> None:
         self.counters.nak += 1
-        self.pending.pop(dev.xid, None)
+        if ex is not None:
+            self.ledger.close(ex.xid, now, "nak")
         self.lifecycle.emit(mac=dev.mac, index=dev.index, event="nak")
-        # NAK → fall back to a fresh DISCOVER (lease invalid).
+        # NAK → fall back to a fresh DISCOVER (lease invalid). Every other
+        # exchange of the device is over with it.
         dev.leased_ip = None
         self.online_set.discard(dev.index)
-        self._send_discover(dev)
+        self.ledger.settle(dev.index, now, reason="abandoned")
+        self._send_discover(dev, new_round=True)
+
+    def _timer_exchange(self, dev: Device, arg: str, now: float) -> tuple[int, bool]:
+        """(xid, live) for an exchange-scoped timer: ``live`` when the exchange
+        is still open AND still the device's current send — the only case a
+        deadline may act on. Anything else (answered, superseded by a later
+        send of the same round, already retired) is marked expired and left."""
+        xid = int(arg) if arg else dev.xid
+        ex = self.ledger.get(xid)
+        if ex is None or not ex.open:
+            return xid, False
+        self.ledger.expire(xid, now)
+        return xid, dev.xid == xid
 
     def _handle_timer(self, idx: int, action: str, now: float) -> None:
         dev = self.devices.get(idx)
         if dev is None:
             return
-        if action == "arrival":
+        # Timers carry the exchange (or T1 token) they belong to: "name:arg".
+        name, _sep, arg = action.partition(":")
+        if name == "arrival":
             if dev.state in (DState.OFFLINE, DState.LEFT):
                 if dev.state is DState.LEFT:
                     self.counters.rearrivals += 1
@@ -603,35 +764,44 @@ class Orchestrator:
                 # sample propagation-probe membership
                 self._probe_counter += 1
                 dev.probe = (self._probe_counter % PROPAGATION_SAMPLE) == 0
-                self._send_discover(dev)
-        elif action == "dora_timeout":
-            if dev.state is DState.DISCOVERING:
-                self.pending.pop(dev.xid, None)
+                self._send_discover(dev, new_round=True)
+        elif name == "dora_timeout":
+            _xid, live = self._timer_exchange(dev, arg, now)
+            if live and dev.state is DState.DISCOVERING:
                 dev.dora_retries += 1
                 if dev.dora_retries <= MAX_DORA_RETRIES:
-                    self._send_discover(dev)
+                    self._send_discover(dev, new_round=False)
                 else:
                     self.counters.timeout += 1
+                    # Every open exchange of the round is marked: a reply that
+                    # still arrives is a late ACK, counted as such (#1057).
+                    self.ledger.give_up(dev.index, now, DORA_KINDS)
                     dev.state = DState.OFFLINE
                     dev.dora_retries = 0
                     self.lifecycle.emit(mac=dev.mac, index=dev.index, event="timeout")
-        elif action == "t1_renew":
+        elif name == "t1_renew":
+            if arg and int(arg) != dev.t1_token:
+                return  # retired: the lease was re-ACKed since and re-armed T1
             if dev.state is DState.ONLINE and dev.leased_ip:
                 self._send_request_renew(dev)
-        elif action == "renew_timeout":
-            if dev.state is DState.RENEWING:
-                self.pending.pop(dev.xid, None)
-                # T1 unanswered → escalate to REBINDING at T2.
+        elif name == "renew_timeout":
+            _xid, live = self._timer_exchange(dev, arg, now)
+            if live and dev.state is DState.RENEWING:
+                # T1 unanswered → escalate to REBINDING at T2. The renew leg is
+                # abandoned: its ACK, if it still comes, is a late renew ACK.
+                self.ledger.give_up(dev.index, now, frozenset({KIND_RENEW}))
                 self._send_request_rebind(dev)
-        elif action == "rebind_timeout":
-            if dev.state is DState.REBINDING:
-                self.pending.pop(dev.xid, None)
+        elif name == "rebind_timeout":
+            _xid, live = self._timer_exchange(dev, arg, now)
+            if live and dev.state is DState.REBINDING:
                 self.counters.lapses += 1
+                self.ledger.give_up(dev.index, now, frozenset({KIND_RENEW, KIND_REBIND}))
                 self.online_set.discard(dev.index)
                 dev.state = DState.LEFT
                 dev.leased_ip = None
+                dev.lapsed = True
                 self.lifecycle.emit(mac=dev.mac, index=dev.index, event="lapse")
-        elif action == "depart":
+        elif name == "depart":
             if dev.state in (DState.ONLINE, DState.RENEWING, DState.REBINDING):
                 self.counters.departures += 1
                 if self.rng.random() < RELEASE_FRACTION:
@@ -641,10 +811,14 @@ class Orchestrator:
                 else:
                     self.lifecycle.emit(mac=dev.mac, index=dev.index, event="depart_silent",
                                         ip=dev.leased_ip)
+                # A renewal still in flight is abandoned with the device: its
+                # ACK, if it comes, is counted late and moves nothing.
+                self.ledger.give_up(dev.index, now)
                 self.online_set.discard(dev.index)
                 dev.state = DState.LEFT
                 dev.leased_ip = None
-        elif action == "probe_start":
+                dev.lapsed = False
+        elif name == "probe_start":
             asyncio.ensure_future(self._run_propagation_probe(dev))
 
     # ---------------- receive loop ----------------
@@ -667,8 +841,10 @@ class Orchestrator:
             if not reply:
                 continue
             xid = reply.get("xid")
-            idx = self.pending.get(xid)
-            if idx is None:
+            ex = self.ledger.get(xid)
+            if ex is not None:
+                idx = ex.index
+            else:
                 idx = xid & 0xFFFFFF if xid is not None else None  # recover from low bits
                 if idx not in self.devices:
                     continue
@@ -676,12 +852,11 @@ class Orchestrator:
             mt = reply.get("msg_type")
             now = time.monotonic()
             if mt == dp.DHCPOFFER:
-                if dev.state is DState.DISCOVERING:
-                    self._on_offer(dev, reply)
+                self._on_offer(dev, reply, ex, now)
             elif mt == dp.DHCPACK:
-                self._on_ack(dev, reply, now)
+                self._on_ack(dev, reply, now, ex)
             elif mt == dp.DHCPNAK:
-                self._on_nak(dev)
+                self._on_nak(dev, ex, now)
 
     # ---------------- scheduler loop ----------------
     async def _scheduler_loop(self) -> None:
@@ -689,6 +864,7 @@ class Orchestrator:
             now = time.monotonic()
             for idx, action in self._due(now):
                 self._handle_timer(idx, action, now)
+            self.ledger.purge(now)
             await asyncio.sleep(SCHED_TICK_S)
 
     # ---------------- arrival / departure / dns drivers (setpoint-driven) ----------------
@@ -965,8 +1141,16 @@ class Orchestrator:
                 "departures": cur["departures"], "releases": cur["releases"],
                 "lapses": cur["lapses"], "rearrivals": cur["rearrivals"],
                 "dns_timeout": cur["dns_timeout"],
-                # #1057 — the DNS ledger at this window's end (cumulative like the
-                # fields above: never sum these across windows).
+                # #1057 — the cumulative ledger at this window's end (cumulative
+                # like the fields above: never sum these across windows).
+                "dora_sent": cur["dora_sent"], "dora_offer": cur["dora_offer"],
+                "request_sent": cur["request_sent"], "dora_ack": cur["dora_ack"],
+                "dora_ack_late": cur["dora_ack_late"],
+                "renew_sent": cur["renew_sent"], "renew_ack": cur["renew_ack"],
+                "renew_ack_late": cur["renew_ack_late"],
+                "rebind_sent": cur["rebind_sent"], "rebind_ack": cur["rebind_ack"],
+                "rebind_ack_late": cur["rebind_ack_late"],
+                "ack_unmatched": cur["ack_unmatched"],
                 "dns_sent": cur["dns_sent"], "dns_ok": cur["dns_ok"],
                 "dns_answered": cur["dns_answered"], "dns_error": cur["dns_error"],
                 "dns_rcodes": dict(sorted(self.dns_tally.rcodes.items())),
@@ -1018,7 +1202,7 @@ class Orchestrator:
 
     def _finalize(self) -> None:
         # Dump cumulative HdrHistograms + a final summary.
-        for acc in (self.lat_dora, self.lat_renew, self.lat_dns,
+        for acc in (self.lat_dora, self.lat_dora_late, self.lat_renew, self.lat_dns,
                     self.lat_prop_ipam, self.lat_prop_dns):
             acc.dump_hdr(str(self.rp.generator(f"orchestrator.shard{self.shard}.{acc.name}.hdr")))
         counters = self._counter_snapshot()
@@ -1027,6 +1211,7 @@ class Orchestrator:
             "shard": self.shard,
             "counters": counters,
             "dora_ack": self.lat_dora.cumulative_summary(),
+            "dora_ack_late": self.lat_dora_late.cumulative_summary(),
             "renew_ack": self.lat_renew.cumulative_summary(),
             "dns_resolve": self.lat_dns.cumulative_summary(),
             "propagation_lease_to_ipam": self.lat_prop_ipam.cumulative_summary(),
@@ -1034,7 +1219,9 @@ class Orchestrator:
             "unique_macs_with_lease_or_seen": sum(
                 1 for d in self.devices.values()
                 if d.state is not DState.OFFLINE),
-            # #1057 — the DNS outcome by rcode, folded the way the report prints it.
+            # #1057 — the two ledgers a consumer needs without re-deriving them:
+            # the handshake at three strictnesses and the DNS outcome by rcode.
+            "handshake": handshake_summary(counters),
             "dns": dns_summary(counters),
             "dns_error_types": dict(sorted(self.dns_tally.errors.items())),
         }

--- a/perf/generators/orchestrator/device_fleet.py
+++ b/perf/generators/orchestrator/device_fleet.py
@@ -66,18 +66,27 @@ import dhcp_packet as dp  # noqa: E402
 from lifecycle_log import LatencyAccumulator, LifecycleLog  # noqa: E402
 from relay_sockets import open_relay_sockets  # noqa: E402
 
+from accounting import DnsTally, rcode_name  # noqa: E402
+from spddi_perf.generator_tallies import dns_summary  # noqa: E402
+
 # dnspython is an off-box runtime dep (perf/requirements.txt: dnspython>=2.6); resolve
 # it once at import so the per-query hot path doesn't re-run the import machinery. When
 # absent (bare env) the DNS query stream + the IPAM->DNS propagation leg no-op cleanly.
 try:
     import dns.asyncquery as _dns_aq  # type: ignore
+    import dns.exception as _dns_exc  # type: ignore
     import dns.message as _dns_msg  # type: ignore
     import dns.rcode as _dns_rcode  # type: ignore
 
     _HAVE_DNSPYTHON = True
+    # A timed-out query is a timeout; every other exception is an error the
+    # tally names by type (#1057 — the two used to share one counter).
+    _DNS_TIMEOUT_EXC: tuple[type[BaseException], ...] = (
+        _dns_exc.Timeout, asyncio.TimeoutError, TimeoutError)
 except Exception:  # pragma: no cover - exercised only in a bare env
-    _dns_aq = _dns_msg = _dns_rcode = None  # type: ignore
+    _dns_aq = _dns_exc = _dns_msg = _dns_rcode = None  # type: ignore
     _HAVE_DNSPYTHON = False
+    _DNS_TIMEOUT_EXC = (asyncio.TimeoutError, TimeoutError)
 
 SERVICE = "orchestrator"
 
@@ -161,6 +170,10 @@ class Counters:
     ddns_first_publish: int = 0
     ddns_renew_writes: int = 0   # MUST stay 0 (H3) — incremented only if a renewal IP-changes
     renew_ip_changed: int = 0    # named correctness FAIL signal
+    # #1057 — every DNS answer counted. The fields above keep their meaning
+    # (add, never rename: ddi-pg's load tier folds them by name).
+    dns_answered: int = 0          # every DNS response received, any rcode (+ dns_rcode_<NAME>)
+    dns_error: int = 0             # DNS exceptions that were not timeouts (types in the log)
 
 
 def _derive_subnets(m: manifest_mod.Manifest, rp: RunPaths, log: Any) -> list[SubnetInfo]:
@@ -314,6 +327,7 @@ class Orchestrator:
         self.online_set: set[int] = set()
         # pending DHCP exchanges keyed by xid -> device index (recv correlation)
         self.pending: dict[int, int] = {}
+        self.dns_tally = DnsTally()
         # timer wheel: due_time -> list[(index, action)]
         self._timers: list[tuple[float, int, str]] = []  # min-heap of (when, index, action)
 
@@ -785,13 +799,26 @@ class Orchestrator:
         try:
             resp = await _dns_aq.udp(
                 q, self.node_ip, port=self.m.target.dns.port, timeout=2.0)
-            latency_ms = (time.monotonic() - t0) * 1000.0
-            self.lat_dns.record_ms(latency_ms)
-            rc = resp.rcode()
-            if rc in (_dns_rcode.NOERROR, _dns_rcode.NXDOMAIN):
-                self.counters.dns_ok += 1
-        except Exception:
+        except _DNS_TIMEOUT_EXC:
             self.counters.dns_timeout += 1
+            return
+        except Exception as exc:  # noqa: BLE001 — every exception is counted, by type
+            self.counters.dns_error += 1
+            if self.dns_tally.error(type(exc).__name__):
+                self.log.warning("DNS query failed: %s: %s", type(exc).__name__, exc,
+                                 extra={"fields": {"event": "dns_query_error",
+                                                   "error_type": type(exc).__name__}})
+            return
+        latency_ms = (time.monotonic() - t0) * 1000.0
+        self.lat_dns.record_ms(latency_ms)
+        # Every answer is counted under its rcode (#1057): before, REFUSED /
+        # SERVFAIL / FORMERR answers were counted as nothing, and a run whose
+        # 606k queries BIND refused read "ok 0, timeouts 46".
+        rc = resp.rcode()
+        self.counters.dns_answered += 1
+        self.dns_tally.answered(rcode_name(rc, _dns_rcode.to_text))
+        if rc in (_dns_rcode.NOERROR, _dns_rcode.NXDOMAIN):
+            self.counters.dns_ok += 1
 
     # ---------------- propagation-lag probe (single-clock) ----------------
     async def _run_propagation_probe(self, dev: Device) -> None:
@@ -938,6 +965,11 @@ class Orchestrator:
                 "departures": cur["departures"], "releases": cur["releases"],
                 "lapses": cur["lapses"], "rearrivals": cur["rearrivals"],
                 "dns_timeout": cur["dns_timeout"],
+                # #1057 — the DNS ledger at this window's end (cumulative like the
+                # fields above: never sum these across windows).
+                "dns_sent": cur["dns_sent"], "dns_ok": cur["dns_ok"],
+                "dns_answered": cur["dns_answered"], "dns_error": cur["dns_error"],
+                "dns_rcodes": dict(sorted(self.dns_tally.rcodes.items())),
             }
             append_ndjson(self.stats_path, rec)
             self._sched_lag_max = 0.0  # reset window max
@@ -945,7 +977,9 @@ class Orchestrator:
 
     def _counter_snapshot(self) -> dict[str, int]:
         c = self.counters
-        return {k: getattr(c, k) for k in c.__dataclass_fields__}
+        out = {k: getattr(c, k) for k in c.__dataclass_fields__}
+        out.update(self.dns_tally.counter_fields())  # dns_rcode_<NAME> per rcode seen
+        return out
 
     # ---------------- lifecycle ----------------
     async def run(self) -> None:
@@ -987,10 +1021,11 @@ class Orchestrator:
         for acc in (self.lat_dora, self.lat_renew, self.lat_dns,
                     self.lat_prop_ipam, self.lat_prop_dns):
             acc.dump_hdr(str(self.rp.generator(f"orchestrator.shard{self.shard}.{acc.name}.hdr")))
+        counters = self._counter_snapshot()
         summary = {
             "ts": utc_now_iso(),
             "shard": self.shard,
-            "counters": self._counter_snapshot(),
+            "counters": counters,
             "dora_ack": self.lat_dora.cumulative_summary(),
             "renew_ack": self.lat_renew.cumulative_summary(),
             "dns_resolve": self.lat_dns.cumulative_summary(),
@@ -999,6 +1034,9 @@ class Orchestrator:
             "unique_macs_with_lease_or_seen": sum(
                 1 for d in self.devices.values()
                 if d.state is not DState.OFFLINE),
+            # #1057 — the DNS outcome by rcode, folded the way the report prints it.
+            "dns": dns_summary(counters),
+            "dns_error_types": dict(sorted(self.dns_tally.errors.items())),
         }
         append_ndjson(self.rp.generator(f"orchestrator.shard{self.shard}.summary.ndjson"), summary)
         # Every socket, not just the wildcard one: relay topology opens one per

--- a/perf/generators/orchestrator/device_fleet.py
+++ b/perf/generators/orchestrator/device_fleet.py
@@ -77,17 +77,17 @@ from spddi_perf.generator_tallies import dns_summary, handshake_summary  # noqa:
 # absent (bare env) the DNS query stream + the IPAM->DNS propagation leg no-op cleanly.
 try:
     import dns.asyncquery as _dns_aq  # type: ignore
-    import dns.exception as _dns_exc  # type: ignore
     import dns.message as _dns_msg  # type: ignore
     import dns.rcode as _dns_rcode  # type: ignore
+    from dns.exception import Timeout as _DnsTimeout  # type: ignore
 
     _HAVE_DNSPYTHON = True
     # A timed-out query is a timeout; every other exception is an error the
     # tally names by type (#1057 — the two used to share one counter).
     _DNS_TIMEOUT_EXC: tuple[type[BaseException], ...] = (
-        _dns_exc.Timeout, asyncio.TimeoutError, TimeoutError)
+        _DnsTimeout, asyncio.TimeoutError, TimeoutError)
 except Exception:  # pragma: no cover - exercised only in a bare env
-    _dns_aq = _dns_exc = _dns_msg = _dns_rcode = None  # type: ignore
+    _dns_aq = _dns_msg = _dns_rcode = None  # type: ignore
     _HAVE_DNSPYTHON = False
     _DNS_TIMEOUT_EXC = (asyncio.TimeoutError, TimeoutError)
 

--- a/perf/generators/orchestrator/tests/test_accounting.py
+++ b/perf/generators/orchestrator/tests/test_accounting.py
@@ -133,9 +133,10 @@ def test_dns_tally_counts_every_rcode_and_names_errors_once() -> None:
         t.answered(name)
     assert t.counter_fields() == {
         "dns_rcode_NOERROR": 1, "dns_rcode_REFUSED": 2, "dns_rcode_SERVFAIL": 1}
-    assert t.error("OSError") is True
-    assert t.error("OSError") is False
-    assert t.error("BadResponse") is True
+    first = t.error("OSError")
+    second = t.error("OSError")
+    other = t.error("BadResponse")
+    assert (first, second, other) == (True, False, True)
     assert t.errors == {"OSError": 2, "BadResponse": 1}
 
 

--- a/perf/generators/orchestrator/tests/test_accounting.py
+++ b/perf/generators/orchestrator/tests/test_accounting.py
@@ -1,0 +1,29 @@
+"""DnsTally: every DNS answer under its rcode, exceptions by type (#1057)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from accounting import DnsTally, rcode_name  # noqa: E402
+
+
+def test_dns_tally_counts_every_rcode_and_names_errors_once() -> None:
+    t = DnsTally()
+    for name in ("REFUSED", "REFUSED", "NOERROR", "SERVFAIL"):
+        t.answered(name)
+    assert t.counter_fields() == {
+        "dns_rcode_NOERROR": 1, "dns_rcode_REFUSED": 2, "dns_rcode_SERVFAIL": 1}
+    assert t.error("OSError") is True
+    assert t.error("OSError") is False
+    assert t.error("BadResponse") is True
+    assert t.errors == {"OSError": 2, "BadResponse": 1}
+
+
+def test_rcode_name_uses_the_mnemonic_and_never_raises() -> None:
+    assert rcode_name(5, lambda rc: {5: "REFUSED"}[rc]) == "REFUSED"
+    assert rcode_name(17, lambda rc: {5: "REFUSED"}[rc]) == "RCODE17"   # to_text raised
+    assert rcode_name(3) == "RCODE3"
+    assert rcode_name("x") == "RCODE?"

--- a/perf/generators/orchestrator/tests/test_accounting.py
+++ b/perf/generators/orchestrator/tests/test_accounting.py
@@ -76,12 +76,16 @@ def test_ack_after_give_up_is_late_and_counted_once() -> None:
 
 def test_unknown_xid_is_none_and_purge_forgets_after_grace() -> None:
     led = ExchangeLedger(grace_s=10.0)
-    assert led.close(xid(9), 1.0) is None
+    unknown = led.close(xid(9), 1.0)
+    assert unknown is None
     led.open(xid(1), DEV, KIND_DISCOVER, 0.0)
     led.close(xid(1), 1.0, "nak")
-    assert led.purge(5.0) == 0 and len(led) == 1           # still known within the grace
-    assert led.purge(11.5) == 1 and len(led) == 0
-    assert led.close(xid(1), 12.0) is None                 # now unmatched
+    purged_early = led.purge(5.0)                          # still known within the grace
+    assert purged_early == 0 and len(led) == 1
+    purged_late = led.purge(11.5)
+    assert purged_late == 1 and len(led) == 0
+    forgotten = led.close(xid(1), 12.0)                    # now unmatched
+    assert forgotten is None
     assert led.open_for(DEV) == []
 
 

--- a/perf/generators/orchestrator/tests/test_accounting.py
+++ b/perf/generators/orchestrator/tests/test_accounting.py
@@ -1,4 +1,8 @@
-"""DnsTally: every DNS answer under its rcode, exceptions by type (#1057)."""
+"""ExchangeLedger + DnsTally: a reply is attributed to the exchange it answers.
+
+Hermetic — the ledger is pure; the orchestrator's FSM wiring is exercised in
+test_device_fleet_accounting.py (skipped where the harness deps are absent).
+"""
 
 from __future__ import annotations
 
@@ -7,7 +11,120 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from accounting import DnsTally, rcode_name  # noqa: E402
+from accounting import (  # noqa: E402
+    DORA_KINDS,
+    KIND_DISCOVER,
+    KIND_REBIND,
+    KIND_RENEW,
+    KIND_SELECT,
+    DnsTally,
+    ExchangeLedger,
+    rcode_name,
+)
+
+DEV = 7
+
+
+def xid(nonce: int, index: int = DEV) -> int:
+    return ((nonce & 0xFF) << 24) | (index & 0xFFFFFF)
+
+
+def test_ack_to_the_live_exchange_is_strict() -> None:
+    led = ExchangeLedger()
+    led.open(xid(1), DEV, KIND_DISCOVER, 0.0, episode=1)
+    led.close(xid(1), 0.05, "offer")                       # OFFER answered the DISCOVER
+    led.open(xid(2), DEV, KIND_SELECT, 0.05, episode=1)
+    c = led.close(xid(2), 0.09, "ack")
+    assert c is not None and not c.duplicate and not c.over_budget and not c.late
+    assert c.exchange.kind == KIND_SELECT and c.exchange.tx_at == 0.05
+
+
+def test_ack_during_a_retry_is_over_budget_not_late() -> None:
+    """REQUEST#1 timed out (retransmit fired), the device is still DISCOVERING
+    on DISCOVER#2 when the ACK for REQUEST#1 lands: counted as an ack, flagged
+    over budget, never late (the device had not given up)."""
+    led = ExchangeLedger()
+    led.open(xid(1), DEV, KIND_DISCOVER, 0.0, episode=1)
+    led.close(xid(1), 0.1, "offer")
+    led.open(xid(2), DEV, KIND_SELECT, 0.1, episode=1)
+    led.expire(xid(2), 4.1)                                # its own timer fired → retry
+    led.open(xid(3), DEV, KIND_DISCOVER, 4.1, episode=1)
+    c = led.close(xid(2), 4.6, "ack")
+    assert c is not None and c.over_budget and not c.late and not c.duplicate
+    # the retried DISCOVER is settled with the round, so its OFFER later is not "open"
+    settled = led.settle(DEV, 4.6, kinds=DORA_KINDS)
+    assert [e.xid for e in settled] == [xid(3)]
+    assert not led.get(xid(3)).open and led.get(xid(3)).closed_by == "superseded"
+
+
+def test_ack_after_give_up_is_late_and_counted_once() -> None:
+    led = ExchangeLedger()
+    led.open(xid(1), DEV, KIND_DISCOVER, 0.0, episode=1)
+    led.close(xid(1), 0.1, "offer")
+    led.open(xid(2), DEV, KIND_SELECT, 0.1, episode=1)
+    led.expire(xid(2), 4.1)
+    led.open(xid(3), DEV, KIND_DISCOVER, 4.1, episode=1)
+    led.expire(xid(3), 8.1)
+    gave = led.give_up(DEV, 8.1, DORA_KINDS)              # MAX_DORA_RETRIES exceeded
+    assert {e.xid for e in gave} == {xid(2), xid(3)}
+    c = led.close(xid(2), 9.0, "ack")                      # kea's ACK, 5 s after the REQUEST
+    assert c is not None and c.late and c.over_budget and not c.duplicate
+    assert c.exchange.gave_up_at == 8.1
+    again = led.close(xid(2), 9.5, "ack")                  # a retransmitted ACK
+    assert again is not None and again.duplicate
+
+
+def test_unknown_xid_is_none_and_purge_forgets_after_grace() -> None:
+    led = ExchangeLedger(grace_s=10.0)
+    assert led.close(xid(9), 1.0) is None
+    led.open(xid(1), DEV, KIND_DISCOVER, 0.0)
+    led.close(xid(1), 1.0, "nak")
+    assert led.purge(5.0) == 0 and len(led) == 1           # still known within the grace
+    assert led.purge(11.5) == 1 and len(led) == 0
+    assert led.close(xid(1), 12.0) is None                 # now unmatched
+    assert led.open_for(DEV) == []
+
+
+def test_reused_xid_supersedes_the_older_send() -> None:
+    led = ExchangeLedger()
+    a = led.open(xid(1), DEV, KIND_DISCOVER, 0.0)
+    b = led.open(xid(1), DEV, KIND_DISCOVER, 4.0)          # nonce collided on the retry
+    assert not a.open and a.closed_by == "superseded" and b.open
+    assert led.get(xid(1)) is b
+
+
+def test_renew_ack_after_escalation_is_late_and_rebind_ack_is_strict() -> None:
+    """The renew timer escalated to REBIND; both ACKs then arrive. Each is
+    attributed to its own exchange: one late renew, one strict rebind — two
+    ACKs from kea, two counted here."""
+    led = ExchangeLedger()
+    led.open(xid(1), DEV, KIND_RENEW, 100.0, episode=5)
+    led.expire(xid(1), 104.0)
+    led.give_up(DEV, 104.0, frozenset({KIND_RENEW}))       # the escalation abandons the renew leg
+    led.open(xid(2), DEV, KIND_REBIND, 104.0, episode=5)
+    renew = led.close(xid(1), 104.5, "ack")
+    assert renew is not None and renew.over_budget and renew.late
+    rebind = led.close(xid(2), 104.6, "ack")
+    assert rebind is not None and not rebind.over_budget and not rebind.late
+    assert renew.exchange.kind == KIND_RENEW and rebind.exchange.kind == KIND_REBIND
+
+
+def test_rebind_ack_after_lapse_is_late() -> None:
+    led = ExchangeLedger()
+    led.open(xid(2), DEV, KIND_REBIND, 104.0, episode=5)
+    led.expire(xid(2), 108.0)
+    led.give_up(DEV, 108.0, frozenset({KIND_RENEW, KIND_REBIND}))   # lapse
+    c = led.close(xid(2), 109.0, "ack")
+    assert c is not None and c.late
+
+
+def test_give_up_without_kinds_marks_every_open_exchange() -> None:
+    led = ExchangeLedger()
+    led.open(xid(1), DEV, KIND_RENEW, 0.0)
+    led.open(xid(2), 8, KIND_RENEW, 0.0)                   # another device
+    marked = led.give_up(DEV, 1.0)
+    assert [e.xid for e in marked] == [xid(1)]
+    assert led.get(xid(2)).gave_up_at is None
 
 
 def test_dns_tally_counts_every_rcode_and_names_errors_once() -> None:

--- a/perf/generators/orchestrator/tests/test_device_fleet_accounting.py
+++ b/perf/generators/orchestrator/tests/test_device_fleet_accounting.py
@@ -1,0 +1,116 @@
+"""The orchestrator's DNS leg wired to the per-rcode tally (#1057), driven without
+a socket: the dnspython query is faked and its outcomes injected.
+
+Needs the harness deps (PyYAML for the manifest, dnspython for the DNS leg);
+skipped where they are absent (CI's perf job installs pytest only — the pure
+ledger is covered by test_accounting.py there).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+dns_exception = pytest.importorskip("dns.exception")
+dns_rcode = pytest.importorskip("dns.rcode")
+
+HERE = Path(__file__).resolve()
+sys.path.insert(0, str(HERE.parents[1]))                 # generators/orchestrator
+sys.path.insert(0, str(HERE.parents[3] / "harness"))     # spddi_perf
+
+import device_fleet as df  # noqa: E402
+from spddi_perf.runpaths import RunPaths  # noqa: E402
+
+SMOKE = HERE.parents[3] / "manifests" / "smoke.yaml"
+
+
+@pytest.fixture
+def orch(tmp_path, monkeypatch):
+    """A relay-topology orchestrator over 8 devices / 2 subnets, no socket."""
+    monkeypatch.delenv("SPDDI_PERF_NODE_IP", raising=False)
+    monkeypatch.delenv("SPDDI_PERF_API_BASE", raising=False)
+    monkeypatch.delenv("SPDDI_PERF_DHCP_IFACE", raising=False)
+    m = yaml.safe_load(SMOKE.read_text())
+    m["target"]["node_ip"] = "192.0.2.10"
+    m["target"]["api_base"] = "https://192.0.2.10/api"
+    m["target"]["dhcp"] = {"port": 67, "topology": "relay",
+                           "giaddr": ["10.9.0.1", "10.9.1.1"], "iface": ""}
+    m["scale"]["unique_devices"] = 8
+    m["scale"]["peak_active_devices"] = 8
+    m["scale"]["students"] = 8
+    m["seed"]["ip_block"] = "10.8.0.0/16"
+    m["seed"]["subnets"] = {"count": 2, "prefix": 24, "pool_fraction": 0.9}
+    m["seed"]["relay_addresses_per_scope"] = True
+    mpath = tmp_path / "m.yaml"
+    mpath.write_text(yaml.safe_dump(m))
+    run_root = tmp_path / "run"
+    RunPaths.for_run("t-run", run_root).ensure_dirs()
+    o = df.Orchestrator(argparse.Namespace(
+        run_id="t-run", run_root=str(run_root), manifest=str(mpath), shard=0, shards=1))
+    o.sent = []
+    o._send = lambda pkt, dev: o.sent.append((dev.index, bytes(pkt)))  # type: ignore[method-assign]
+    # The send paths stamp tx_at with time.monotonic(); the tests hand every
+    # handler an explicit `now`, so the clock the stamps read is the same one.
+    o.clock = {"t": 0.0}
+    monkeypatch.setattr(df.time, "monotonic", lambda: o.clock["t"])
+    return o
+
+
+def at(o, t: float) -> float:
+    """Advance the orchestrator's clock to t and return it (for a handler's `now`)."""
+    o.clock["t"] = t
+    return t
+
+
+def test_dns_query_counts_every_rcode_timeouts_and_errors_apart(orch, monkeypatch):
+    o = orch
+    dev = o.devices[0]
+    outcomes = iter([
+        types.SimpleNamespace(rcode=lambda: dns_rcode.REFUSED),
+        types.SimpleNamespace(rcode=lambda: dns_rcode.NOERROR),
+        types.SimpleNamespace(rcode=lambda: dns_rcode.NXDOMAIN),
+        types.SimpleNamespace(rcode=lambda: dns_rcode.SERVFAIL),
+        dns_exception.Timeout(),
+        OSError("network unreachable"),
+        OSError("network unreachable"),
+    ])
+
+    async def fake_udp(q, where, port=53, timeout=None):
+        nxt = next(outcomes)
+        if isinstance(nxt, BaseException):
+            raise nxt
+        return nxt
+
+    monkeypatch.setattr(df, "_dns_aq", types.SimpleNamespace(udp=fake_udp))
+    for _ in range(7):
+        asyncio.run(o._dns_query(dev))
+    c = o.counters
+    assert (c.dns_sent, c.dns_answered, c.dns_ok, c.dns_timeout, c.dns_error) == (7, 4, 2, 1, 2)
+    snap = o._counter_snapshot()
+    assert snap["dns_rcode_REFUSED"] == 1 and snap["dns_rcode_NOERROR"] == 1
+    assert snap["dns_rcode_NXDOMAIN"] == 1 and snap["dns_rcode_SERVFAIL"] == 1
+    assert o.dns_tally.errors == {"OSError": 2}
+    assert o.lat_dns.cumulative_summary()["count"] == 4
+    d = df.dns_summary(snap)
+    assert d["unaccounted"] == 0 and d["not_ok"] == 2 and d["ok_pct_of_sent"] == round(200 / 7, 3)
+
+
+def test_finalize_writes_the_dns_ledger_into_the_shard_summary(orch):
+    o = orch
+    o.dns_tally.answered("REFUSED")
+    o.counters.dns_sent += 1
+    o.counters.dns_answered += 1
+    o._finalize()
+    path = o.rp.generator("orchestrator.shard0.summary.ndjson")
+    summary = json.loads(path.read_text().splitlines()[-1])
+    assert summary["counters"]["dns_rcode_REFUSED"] == 1
+    assert summary["counters"]["dns_answered"] == 1
+    assert summary["dns"]["rcodes"] == {"REFUSED": 1} and summary["dns"]["ok"] == 0
+    assert summary["dns"]["unaccounted"] == 0 and summary["dns_error_types"] == {}

--- a/perf/generators/orchestrator/tests/test_device_fleet_accounting.py
+++ b/perf/generators/orchestrator/tests/test_device_fleet_accounting.py
@@ -1,5 +1,5 @@
-"""The orchestrator's DNS leg wired to the per-rcode tally (#1057), driven without
-a socket: the dnspython query is faked and its outcomes injected.
+"""The orchestrator's FSM wired to the exchange ledger (#1057), driven without a
+socket: replies are injected as parsed dicts and timers fired by hand.
 
 Needs the harness deps (PyYAML for the manifest, dnspython for the DNS leg);
 skipped where they are absent (CI's perf job installs pytest only — the pure
@@ -26,6 +26,7 @@ sys.path.insert(0, str(HERE.parents[1]))                 # generators/orchestrat
 sys.path.insert(0, str(HERE.parents[3] / "harness"))     # spddi_perf
 
 import device_fleet as df  # noqa: E402
+from accounting import DORA_KINDS, KIND_RENEW, KIND_SELECT  # noqa: E402
 from spddi_perf.runpaths import RunPaths  # noqa: E402
 
 SMOKE = HERE.parents[3] / "manifests" / "smoke.yaml"
@@ -69,6 +70,181 @@ def at(o, t: float) -> float:
     return t
 
 
+def timers(o, prefix: str, idx: int) -> list[str]:
+    return sorted(a for _w, i, a in o._timers if i == idx and a.startswith(prefix))
+
+
+def ack(ip: str, xid: int) -> dict:
+    return {"xid": xid, "yiaddr": ip, "server_id": "192.0.2.10", "lease_time": 1800,
+            "msg_type": df.dp.DHCPACK}
+
+
+def offer(ip: str, xid: int) -> dict:
+    return {"xid": xid, "yiaddr": ip, "server_id": "192.0.2.10", "msg_type": df.dp.DHCPOFFER}
+
+
+def dora_to_select(o, idx: int, ip: str, t: float) -> tuple[int, int]:
+    """arrival → DISCOVER → OFFER → REQUEST(selecting); returns (discover xid, select xid)."""
+    dev = o.devices[idx]
+    o._handle_timer(idx, "arrival", at(o, t))
+    xd = dev.xid
+    assert dev.state is df.DState.DISCOVERING
+    assert timers(o, "dora_timeout:", idx) == [f"dora_timeout:{xd}"]
+    o._on_offer(dev, offer(ip, xd), o.ledger.get(xd), at(o, at(o, t + 0.02)))
+    xs = dev.xid
+    assert xs != xd and o.ledger.get(xs).kind == KIND_SELECT
+    assert not o.ledger.get(xd).open and o.ledger.get(xd).closed_by == "offer"
+    return xd, xs
+
+
+def test_discover_deadline_does_not_retransmit_over_a_live_request(orch):
+    """Pre-#1057 the DISCOVER's per-packet timer fired on whatever exchange was
+    current and re-DISCOVERed under an in-flight REQUEST."""
+    o = orch
+    xd, xs = dora_to_select(o, 0, "10.8.0.5", 0.0)
+    sent_before = len(o.sent)
+    o._handle_timer(0, f"dora_timeout:{xd}", at(o, 4.0))      # the DISCOVER's own deadline
+    assert len(o.sent) == sent_before and o.devices[0].xid == xs
+    assert o.devices[0].dora_retries == 0 and o.counters.dora_sent == 1
+    # the REQUEST's own deadline is what retries
+    o._handle_timer(0, f"dora_timeout:{xs}", at(o, 4.1))
+    assert o.counters.dora_sent == 2 and o.devices[0].dora_retries == 1
+    assert o.devices[0].state is df.DState.DISCOVERING
+
+
+def test_strict_ack_and_over_budget_ack_keep_dora_ack_meaning(orch):
+    o = orch
+    # strict: ACK within the REQUEST's budget
+    _xd, xs = dora_to_select(o, 1, "10.8.1.5", 10.0)
+    o._on_ack(o.devices[1], ack("10.8.1.5", xs), at(o, 10.05), o.ledger.get(xs))
+    assert o.counters.dora_ack == 1 and o.counters.dora_ack_over_budget == 0
+    assert o.devices[1].state is df.DState.ONLINE and o.devices[1].leased_ip == "10.8.1.5"
+    assert 1 in o.online_set and timers(o, "t1_renew:", 1) == ["t1_renew:1"]
+    assert o.lat_dora.cumulative_summary()["count"] == 1
+    # over budget: the REQUEST timed out (retry sent), then its ACK lands
+    _xd, xs2 = dora_to_select(o, 2, "10.8.0.6", 20.0)
+    o._handle_timer(2, f"dora_timeout:{xs2}", at(o, 24.0))
+    retry_xid = o.devices[2].xid
+    assert retry_xid != xs2 and o.ledger.get(retry_xid).open
+    o._on_ack(o.devices[2], ack("10.8.0.6", xs2), at(o, 24.5), o.ledger.get(xs2))
+    assert o.counters.dora_ack == 2 and o.counters.dora_ack_over_budget == 1
+    assert o.counters.dora_ack_late == 0 and o.counters.timeout == 0
+    assert o.devices[2].state is df.DState.ONLINE
+    # the retried DISCOVER was settled with the round; its OFFER is now ignored
+    assert not o.ledger.get(retry_xid).open
+    o._on_offer(o.devices[2], offer("10.8.0.6", retry_xid), o.ledger.get(retry_xid), at(o, 24.6))
+    assert o.counters.offer_ignored == 1 and o.counters.dora_offer == 3
+    assert o.devices[2].state is df.DState.ONLINE
+
+
+def test_late_ack_after_give_up_is_counted_and_takes_the_lease(orch):
+    """The #1057 hole: after MAX_DORA_RETRIES the device is OFFLINE and its
+    `timeout` counted; the ACK kea sends a moment later used to match no branch."""
+    o = orch
+    dev = o.devices[3]
+    _xd, xs = dora_to_select(o, 3, "10.8.1.9", 30.0)
+    t = 34.0
+    last_select = xs
+    for _ in range(df.MAX_DORA_RETRIES):                 # 3 retries, each a fresh DORA
+        o._handle_timer(3, f"dora_timeout:{dev.xid}", at(o, t))
+        assert dev.state is df.DState.DISCOVERING
+        xd = dev.xid
+        o._on_offer(dev, offer("10.8.1.9", xd), o.ledger.get(xd), at(o, t + 0.1))
+        last_select = dev.xid
+        t += 4.0
+    o._handle_timer(3, f"dora_timeout:{dev.xid}", at(o, t))     # 4th deadline → give up
+    assert o.counters.timeout == 1 and dev.state is df.DState.OFFLINE
+    assert dev.leased_ip is None and 3 not in o.online_set
+    assert all(e.gave_up_at is not None for e in [o.ledger.get(last_select)])
+    # kea's ACK for the last REQUEST arrives 2 s after the device gave up
+    o._on_ack(dev, ack("10.8.1.9", last_select), at(o, t + 2.0), o.ledger.get(last_select))
+    assert o.counters.dora_ack_late == 1 and o.counters.dora_ack == 0
+    assert dev.state is df.DState.ONLINE and dev.leased_ip == "10.8.1.9" and 3 in o.online_set
+    assert timers(o, "t1_renew:", 3) == ["t1_renew:1"]
+    assert o.lat_dora_late.cumulative_summary()["count"] == 1
+    assert o.lat_dora.cumulative_summary()["count"] == 0
+    # a retransmitted ACK for the same exchange is a duplicate, an unknown xid unmatched
+    o._on_ack(dev, ack("10.8.1.9", last_select), at(o, t + 2.5), o.ledger.get(last_select))
+    o._on_ack(dev, ack("10.8.1.9", 0xAB000003), at(o, t + 2.6), None)
+    assert o.counters.ack_duplicate == 1 and o.counters.ack_unmatched == 1
+    assert o.counters.dora_ack_late == 1
+    snap = o._counter_snapshot()
+    assert snap["dora_ack_late"] == 1 and snap["timeout"] == 1
+    h = df.handshake_summary(snap)
+    assert h["strict_pct"] == 0.0 and h["with_late_pct"] == 100.0
+
+
+def test_renew_ack_after_escalation_then_rebind_ack_renews_once(orch):
+    o = orch
+    dev = o.devices[4]
+    _xd, xs = dora_to_select(o, 4, "10.8.0.7", 40.0)
+    o._on_ack(dev, ack("10.8.0.7", xs), at(o, 40.1), o.ledger.get(xs))
+    assert timers(o, "t1_renew:", 4) == ["t1_renew:1"]
+    o._handle_timer(4, "t1_renew:1", at(o, 940.1))
+    xr = dev.xid
+    assert dev.state is df.DState.RENEWING and o.ledger.get(xr).kind == KIND_RENEW
+    assert o.counters.renew_sent == 1
+    o._handle_timer(4, f"renew_timeout:{xr}", at(o, 944.1))   # escalate
+    xb = dev.xid
+    assert dev.state is df.DState.REBINDING and o.counters.rebind_sent == 1
+    # the renew's ACK lands late (kea unicast it after the deadline)
+    o._on_ack(dev, ack("10.8.0.7", xr), at(o, 944.3), o.ledger.get(xr))
+    assert o.counters.renew_ack_late == 1 and o.counters.renew_ack == 0
+    assert dev.state is df.DState.ONLINE and dev.leased_ip == "10.8.0.7"
+    assert timers(o, "t1_renew:", 4)[-1] == "t1_renew:2"
+    # then the rebind's ACK: its exchange is live → strict, and T1 re-armed once more
+    o._on_ack(dev, ack("10.8.0.7", xb), at(o, 944.4), o.ledger.get(xb))
+    assert o.counters.rebind_ack == 1 and o.counters.rebind_ack_late == 0
+    # the device was already ONLINE: the T1 armed by the round's first ACK stands
+    assert dev.state is df.DState.ONLINE and dev.t1_token == 2
+    # the retired T1 token renews nothing; the live one does — one renewal, not two
+    o._handle_timer(4, "t1_renew:1", at(o, 1844.4))
+    assert o.counters.renew_sent == 1
+    o._handle_timer(4, "t1_renew:2", at(o, 1844.5))
+    assert o.counters.renew_sent == 2 and dev.state is df.DState.RENEWING
+
+
+def test_lapse_then_late_rebind_ack_revives_but_departure_does_not(orch):
+    o = orch
+    # lapse → late rebind ACK revives the lease
+    dev = o.devices[5]
+    _xd, xs = dora_to_select(o, 5, "10.8.1.7", 50.0)
+    o._on_ack(dev, ack("10.8.1.7", xs), at(o, 50.1), o.ledger.get(xs))
+    o._handle_timer(5, "t1_renew:1", at(o, 950.1))
+    o._handle_timer(5, f"renew_timeout:{dev.xid}", at(o, 954.1))
+    xb = dev.xid
+    o._handle_timer(5, f"rebind_timeout:{xb}", at(o, 958.1))
+    assert o.counters.lapses == 1 and dev.state is df.DState.LEFT and dev.lapsed
+    assert dev.leased_ip is None and 5 not in o.online_set
+    o._on_ack(dev, ack("10.8.1.7", xb), at(o, 959.0), o.ledger.get(xb))
+    assert o.counters.rebind_ack_late == 1
+    assert dev.state is df.DState.ONLINE and dev.leased_ip == "10.8.1.7" and 5 in o.online_set
+    # departure with a renew in flight → its ACK is late and moves nothing
+    dev6 = o.devices[6]
+    _xd, xs6 = dora_to_select(o, 6, "10.8.0.8", 60.0)
+    o._on_ack(dev6, ack("10.8.0.8", xs6), at(o, 60.1), o.ledger.get(xs6))
+    o._handle_timer(6, "t1_renew:1", at(o, 960.1))
+    xr6 = dev6.xid
+    o.rng.random = lambda: 0.99                          # silent departure, no RELEASE
+    o._handle_timer(6, "depart", at(o, 961.0))
+    assert o.counters.departures == 1 and dev6.state is df.DState.LEFT and not dev6.lapsed
+    o._on_ack(dev6, ack("10.8.0.8", xr6), at(o, 961.5), o.ledger.get(xr6))
+    assert o.counters.renew_ack_late == 1
+    assert dev6.state is df.DState.LEFT and dev6.leased_ip is None and 6 not in o.online_set
+
+
+def test_nak_restarts_the_round_and_settles_the_old_exchanges(orch):
+    o = orch
+    dev = o.devices[7]
+    _xd, xs = dora_to_select(o, 7, "10.8.1.8", 70.0)
+    ep = dev.episode
+    o._on_nak(dev, o.ledger.get(xs), at(o, 70.1))
+    assert o.counters.nak == 1 and dev.state is df.DState.DISCOVERING
+    assert dev.episode == ep + 1 and o.counters.dora_sent == 2
+    assert o.ledger.get(xs).closed_by == "nak"
+    assert [e.xid for e in o.ledger.open_for(7, DORA_KINDS)] == [dev.xid]
+
+
 def test_dns_query_counts_every_rcode_timeouts_and_errors_apart(orch, monkeypatch):
     o = orch
     dev = o.devices[0]
@@ -102,15 +278,18 @@ def test_dns_query_counts_every_rcode_timeouts_and_errors_apart(orch, monkeypatc
     assert d["unaccounted"] == 0 and d["not_ok"] == 2 and d["ok_pct_of_sent"] == round(200 / 7, 3)
 
 
-def test_finalize_writes_the_dns_ledger_into_the_shard_summary(orch):
+def test_finalize_writes_the_ledgers_into_the_shard_summary(orch):
     o = orch
+    _xd, xs = dora_to_select(o, 1, "10.8.1.5", 10.0)
+    o._on_ack(o.devices[1], ack("10.8.1.5", xs), at(o, 10.05), o.ledger.get(xs))
     o.dns_tally.answered("REFUSED")
     o.counters.dns_sent += 1
     o.counters.dns_answered += 1
     o._finalize()
     path = o.rp.generator("orchestrator.shard0.summary.ndjson")
     summary = json.loads(path.read_text().splitlines()[-1])
-    assert summary["counters"]["dns_rcode_REFUSED"] == 1
-    assert summary["counters"]["dns_answered"] == 1
+    assert summary["counters"]["dora_ack"] == 1 and summary["counters"]["dns_rcode_REFUSED"] == 1
+    assert summary["handshake"]["strict_pct"] == 100.0 and summary["handshake"]["acked_late"] == 0
     assert summary["dns"]["rcodes"] == {"REFUSED": 1} and summary["dns"]["ok"] == 0
-    assert summary["dns"]["unaccounted"] == 0 and summary["dns_error_types"] == {}
+    assert summary["dora_ack_late"]["count"] == 0 and summary["dora_ack"]["count"] == 1
+    assert o.rp.generator("orchestrator.shard0.dhcp_dora_ack_late.hdr").exists()

--- a/perf/generators/orchestrator/tests/test_device_fleet_accounting.py
+++ b/perf/generators/orchestrator/tests/test_device_fleet_accounting.py
@@ -1,9 +1,10 @@
 """The orchestrator's FSM wired to the exchange ledger (#1057), driven without a
 socket: replies are injected as parsed dicts and timers fired by hand.
 
-Needs the harness deps (PyYAML for the manifest, dnspython for the DNS leg);
-skipped where they are absent (CI's perf job installs pytest only — the pure
-ledger is covered by test_accounting.py there).
+Needs PyYAML (the manifest) and dnspython (the DNS leg) — both installed by
+the perf CI job; in a bare environment the file import-skips. The one
+assertion that needs the HdrHistogram backend (the .hdr dump) is gated on
+it: hdrhistogram ships a wheel for x86_64 only.
 """
 
 from __future__ import annotations
@@ -26,6 +27,7 @@ sys.path.insert(0, str(HERE.parents[1]))                 # generators/orchestrat
 sys.path.insert(0, str(HERE.parents[3] / "harness"))     # spddi_perf
 
 import device_fleet as df  # noqa: E402
+import lifecycle_log  # noqa: E402
 from accounting import DORA_KINDS, KIND_RENEW, KIND_SELECT  # noqa: E402
 from spddi_perf.runpaths import RunPaths  # noqa: E402
 
@@ -292,4 +294,7 @@ def test_finalize_writes_the_ledgers_into_the_shard_summary(orch):
     assert summary["handshake"]["strict_pct"] == 100.0 and summary["handshake"]["acked_late"] == 0
     assert summary["dns"]["rcodes"] == {"REFUSED": 1} and summary["dns"]["ok"] == 0
     assert summary["dora_ack_late"]["count"] == 0 and summary["dora_ack"]["count"] == 1
-    assert o.rp.generator("orchestrator.shard0.dhcp_dora_ack_late.hdr").exists()
+    # The encoded histogram exists only with the HdrHistogram backend; the
+    # reservoir fallback dumps nothing (lifecycle_log.dump_hdr).
+    hdr = o.rp.generator("orchestrator.shard0.dhcp_dora_ack_late.hdr")
+    assert hdr.exists() == lifecycle_log._HAVE_HDR

--- a/perf/harness/spddi_perf/collect.py
+++ b/perf/harness/spddi_perf/collect.py
@@ -681,16 +681,21 @@ def criterion_b(rd: RunData) -> list[dict[str, Any]]:
     # BIND answered REFUSED read "ok 0, timeouts 46" and b6a said NO_DATA.
     orch_c = gt.sum_counters(rd.orchestrator_summary)
     orch_rc = gt.dns_rcodes(orch_c)
-    orch_answered = int(orch_c.get("dns_answered") or 0) or sum(orch_rc.values())
+    orch_sent = int(orch_c.get("dns_sent") or 0)
     has_orch = bool(rd.orchestrator_summary)
 
-    # b6 — DNS SERVFAIL rate < 0.1% steady. dnsperf rcode + orchestrator rcode.
+    # b6 — DNS SERVFAIL rate < 0.1% steady. dnsperf rcode + orchestrator rcode,
+    # both halves over queries SENT (dnsperf `sent`, orchestrator `dns_sent`):
+    # a query that timed out was sent and did not SERVFAIL, so the rate is per
+    # attempt on either side and reproduces against BIND's own
+    # SERVFAIL / QUERY ratio. (Over `dns_answered` a heavy-timeout run would
+    # read higher than BIND does.)
     dp_sent, dp_servfail = _dnsperf_rcode_totals(rd, "SERVFAIL")
-    sf_total = dp_sent + orch_answered
+    sf_total = dp_sent + orch_sent
     servfail = ((dp_servfail + orch_rc.get("SERVFAIL", 0)) / sf_total) if sf_total else None
     rows.append(_row(
         "b6", "DNS SERVFAIL rate < 0.1% steady",
-        "dnsperf.rcode.SERVFAIL / sent + orchestrator dns_rcode_SERVFAIL / dns_answered",
+        "dnsperf.rcode.SERVFAIL / sent + orchestrator dns_rcode_SERVFAIL / dns_sent",
         _fmt(servfail * 100.0 if servfail is not None else None, "%"), "< 0.1%",
         _verdict_lt(servfail, 0.001) if servfail is not None else NO_DATA))
 

--- a/perf/harness/spddi_perf/collect.py
+++ b/perf/harness/spddi_perf/collect.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import Any
 
 import spddi_perf.manifest as manifest_mod
+from spddi_perf import generator_tallies as gt
 from spddi_perf.logging_util import atomic_write_json, get_logger, log_event, utc_now_iso
 from spddi_perf.runpaths import RunPaths
 
@@ -675,38 +676,64 @@ def criterion_b(rd: RunData) -> list[dict[str, Any]]:
         f"p999 {_fmt(p999, ' ms')}, max {_fmt(dns_max, ' ms')}", "< 50 / < 200 ms",
         b5_verdict))
 
-    # b6 — DNS SERVFAIL rate < 0.1% steady. dnsperf rcode + native metric cross-check.
-    servfail = _dns_rcode_rate(rd, "SERVFAIL")
+    # The orchestrator's own DNS stream, by rcode (#1057). Before per-rcode
+    # accounting its answers were invisible to b6/b6a: a run whose 606k queries
+    # BIND answered REFUSED read "ok 0, timeouts 46" and b6a said NO_DATA.
+    orch_c = gt.sum_counters(rd.orchestrator_summary)
+    orch_rc = gt.dns_rcodes(orch_c)
+    orch_answered = int(orch_c.get("dns_answered") or 0) or sum(orch_rc.values())
+    has_orch = bool(rd.orchestrator_summary)
+
+    # b6 — DNS SERVFAIL rate < 0.1% steady. dnsperf rcode + orchestrator rcode.
+    dp_sent, dp_servfail = _dnsperf_rcode_totals(rd, "SERVFAIL")
+    sf_total = dp_sent + orch_answered
+    servfail = ((dp_servfail + orch_rc.get("SERVFAIL", 0)) / sf_total) if sf_total else None
     rows.append(_row(
         "b6", "DNS SERVFAIL rate < 0.1% steady",
-        "dnsperf.rcode.SERVFAIL / sent",
+        "dnsperf.rcode.SERVFAIL / sent + orchestrator dns_rcode_SERVFAIL / dns_answered",
         _fmt(servfail * 100.0 if servfail is not None else None, "%"), "< 0.1%",
         _verdict_lt(servfail, 0.001) if servfail is not None else NO_DATA))
 
     # b6a — DNS REFUSED rate exactly 0 (structural; out-of-zone leak detector §4.9).
-    refused_total = sum(int((r.get("rcode") or {}).get("REFUSED", r.get("refused", 0)) or 0)
-                        for r in rd.dnsperf)
-    has_dnsperf = bool(rd.dnsperf)
+    # The orchestrator's REFUSED count joins dnsperf's: a refused query measured
+    # nothing, whether the name escaped the validator or the generator queried
+    # from a vantage outside the served view — the run cannot stand either way.
+    refused_dnsperf = sum(int((r.get("rcode") or {}).get("REFUSED", r.get("refused", 0)) or 0)
+                          for r in rd.dnsperf)
+    refused_orch = int(orch_rc.get("REFUSED", 0))
+    refused_total = refused_dnsperf + refused_orch
+    has_refused_data = bool(rd.dnsperf) or has_orch
     rows.append(_row(
         "b6a", "DNS REFUSED rate exactly 0 (structural — out-of-zone leak, §4.9)",
-        "dnsperf.rcode.REFUSED / refused_alert",
-        _fmt(refused_total if has_dnsperf else None), "= 0",
-        (NO_DATA if not has_dnsperf else (PASS if refused_total == 0 else FAIL)),
-        note="any REFUSED = out-of-zone query escaped the §4.9 validator (bug/leak)"))
+        "dnsperf.rcode.REFUSED + orchestrator dns_rcode_REFUSED",
+        (f"{refused_total} (dnsperf {refused_dnsperf}, orchestrator {refused_orch})"
+         if has_refused_data else _fmt(None)), "= 0",
+        (NO_DATA if not has_refused_data else (PASS if refused_total == 0 else FAIL)),
+        note="any REFUSED = an out-of-zone query escaped the §4.9 validator (bug/leak), "
+             "or the generator queried from outside the served view (vantage)"))
 
-    # b7 — DNS timeout/drop rate ~0 steady. dnsperf timeouts + orchestrator dns_timeout.
+    # b7 — DNS timeout/drop rate ~0 steady. dnsperf timeouts + orchestrator dns_timeout
+    # (+ dns_error: exceptions that were not timeouts, once one counter — #1057).
+    # The orchestrator counters are cumulative per shard: read the run's final
+    # summary, or the last window per shard — never a sum over windows, which
+    # multiplied every earlier window's timeouts into the figure printed here.
     timeouts = sum(int(r.get("timeouts") or 0) for r in rd.dnsperf if r.get("kind") == "dnsperf_window")
     sent = sum(int(r.get("sent") or 0) for r in rd.dnsperf if r.get("kind") == "dnsperf_window")
-    orch_dns_to = sum(int(r.get("dns_timeout") or 0) for r in rd.orchestrator_stats)
+    if has_orch:
+        orch_dns_to = int(orch_c.get("dns_timeout") or 0)
+    else:
+        orch_dns_to = gt.dns_timeouts_from_windows(rd.orchestrator_stats)
+    orch_dns_err = int(orch_c.get("dns_error") or 0)
     to_rate = (timeouts / sent) if sent else None
     rows.append(_row(
         "b7", "DNS timeout/drop rate ~0 steady",
-        "dnsperf.timeouts/sent + orchestrator.dns_timeout",
+        "dnsperf.timeouts/sent + orchestrator dns_timeout (+ dns_error)",
         f"{_fmt(to_rate * 100.0 if to_rate is not None else None, '%')} "
-        f"(+{orch_dns_to} orch)".strip(),
+        f"(+{orch_dns_to} orch timeouts, +{orch_dns_err} errors)".strip(),
         "~0 (no sustained timeouts)",
-        (NO_DATA if to_rate is None and not rd.orchestrator_stats
-         else (PASS if (to_rate or 0) < 0.005 and orch_dns_to == 0 else FAIL))))
+        (NO_DATA if to_rate is None and not (rd.orchestrator_stats or has_orch)
+         else (PASS if (to_rate or 0) < 0.005 and orch_dns_to == 0 and orch_dns_err == 0
+               else FAIL))))
 
     # b8 — lease→IPAM→DNS propagation p95 (phase-aware) < 10s. propagation_ipam_to_dns.
     steady_prop_p95 = _phase_p95(rd, "propagation_dns_p95", _is_steady)
@@ -808,7 +835,8 @@ def _phase_pair_verdict(steady: float | None, steady_thr: float,
     return PASS if seen else NO_DATA
 
 
-def _dns_rcode_rate(rd: RunData, code: str) -> float | None:
+def _dnsperf_rcode_totals(rd: RunData, code: str) -> tuple[int, int]:
+    """(sent, answers with ``code``) over the dnsperf windows."""
     total = 0
     code_n = 0
     for r in rd.dnsperf:
@@ -818,6 +846,11 @@ def _dns_rcode_rate(rd: RunData, code: str) -> float | None:
         rc = (r.get("rcode") or {}).get(code, 0)
         total += sent
         code_n += int(rc or 0)
+    return total, code_n
+
+
+def _dns_rcode_rate(rd: RunData, code: str) -> float | None:
+    total, code_n = _dnsperf_rcode_totals(rd, code)
     return (code_n / total) if total else None
 
 
@@ -1330,6 +1363,10 @@ def build_slo_results(rd: RunData) -> dict[str, Any]:
         "overall": {"verdict": overall, "note": overall_note},
         "profile_key": _profile_key(rd.m),
         "present_surfaces": sorted(rd.present),
+        # #1057 — the orchestrator's own ledgers, folded across shards: the
+        # handshake at three strictnesses and the DNS outcome by rcode. None
+        # when no shard summary exists (absence is recorded, never fabricated).
+        "generator": gt.orchestrator_accounting(rd.orchestrator_summary),
     }
 
 
@@ -1594,6 +1631,7 @@ def render_markdown(rd: RunData, slo: dict[str, Any], deltas: dict[str, Any],
         "manifest": _manifest_human(rd.m),
         "present_surfaces": slo["present_surfaces"],
         "profile_key": slo["profile_key"],
+        "generator": slo.get("generator"),
         "fmt_verdict": _verdict_badge,
     }
     tpl = _template_path()
@@ -1686,6 +1724,15 @@ def _render_markdown_builtin(ctx: dict[str, Any]) -> str:
             lines.append(f"| {r['id']} | {slo_txt} | {meas} | {thr} | "
                          f"{_verdict_badge(r['verdict'])} |")
 
+    # Generator accounting (§8.2 / #1057) — what the orchestrator itself counted,
+    # so a handshake or DNS figure can be reconciled with the appliance's own.
+    gen = ctx.get("generator")
+    lines.append("\n## Generator accounting (orchestrator)\n")
+    if gen:
+        lines.extend(_generator_lines(gen))
+    else:
+        lines.append("_No orchestrator shard summary in the run directory._")
+
     # Bottleneck finding (§8.4 #4)
     b = ctx["bottleneck"]
     lines.append("\n## Bottleneck finding (first-to-give + ready §5 mitigation)\n")
@@ -1771,6 +1818,31 @@ def _render_markdown_builtin(ctx: dict[str, Any]) -> str:
                  "`v2-measured` (§8.3.1) once the idle floor is established.")
     lines.append("")
     return "\n".join(lines)
+
+
+def _generator_lines(gen: dict[str, Any]) -> list[str]:
+    """The generator-accounting block, one bullet per ledger (shared shape with
+    the template so the two renderers stay in sync)."""
+    h = gen.get("handshake") or {}
+    d = gen.get("dns") or {}
+
+    def pct(v: Any) -> str:
+        return "—" if v is None else f"{v:.2f}%"
+
+    rc = ", ".join(f"{k} {v:,}" for k, v in (d.get("rcodes") or {}).items()) or "none"
+    return [
+        f"- **Shards:** {gen.get('shards', 0)}",
+        f"- **DHCP handshake:** attempts {h.get('attempts', 0):,} · "
+        f"acked {h.get('acked', 0):,} ({pct(h.get('strict_pct'))} strict) · "
+        f"within budget {h.get('acked_within_budget', 0):,} ({pct(h.get('within_budget_pct'))}) · "
+        f"late {h.get('acked_late', 0):,} ({pct(h.get('with_late_pct'))} with late) · "
+        f"timeouts {h.get('timeouts', 0):,} · naks {h.get('naks', 0):,}",
+        f"- **DNS stream:** sent {d.get('sent', 0):,} · answered {d.get('answered', 0):,} · "
+        f"ok {d.get('ok', 0):,} ({pct(d.get('ok_pct_of_sent'))} of sent) · "
+        f"timeouts {d.get('timeouts', 0):,} · errors {d.get('errors', 0):,} · "
+        f"unaccounted {d.get('unaccounted', 0):,}",
+        f"- **DNS rcodes:** {rc}",
+    ]
 
 
 def _ddns_short_circuit_note(ctx: dict[str, Any]) -> str:

--- a/perf/harness/spddi_perf/generator_tallies.py
+++ b/perf/harness/spddi_perf/generator_tallies.py
@@ -1,0 +1,119 @@
+"""Fold the orchestrator's shard counters into the numbers a report can print.
+
+Pure and dependency-free so the orchestrator (perf/generators/orchestrator/
+accounting.py), the report generator (collect.py) and any consumer of a
+``orchestrator.shard*.summary.ndjson`` line compute the SAME handshake and DNS
+figures from the same counters (#1057).
+
+Two accounting holes made the shard summaries unreliable evidence before this
+module existed:
+
+* ``_dns_query`` counted ``dns_ok`` only for NOERROR/NXDOMAIN and
+  ``dns_timeout`` only on an exception, so an answer with any other rcode was
+  counted as nothing. A run whose 606k queries BIND answered REFUSED read
+  "ok 0, timeouts 46" beside a 606k-sample latency histogram.
+* ``_on_ack`` counted ``dora_ack`` only while the device was still
+  DISCOVERING; an ACK arriving after the device had given up was counted as a
+  timeout AND discarded, so the generator's handshake figure could not be
+  reconciled with kea's own ACK count.
+
+The counters are cumulative per shard; ``sum_counters`` adds shards, never
+windows (a per-window row carries the cumulative value at that window's end,
+so summing windows multiplies the truth — see ``dns_timeouts_from_windows``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+#: rcodes that count as an answered query for ``dns_ok`` — unchanged meaning:
+#: NOERROR is the positive path, NXDOMAIN the deliberate-miss slice (§1.7).
+DNS_OK_RCODES = ("NOERROR", "NXDOMAIN")
+RCODE_PREFIX = "dns_rcode_"
+
+
+def _int(v: Any) -> int:
+    try:
+        return int(v or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def sum_counters(summaries: Iterable[dict[str, Any]]) -> dict[str, int]:
+    """Add every integer ``counters`` field across shard summaries.
+
+    Dynamic ``dns_rcode_<NAME>`` keys are summed like any other counter, so a
+    rcode seen by one shard only still appears in the fold.
+    """
+    out: dict[str, int] = {}
+    for s in summaries:
+        c = s.get("counters") if isinstance(s, dict) else None
+        if not isinstance(c, dict):
+            continue
+        for k, v in c.items():
+            if isinstance(v, bool) or not isinstance(v, (int, float, str)):
+                continue
+            out[k] = out.get(k, 0) + _int(v)
+    return out
+
+
+def dns_rcodes(counters: dict[str, Any]) -> dict[str, int]:
+    """``{"REFUSED": n, "NOERROR": m, ...}`` from the flattened counter keys."""
+    return {k[len(RCODE_PREFIX):]: _int(v) for k, v in counters.items()
+            if k.startswith(RCODE_PREFIX)}
+
+
+def _pct(num: int, den: int) -> float | None:
+    return round(100.0 * num / den, 3) if den > 0 else None
+
+
+def dns_summary(counters: dict[str, Any]) -> dict[str, Any]:
+    """The DNS query stream's outcome ledger from one counter set.
+
+    ``sent`` = ``answered + timeouts + errors`` when every query was accounted
+    for; ``unaccounted`` shows any gap (queries still in flight at shutdown, or
+    a generator that predates per-rcode accounting, where it equals the
+    answers that were counted as nothing).
+    """
+    sent = _int(counters.get("dns_sent"))
+    ok = _int(counters.get("dns_ok"))
+    answered = _int(counters.get("dns_answered"))
+    timeouts = _int(counters.get("dns_timeout"))
+    errors = _int(counters.get("dns_error"))
+    rcodes = dns_rcodes(counters)
+    if not answered and rcodes:
+        answered = sum(rcodes.values())
+    not_ok = max(0, answered - ok)
+    return {
+        "sent": sent,
+        "answered": answered,
+        "ok": ok,
+        "not_ok": not_ok,
+        "timeouts": timeouts,
+        "errors": errors,
+        "unaccounted": max(0, sent - answered - timeouts - errors),
+        "rcodes": dict(sorted(rcodes.items())),
+        "ok_pct_of_sent": _pct(ok, sent),
+        "ok_pct_of_answered": _pct(ok, answered),
+        "timeout_pct_of_sent": _pct(timeouts, sent),
+    }
+
+
+def dns_timeouts_from_windows(stats_rows: Iterable[dict[str, Any]]) -> int:
+    """Cumulative ``dns_timeout`` across shards from the PERIODIC stat rows.
+
+    Each row carries the shard's cumulative value at the end of that window,
+    so the run's total is the last (largest) value per shard, summed over
+    shards — never the sum over rows, which counts every earlier window's
+    timeouts again on every later row (collect.py b7 did exactly that).
+    """
+    per_shard: dict[Any, int] = {}
+    for r in stats_rows:
+        if not isinstance(r, dict):
+            continue
+        shard = r.get("shard", 0)
+        v = _int(r.get("dns_timeout"))
+        if v > per_shard.get(shard, 0):
+            per_shard[shard] = v
+    return sum(per_shard.values())

--- a/perf/harness/spddi_perf/generator_tallies.py
+++ b/perf/harness/spddi_perf/generator_tallies.py
@@ -68,6 +68,44 @@ def _pct(num: int, den: int) -> float | None:
     return round(100.0 * num / den, 3) if den > 0 else None
 
 
+def handshake_summary(counters: dict[str, Any]) -> dict[str, Any]:
+    """The DORA handshake figure at three strictnesses, from one counter set.
+
+    ``attempts``            = dora_ack + timeout + nak — every DORA the generator
+                              closed itself, one way or the other (unchanged
+                              denominator; a device that never got a verdict is
+                              in none of the three).
+    ``acked``               = dora_ack: ACKed before the device gave up, retries
+                              included — the pre-#1057 meaning, kept so existing
+                              consumers read the same figure.
+    ``acked_within_budget`` = acked minus ``dora_ack_over_budget``: the ACK
+                              answered the exchange within its own DORA_TIMEOUT_S
+                              (no retransmit had fired for it).
+    ``acked_late``          = dora_ack_late: the ACK arrived after the device had
+                              given up and been counted as a timeout. Each one is
+                              a timeout that turned out to be a slow ACK, so
+                              ``acked_late <= timeouts`` and ``with_late_pct``
+                              never exceeds 100.
+    """
+    acked = _int(counters.get("dora_ack"))
+    over = _int(counters.get("dora_ack_over_budget"))
+    late = _int(counters.get("dora_ack_late"))
+    timeouts = _int(counters.get("timeout"))
+    naks = _int(counters.get("nak"))
+    attempts = acked + timeouts + naks
+    return {
+        "attempts": attempts,
+        "acked": acked,
+        "acked_within_budget": max(0, acked - over),
+        "acked_late": late,
+        "timeouts": timeouts,
+        "naks": naks,
+        "within_budget_pct": _pct(max(0, acked - over), attempts),
+        "strict_pct": _pct(acked, attempts),
+        "with_late_pct": _pct(min(attempts, acked + late), attempts),
+    }
+
+
 def dns_summary(counters: dict[str, Any]) -> dict[str, Any]:
     """The DNS query stream's outcome ledger from one counter set.
 
@@ -117,3 +155,18 @@ def dns_timeouts_from_windows(stats_rows: Iterable[dict[str, Any]]) -> int:
         if v > per_shard.get(shard, 0):
             per_shard[shard] = v
     return sum(per_shard.values())
+
+
+def orchestrator_accounting(summaries: Iterable[dict[str, Any]]) -> dict[str, Any] | None:
+    """The report's generator block: folded counters + both ledgers, or None
+    when no shard summary exists (absence is recorded, never fabricated)."""
+    summaries = [s for s in summaries if isinstance(s, dict)]
+    if not summaries:
+        return None
+    counters = sum_counters(summaries)
+    return {
+        "shards": len(summaries),
+        "counters": dict(sorted(counters.items())),
+        "handshake": handshake_summary(counters),
+        "dns": dns_summary(counters),
+    }

--- a/perf/harness/tests/test_collect_generator_rows.py
+++ b/perf/harness/tests/test_collect_generator_rows.py
@@ -1,0 +1,109 @@
+"""collect.py reads the orchestrator's per-rcode and late-ACK ledgers (#1057).
+
+Needs PyYAML (the manifest loader) — skipped in a bare env; the fold itself is
+covered by test_generator_tallies.py there.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import spddi_perf.manifest as manifest_mod  # noqa: E402
+from spddi_perf import collect  # noqa: E402
+from spddi_perf.runpaths import RunPaths  # noqa: E402
+
+SMOKE = Path(__file__).resolve().parents[2] / "manifests" / "smoke.yaml"
+
+
+def rundata(tmp_path, summaries, stats=(), dnsperf=()):
+    m = manifest_mod.from_dict(yaml.safe_load(SMOKE.read_text()))
+    rp = RunPaths.for_run("t-run", tmp_path)
+    rp.ensure_dirs()
+    rd = collect.RunData(rp=rp, m=m, profile="p")
+    rd.orchestrator_summary = list(summaries)
+    rd.orchestrator_stats = list(stats)
+    rd.dnsperf = list(dnsperf)
+    if summaries or stats:
+        rd.present.add("orchestrator")
+    return rd
+
+
+def rows_by_id(rows):
+    return {r["id"]: r for r in rows}
+
+
+# The 2026-09-10 PostQA cluster load tier, as the fixed generator would have written it.
+REFUSED_RUN = {"shard": 0, "counters": {
+    "dora_sent": 19520, "dora_ack": 8599, "timeout": 695, "nak": 0, "dora_ack_late": 300,
+    "dns_sent": 606185, "dns_ok": 0, "dns_timeout": 46, "dns_error": 0, "dns_answered": 606139,
+    "dns_rcode_REFUSED": 606138, "dns_rcode_NOERROR": 1}}
+
+
+def test_b6a_fails_structurally_on_the_orchestrators_refused_answers(tmp_path):
+    rd = rundata(tmp_path, [REFUSED_RUN])
+    b = rows_by_id(collect.criterion_b(rd))
+    assert b["b6a"]["verdict"] == collect.FAIL
+    assert b["b6a"]["measured"] == "606138 (dnsperf 0, orchestrator 606138)"
+    assert b["b6"]["verdict"] == collect.PASS          # 0 SERVFAIL of 606,139 answered
+    assert b["b6"]["measured"].startswith("0")            # _fmt renders 0.0 as "0%"
+    slo = collect.build_slo_results(rd)
+    assert slo["overall"]["verdict"] == collect.FAIL
+    assert "b6a" in slo["overall"]["note"]
+    assert slo["generator"]["dns"]["rcodes"] == {"NOERROR": 1, "REFUSED": 606138}
+    assert slo["generator"]["handshake"]["acked_late"] == 300
+    assert slo["generator"]["handshake"]["strict_pct"] == round(100 * 8599 / 9294, 3)
+    assert slo["generator"]["handshake"]["with_late_pct"] == round(100 * 8899 / 9294, 3)
+
+
+def test_b6a_is_no_data_without_any_dns_source_and_passes_on_zero_refused(tmp_path):
+    rd = rundata(tmp_path, [])
+    assert rows_by_id(collect.criterion_b(rd))["b6a"]["verdict"] == collect.NO_DATA
+    clean = {"shard": 0, "counters": {"dns_sent": 10, "dns_ok": 10, "dns_answered": 10,
+                                      "dns_rcode_NOERROR": 10, "dora_ack": 1}}
+    b = rows_by_id(collect.criterion_b(rundata(tmp_path, [clean])))
+    assert b["b6a"]["verdict"] == collect.PASS and b["b7"]["verdict"] == collect.PASS
+
+
+def test_b7_reads_the_cumulative_timeouts_once_not_summed_over_windows(tmp_path):
+    windows = [{"shard": 0, "dns_timeout": v} for v in (1, 5, 46)]
+    # summaries present: their counters are the truth
+    rd = rundata(tmp_path, [REFUSED_RUN], stats=windows)
+    b7 = rows_by_id(collect.criterion_b(rd))["b7"]
+    assert "+46 orch timeouts" in b7["measured"] and b7["verdict"] == collect.FAIL
+    # no summary (a run that died before _finalize): the last window per shard
+    rd2 = rundata(tmp_path, [], stats=windows)
+    b7 = rows_by_id(collect.criterion_b(rd2))["b7"]
+    assert "+46 orch timeouts" in b7["measured"]     # pre-fix this printed 52
+    # errors that are not timeouts still fail the drop-rate row
+    err = {"shard": 0, "counters": {"dns_sent": 5, "dns_ok": 4, "dns_answered": 4,
+                                    "dns_rcode_NOERROR": 4, "dns_error": 1}}
+    b7 = rows_by_id(collect.criterion_b(rundata(tmp_path, [err])))["b7"]
+    assert "+1 errors" in b7["measured"] and b7["verdict"] == collect.FAIL
+
+
+def test_report_renders_the_generator_block_in_both_renderers(tmp_path):
+    import logging
+    log = logging.getLogger("t")
+    rd = rundata(tmp_path, [REFUSED_RUN])
+    slo = collect.build_slo_results(rd)
+    deltas = collect.build_deltas(rd)
+    bottleneck = collect.build_bottleneck(rd, slo)
+    md = collect.render_markdown(rd, slo, deltas, bottleneck, None, log)
+    assert "## Generator accounting (orchestrator)" in md
+    assert "late 300" in md and "REFUSED 606,138" in md and "unaccounted 0" in md
+    ctx = {"run_id": "r", "profile": "p", "generated_at": "t", "slo_thresholds_version": "v",
+           "incomplete": False, "criteria": slo["criteria"], "overall": slo["overall"],
+           "deltas": deltas, "bottleneck": bottleneck, "comparison": None,
+           "manifest": collect._manifest_human(rd.m), "present_surfaces": [],
+           "profile_key": {}, "generator": slo["generator"]}
+    builtin = collect._render_markdown_builtin(ctx)
+    assert "late 300" in builtin and "REFUSED 606,138" in builtin
+    ctx["generator"] = None
+    assert "_No orchestrator shard summary" in collect._render_markdown_builtin(ctx)

--- a/perf/harness/tests/test_collect_generator_rows.py
+++ b/perf/harness/tests/test_collect_generator_rows.py
@@ -1,7 +1,7 @@
 """collect.py reads the orchestrator's per-rcode and late-ACK ledgers (#1057).
 
-Needs PyYAML (the manifest loader) — skipped in a bare env; the fold itself is
-covered by test_generator_tallies.py there.
+Needs PyYAML (the manifest loader), installed by the perf CI job; in a bare
+environment the file import-skips.
 """
 
 from __future__ import annotations
@@ -60,6 +60,18 @@ def test_b6a_fails_structurally_on_the_orchestrators_refused_answers(tmp_path):
     assert slo["generator"]["handshake"]["acked_late"] == 300
     assert slo["generator"]["handshake"]["strict_pct"] == round(100 * 8599 / 9294, 3)
     assert slo["generator"]["handshake"]["with_late_pct"] == round(100 * 8899 / 9294, 3)
+
+
+def test_b6_rates_servfail_over_queries_sent_not_answered(tmp_path):
+    """8 SERVFAILs in 10,000 sent of which 8,000 were answered: 0.08 % per
+    attempt (PASS), which is what BIND's SERVFAIL / QUERY ratio would show;
+    over the answers it would read 0.10 % and FAIL the < 0.1 % row."""
+    run = {"shard": 0, "counters": {"dns_sent": 10000, "dns_answered": 8000, "dns_ok": 7992,
+                                    "dns_timeout": 2000, "dns_rcode_NOERROR": 7992,
+                                    "dns_rcode_SERVFAIL": 8, "dora_ack": 1}}
+    b6 = rows_by_id(collect.criterion_b(rundata(tmp_path, [run])))["b6"]
+    assert b6["measured"] == "0.08%" and b6["verdict"] == collect.PASS
+    assert b6["source"].endswith("dns_rcode_SERVFAIL / dns_sent")
 
 
 def test_b6a_is_no_data_without_any_dns_source_and_passes_on_zero_refused(tmp_path):

--- a/perf/harness/tests/test_generator_tallies.py
+++ b/perf/harness/tests/test_generator_tallies.py
@@ -1,0 +1,49 @@
+"""generator_tallies: the shard counters folded the way the report prints them (#1057)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from spddi_perf.generator_tallies import (  # noqa: E402
+    dns_rcodes,
+    dns_summary,
+    dns_timeouts_from_windows,
+    sum_counters,
+)
+
+
+def test_sum_counters_adds_shards_including_dynamic_rcode_keys() -> None:
+    a = {"counters": {"dora_ack": 10, "dns_rcode_REFUSED": 5, "dns_rcode_NOERROR": 1}}
+    b = {"counters": {"dora_ack": 7, "dns_rcode_REFUSED": 2, "dns_rcode_SERVFAIL": 3}}
+    c = sum_counters([a, b, {"no": "counters"}, "junk"])
+    assert c == {"dora_ack": 17, "dns_rcode_REFUSED": 7, "dns_rcode_NOERROR": 1,
+                 "dns_rcode_SERVFAIL": 3}
+    assert dns_rcodes(c) == {"REFUSED": 7, "NOERROR": 1, "SERVFAIL": 3}
+
+
+def test_dns_summary_shows_the_pre_fix_hole_and_the_fixed_ledger() -> None:
+    """nightly-20260909 PostQA: dns_sent 606,185 / ok 0 / timeouts 46 beside a
+    606,139-sample histogram — the answers counted as nothing show up as
+    `unaccounted`. With per-rcode counters they are REFUSED."""
+    old = dns_summary({"dns_sent": 606185, "dns_ok": 0, "dns_timeout": 46})
+    assert old["answered"] == 0 and old["unaccounted"] == 606139
+    assert old["ok_pct_of_sent"] == 0.0 and old["ok_pct_of_answered"] is None
+    new = dns_summary({"dns_sent": 606185, "dns_ok": 0, "dns_timeout": 46,
+                       "dns_answered": 606139, "dns_rcode_REFUSED": 606138,
+                       "dns_rcode_NOERROR": 1})
+    assert new["unaccounted"] == 0 and new["not_ok"] == 606139
+    assert new["rcodes"] == {"NOERROR": 1, "REFUSED": 606138}
+    # a summary written before dns_answered existed still gets a total from the rcodes
+    partial = dns_summary({"dns_sent": 10, "dns_ok": 4, "dns_rcode_NOERROR": 4,
+                           "dns_rcode_REFUSED": 6})
+    assert partial["answered"] == 10 and partial["ok_pct_of_answered"] == 40.0
+
+
+def test_dns_timeouts_from_windows_takes_the_last_value_per_shard_not_the_sum() -> None:
+    rows = [{"shard": 0, "dns_timeout": 1}, {"shard": 0, "dns_timeout": 3},
+            {"shard": 0, "dns_timeout": 46}, {"shard": 1, "dns_timeout": 2},
+            {"shard": 1, "dns_timeout": 2}, "junk"]
+    assert dns_timeouts_from_windows(rows) == 48      # not 1+3+46+2+2 = 54

--- a/perf/harness/tests/test_generator_tallies.py
+++ b/perf/harness/tests/test_generator_tallies.py
@@ -11,6 +11,8 @@ from spddi_perf.generator_tallies import (  # noqa: E402
     dns_rcodes,
     dns_summary,
     dns_timeouts_from_windows,
+    handshake_summary,
+    orchestrator_accounting,
     sum_counters,
 )
 
@@ -22,6 +24,22 @@ def test_sum_counters_adds_shards_including_dynamic_rcode_keys() -> None:
     assert c == {"dora_ack": 17, "dns_rcode_REFUSED": 7, "dns_rcode_NOERROR": 1,
                  "dns_rcode_SERVFAIL": 3}
     assert dns_rcodes(c) == {"REFUSED": 7, "NOERROR": 1, "SERVFAIL": 3}
+
+
+def test_handshake_three_strictnesses_from_todays_numbers() -> None:
+    """nightly-20260910 PostQA gate_load: acks 9997 / timeouts 637 → 94.01 %.
+    The pre-fix figure is `strict_pct` unchanged; a late ACK per timed-out
+    device would lift `with_late_pct` and never past 100."""
+    h = handshake_summary({"dora_ack": 9997, "timeout": 637, "nak": 0})
+    assert h["attempts"] == 10634 and h["strict_pct"] == 94.01
+    assert h["with_late_pct"] == 94.01 and h["acked_late"] == 0
+    h2 = handshake_summary({"dora_ack": 9997, "timeout": 637, "nak": 0,
+                            "dora_ack_late": 600, "dora_ack_over_budget": 40})
+    assert h2["acked_within_budget"] == 9957 and h2["within_budget_pct"] == 93.634
+    assert h2["with_late_pct"] == round(100 * 10597 / 10634, 3)
+    h3 = handshake_summary({"dora_ack": 10, "timeout": 2, "dora_ack_late": 5})
+    assert h3["with_late_pct"] == 100.0            # capped: late ≤ timeouts by construction
+    assert handshake_summary({})["strict_pct"] is None
 
 
 def test_dns_summary_shows_the_pre_fix_hole_and_the_fixed_ledger() -> None:
@@ -47,3 +65,18 @@ def test_dns_timeouts_from_windows_takes_the_last_value_per_shard_not_the_sum() 
             {"shard": 0, "dns_timeout": 46}, {"shard": 1, "dns_timeout": 2},
             {"shard": 1, "dns_timeout": 2}, "junk"]
     assert dns_timeouts_from_windows(rows) == 48      # not 1+3+46+2+2 = 54
+
+
+def test_orchestrator_accounting_block_and_absence() -> None:
+    assert orchestrator_accounting([]) is None
+    blk = orchestrator_accounting([
+        {"counters": {"dora_ack": 3, "timeout": 1, "dns_sent": 5, "dns_ok": 5,
+                      "dns_answered": 5, "dns_rcode_NOERROR": 5}},
+        {"counters": {"dora_ack": 2, "dora_ack_late": 1, "dns_sent": 1,
+                      "dns_timeout": 1}},
+    ])
+    assert blk["shards"] == 2
+    assert blk["handshake"]["acked"] == 5 and blk["handshake"]["acked_late"] == 1
+    assert blk["handshake"]["with_late_pct"] == 100.0
+    assert blk["dns"]["sent"] == 6 and blk["dns"]["timeouts"] == 1
+    assert blk["dns"]["rcodes"] == {"NOERROR": 5} and blk["dns"]["unaccounted"] == 0

--- a/perf/reports/template.md.j2
+++ b/perf/reports/template.md.j2
@@ -8,7 +8,7 @@
   sync. Context keys: run_id, profile, generated_at, slo_thresholds_version,
   incomplete, criteria{a,b,c,d:{name,verdict,summary,rows[]}}, overall{verdict,note},
   deltas{row_count_ledger,table_delta,db_size}, bottleneck, comparison, manifest,
-  present_surfaces, profile_key.
+  present_surfaces, profile_key, generator{shards,handshake,dns} (or none).
 -#}
 # SpatiumDDI 24h Performance Run — `{{ run_id }}`
 {% if incomplete %}
@@ -44,6 +44,18 @@ OVERALL: {{ overall.verdict }} — {{ overall.note }}
 | {{ r.id }} | {{ r.slo|replace("|", "\\|") }} | {{ r.measured|string|replace("|", "\\|") }} | {{ r.threshold|string|replace("|", "\\|") }} | {{ r.verdict|badge }} |
 {% endfor %}
 {% endfor %}
+
+## Generator accounting (orchestrator)
+{% if generator %}
+
+- **Shards:** {{ generator.shards }}
+- **DHCP handshake:** attempts {{ "{:,}".format(generator.handshake.attempts) }} · acked {{ "{:,}".format(generator.handshake.acked) }} ({{ "%.2f%%"|format(generator.handshake.strict_pct) if generator.handshake.strict_pct is not none else "—" }} strict) · within budget {{ "{:,}".format(generator.handshake.acked_within_budget) }} ({{ "%.2f%%"|format(generator.handshake.within_budget_pct) if generator.handshake.within_budget_pct is not none else "—" }}) · late {{ "{:,}".format(generator.handshake.acked_late) }} ({{ "%.2f%%"|format(generator.handshake.with_late_pct) if generator.handshake.with_late_pct is not none else "—" }} with late) · timeouts {{ "{:,}".format(generator.handshake.timeouts) }} · naks {{ "{:,}".format(generator.handshake.naks) }}
+- **DNS stream:** sent {{ "{:,}".format(generator.dns.sent) }} · answered {{ "{:,}".format(generator.dns.answered) }} · ok {{ "{:,}".format(generator.dns.ok) }} ({{ "%.2f%%"|format(generator.dns.ok_pct_of_sent) if generator.dns.ok_pct_of_sent is not none else "—" }} of sent) · timeouts {{ "{:,}".format(generator.dns.timeouts) }} · errors {{ "{:,}".format(generator.dns.errors) }} · unaccounted {{ "{:,}".format(generator.dns.unaccounted) }}
+- **DNS rcodes:** {% for k, v in generator.dns.rcodes.items() %}{{ k }} {{ "{:,}".format(v) }}{{ ", " if not loop.last }}{% else %}none{% endfor %}
+{% else %}
+
+_No orchestrator shard summary in the run directory._
+{% endif %}
 
 ## Bottleneck finding (first-to-give + ready §5 mitigation)
 


### PR DESCRIPTION
Fixes #1057 — the device-fleet orchestrator counted DNS answers only when they were NOERROR/NXDOMAIN and DHCP ACKs only while the device's state still expected them, so its handshake and DNS figures could not be reconciled with kea's and BIND's own counters for the same packets.

Root-caused and validated live on a nested single-node QA appliance driven by the same `gate` manifest from the same load-generator host, once with the unfixed `perf/` tree at `ca1b6bfd` and once with this branch, with kea's `statistic-get-all` (`pkt4-*`), kea's `dhcp_metric_sample` buckets and BIND's JSON statistics channel read inside the appliance before and after each run; then again under a 9 s one-way network delay on DHCP alone, which is the only way to make the late-ACK path fire deterministically. Unit tests drive the orchestrator's FSM without a socket for the same paths.

## 1. `_dns_query` counted every non-NOERROR/NXDOMAIN answer as nothing

`perf/generators/orchestrator/device_fleet.py` (at `ca1b6bfd`, lines 785-794): `dns_ok += 1` only for rcode NOERROR/NXDOMAIN, `dns_timeout += 1` in a bare `except Exception`. An answer with any other rcode incremented `dns_sent` and the `dns_resolve` histogram and nothing else; `dns_timeout` also swallowed every non-timeout exception.

Live, same appliance, same manifest, ~606k queries, every one answered REFUSED by BIND (the generator's UDP source matches no view — a fact about the vantage, which the numbers should say, and did not):

| | unfixed | fixed | BIND, Δ over the run (unfixed / fixed) |
|---|---|---|---|
| `dns_sent` | 606,196 | 606,237 | `opcodes.QUERY` 606,549 / 606,800 — the excess is the propagation probe's own `dig` polls |
| `dns_answered` | — | **606,237** | `nsstats.Response` 606,549 / 606,800 |
| `dns_ok` / `dns_timeout` | 0 / 0 | 0 / 0 | `NOERROR` 0 / 0 |
| `dns_rcode_REFUSED` | (not counted) | **606,237** | `REFUSED` 606,549 / 606,800 |
| answers counted as nothing | **606,196** | 0 | |
| report row b6a (REFUSED = 0, structural) | NO_DATA | **FAIL** `606237 (dnsperf 0, orchestrator 606237)` | |

The unfixed run's histogram held all 606,196 answers (p50 25.8 ms) while its counters said "ok 0, timeouts 0"; the run this issue was filed from said "ok 0, timeouts 46" for the same reason.

**Fix (commit 1):** every answer is counted under `dns_rcode_<NAME>` (counter snapshot, periodic stats, final summary); `dns_answered` counts every response; `dns_ok` keeps its meaning (NOERROR + NXDOMAIN); `dns.exception.Timeout` → `dns_timeout`, any other exception → `dns_error` (logged once per type). The final summary carries a `dns` block computed by the new `spddi_perf.generator_tallies` fold.

## 2. `_on_ack` decided what an ACK meant from the device's state; the DORA deadline timers were per packet

`device_fleet.py` (at `ca1b6bfd`, lines 505-567, 593-603, 433, 474). `_on_ack` branched on `prev_state`: DISCOVERING → DORA ack, RENEWING/REBINDING → renew/rebind ack, anything else → nothing. After `MAX_DORA_RETRIES` the device is OFFLINE with `timeout += 1`, so the ACK that answers its last REQUEST matched no branch: the timeout stood and the lease kea had just allocated was discarded. Each DISCOVER and each REQUEST scheduled its own `dora_timeout` against the device, so a DISCOVER's deadline could retransmit over a live REQUEST. And an ACK from a previous round landing on a device that had already re-arrived was counted as the new round's DORA, with a latency measured from the wrong send.

Live, under a 9 s one-way delay on UDP/67 into the appliance (DNS untouched: `dig` still answered in 20 ms), 400-device manifest, 12 minutes, unfixed then fixed:

| | unfixed | fixed | kea, Δ over the run (unfixed / fixed) |
|---|---|---|---|
| DISCOVERs sent | 10,566 | 5,679 | `discover-received` 10,357 / 5,650 |
| OFFERs received / ignored (device already leased) | — | 5,650 / 1,685 | `offer-sent` 10,357 / 5,650 |
| REQUESTs sent | — | 3,965 | `request-received` 3,385 / 3,962 |
| `dora_ack` (before the device gave up) | 1,341 | 1,160 (all over budget) | `ack-sent` 3,385 / 3,962 |
| `dora_ack_late` (after it gave up) | — | **241** | |
| `ack_duplicate` (ACKs to REQUESTs the device had superseded) | — | 2,561 | |
| `timeout` | 1,460 | 241 | `receive-drop` 0 / 0 |
| handshake strict / with late | 47.9 % / — | 82.8 % / **100 %** | kea served 100 % / 100 % |
| ACKs kea sent vs ACKs the generator accounted for | 3,385 vs 1,341 — **2,044 dropped or misattributed** | 3,962 vs 1,160 + 241 + 2,561 = **3,962, exact** | |
| DORA latency p50 | "535 ms" under a 9 s delay — the ACK was attributed to a later round's send | 9,011 ms (`dora_ack_late` p50 9,011 ms) | |

With every ACK at least 18 s away, the unfixed device gives up at ~13 s (four per-packet deadlines) before any ACK arrives; the ACKs that then land are dropped (device OFFLINE) or, when the device has re-arrived, counted as the new round's DORA. The fixed tree attributes each ACK to the REQUEST it answers: 1,160 answered a round still in progress, 241 answered after the device had given up (every one of its 241 timeouts turned out to be a slow ACK), 2,561 answered REQUESTs the device had superseded (a second OFFER accepted while the first REQUEST's ACK was in the pipe), and 1,685 OFFERs arrived after the device already held a lease (5,650 − 3,965, exact).

The unstressed full run tells the other half of the story. Fixed tree, 4,000 devices, 25 minutes:

| | fixed generator | kea, Δ over the run |
|---|---|---|
| DISCOVERs sent / OFFERs received | 5,336 / 5,007 | `discover-received` 5,007 / `offer-sent` 5,007 |
| REQUESTs sent: selecting / renew / rebind | 5,007 / 2,791 / 2,676 | `request-received` 9,922 |
| `dora_ack` / `renew_ack` / `rebind_ack` | 4,731 / 0 / 2,497 | `ack-sent` 9,922 |
| `timeout` / lapses / late / over budget | 0 / 179 / 0 / 0 | `receive-drop` 0 |

The OFFER leg proves the return path lost nothing (5,007 = 5,007), so the 552 REQUESTs kea never received (10,474 − 9,922) are inbound loss: 276 selecting (5,007 − 4,731), 179 rebind (exactly the 179 lapses), 97 renew — and kea's 9,922 ACKs are 4,731 + 2,497 received at the relay address plus 2,694 renew ACKs (2,791 − 97) unicast to `ciaddr:68`, which a relay-topology load generator never owns. Every one of the 605 retransmitted DISCOVERs (5,336 − 4,731) is an inbound loss, not a slow reply (`dora_ack_over_budget 0`, DORA p99 78 ms). None of this was visible before: the unfixed run reported "handshake 100 %" over the same loss, and the cluster run this issue came from reported "94 %" with kea serving 100 % of what reached it. Where the inbound loss happens (before kea's `pkt4-received`, with kea's own drop counter at 0 and the socket buffer at 0-25) is a separate investigation the new counters now make possible on every run.

**Fix (commit 2):** an `ExchangeLedger` keyed by xid. A reply is attributed to the exchange it answers, with that exchange's own send time, and a verdict: `duplicate` (already closed), `over_budget` (its own timer had fired — the device retried past it but had not given up) or `late` (the device had given up on the round and counted a timeout / lapse).

- `dora_ack` keeps its pre-fix meaning (ACKed before the device gave up, retries included) so existing consumers read the same figure.
- `dora_ack_late`, `renew_ack_late`, `rebind_ack_late` count what used to be dropped; `dora_ack_over_budget`, `dora_offer`, `offer_ignored`, `request_sent`, `ack_duplicate`, `ack_unmatched` make the tally reconcilable with kea's `pkt4-*` counters, as above.
- A late DORA or rebind ACK takes the lease it carries (the server holds it) unless a newer round already did; a late ACK for a device that departed moves nothing.
- Timers are scoped to their exchange; T1 carries a token so a lease re-ACKed twice (a late renew ACK, then the rebind's) renews once; late DORA latencies go to their own histogram (`dhcp_dora_ack_late`) so the strict one keeps its meaning.
- The final summary carries a `handshake` block at three strictnesses: within budget / strict / with late.

Deliberate behaviour change, stated for review: the retry budget is now per exchange — a REQUEST gets its own `DORA_TIMEOUT_S` instead of inheriting its DISCOVER's remaining deadline — so a device facing a slow OFFER *and* a slow ACK can take up to about twice as long to give up as before. `MAX_DORA_RETRIES` still bounds the attempts.

## 3. The report ignored the orchestrator's rcodes and summed a cumulative counter

`perf/harness/spddi_perf/collect.py` (at `ca1b6bfd`): b6 (SERVFAIL rate) and b6a (REFUSED = 0, a structural invariant per §8.3.1) read dnsperf only (lines 678-695), so a run whose orchestrator stream was entirely refused reported NO_DATA on both. b7 summed `dns_timeout` over every periodic window (line 700), but the field is cumulative per shard, so the printed figure multiplied every earlier window's timeouts into every later row.

**Fix (commit 3):** b6/b6a fold the orchestrator's `dns_rcode_*` in (b6a now FAILS structurally on a refused stream — the run measured nothing, whether the name escaped the §4.9 validator or the generator queried from outside the served view; live: overall `FAIL — structural invariant failed: b6a`); b7 reads the final summary (or the last window per shard) and counts `dns_error` beside the timeouts; `slo_results.json` gains a `generator` block; both report renderers print a "Generator accounting (orchestrator)" section.

## What the gate reports until the vantage is fixed

b6a moves from NO_DATA to a structural FAIL on any orchestrator run whose stream BIND refused. On the QA appliance this change was proven on, that is every run today: the generator's UDP source sits outside the client ACL of every view the appliance serves, so the DNS half of those runs measured nothing — and the report now says so instead of saying nothing. The vantage fix is queued on the QA side (ddi-pg #216: an in-view source address for the generator's DNS stream). Until it lands, the perf gate on that appliance reads `overall FAIL — structural invariant failed: b6a` by construction, and the QA harness turns its DNS rows into an infrastructure skip that names the vantage (ddi-pg #209, merged) and will treat the SLO row the same way (ddi-pg #219). Once the vantage is in view, b6a is back to measuring what it was written for — an out-of-zone leak — and the first cluster re-measurement after the harness pin bump is expected green on that row.

## Validation on real hardware

Both trees ran from the same host against the same appliance with the same manifest and bound groups (the fixed full run with `--skip-seed`, because the seeder cannot run twice against one appliance in relay topology — it creates a new IP space per run_id and POSTs the same scopes into the shared DHCP group, `409 … already covers 10.100.0.0/22`; noted here as a fact about the seeder, not changed). Appliance-side counters bracket each run; the load host's own DHCP/DNS probes counted 0 in every window. The identities above are exact packet counts; the one derived term is the renew split of the full run (2,694 = kea's ACKs − the ACKs received at the relay address, bounded by the 2,791 renews sent), and the DNS excess (BIND's QUERY − `dns_sent`) is the propagation probe's own polls.

| figure | unfixed | fixed |
|---|---|---|
| DNS answers accounted for, full run | 0 of 606,196 | 606,237 of 606,237 (REFUSED, per BIND) |
| report b6a on a refused stream | NO_DATA | FAIL (structural) |
| ACKs accounted for under a 9 s delay | 1,341 of kea's 3,385 | 3,962 of kea's 3,962 |
| handshake under a 9 s delay | 47.9 % | 82.8 % strict, 100 % with late |
| DORA latency under a 9 s delay | p50 "535 ms" | p50 9,011 ms |
| inbound DHCP loss, full run | invisible | 329 DISCOVERs, 552 REQUESTs (of 5,336 / 10,474) |

## Tests

- `python -m pytest perf -q` in the CI job's environment: **69 passed, 0 skipped** (41 at base). The job now installs `pytest pyyaml dnspython hdrhistogram` — the orchestrator's and report's own imports — because with pytest alone the two behavioural test files import-skipped (56 passed, 2 skipped) and a reverted fix stayed green (review round 1; the same reversion fails 12 tests once they run). hdrhistogram ships a wheel for x86_64 only, so the Makefile mirror takes it as a wheel when one exists and the single `.hdr` assertion is gated on the backend.
- New: `perf/generators/orchestrator/tests/test_accounting.py` (the ledger and the tally, pure), `test_device_fleet_accounting.py` (the orchestrator FSM driven without a socket: DISCOVER deadline over a live REQUEST, strict / over-budget / late ACKs, renew escalation then rebind, lapse revival vs departure, NAK restart, DNS by rcode, the summary blocks), `perf/harness/tests/test_generator_tallies.py`, `test_collect_generator_rows.py`.
- `perf/` is outside the Backend Lint scope by `ci.yml`'s own note; the added files are ruff-clean and the two touched files carry only their pre-existing findings. `py_compile` of every perf file passes.

## Tradeoffs and remaining work

- Existing field names keep their meaning — add, never rename — so a consumer that folds `dora_ack` / `dns_ok` / `dns_timeout` today reads the same numbers; the new fields are what let it reconcile them.
- The RENEWING leg is unobservable in relay topology by construction: the renew REQUEST carries `giaddr=0, ciaddr=leased IP` (`dhcp_packet.build_request_renew`), so kea unicasts the ACK to `ciaddr:68`. This PR counts renew ACKs by xid whatever state finds them, so a topology that can see them counts them — it does not change the packet.
- Late ACK latencies are kept in their own histogram rather than folded into `dora_ack`'s p99, so the criterion-(b) rows keep their meaning.
- The seeder's re-runnability against one appliance, and the inbound DHCP loss the new counters expose, are follow-ups, not part of this change.

## Verification still to come

The QA fleet's rigs clone this harness at a pinned ref rather than at the build under test, so the nightly PostQA walk cannot carry a `perf/` change; the fleet-side proof is the pin bump once this merges, after which the cluster load tier is re-measured with the reconciled counters and the result posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
